### PR TITLE
[levanter] Stop nonprimary telemetry publication

### DIFF
--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -22,6 +22,7 @@ from rigging.telemetry.probes import nccl, nccl_client
 from levanter.callbacks.progress_watchdog import ProgressTimeout
 from levanter.tracker import Tracker, TrackerConfig, get_tracker
 from levanter.tracker.histogram import SummaryStats
+from levanter.tracker.tracker import NoopTracker
 
 logger = logging.getLogger(__name__)
 
@@ -157,16 +158,13 @@ class TelemetryTracker(Tracker):
 
     name: str = "telemetry"
 
-    def __init__(self, *, publish_tracker_metrics: bool = True) -> None:
-        self._publish_tracker_metrics = publish_tracker_metrics
+    def __init__(self) -> None:
         self._nccl_ras_probe = _start_nccl_ras_probe()
         _set("progress_time_seconds", 0)
         set_training_phase(TrainingPhase.INITIALIZING)
         _HEARTBEAT.start()
 
     def _publish(self, metrics: Mapping[str, object]) -> None:
-        if not self._publish_tracker_metrics:
-            return
         for key, value in metrics.items():
             if isinstance(value, SummaryStats):
                 self._publish_summary(key, value)
@@ -232,6 +230,10 @@ class TelemetryTracker(Tracker):
             logger.warning("Telemetry did not flush within the stalled-training diagnostic budget")
 
 
+class _NonPublishingTelemetryTracker(NoopTracker):
+    name = "telemetry"
+
+
 @TrackerConfig.register_subclass("telemetry")
 @dataclasses.dataclass
 class TelemetryConfig(TrackerConfig):
@@ -244,4 +246,6 @@ class TelemetryConfig(TrackerConfig):
             run_id=run_id,
             process_index=process_index,
         )
-        return TelemetryTracker(publish_tracker_metrics=process_index == 0)
+        if process_index == 0:
+            return TelemetryTracker()
+        return _NonPublishingTelemetryTracker()

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -115,20 +115,16 @@ def test_training_progress_and_phase_are_current_snapshots(exported, monkeypatch
     assert values["phase"] == TrainingPhase.FINISHED
 
 
-def test_nonprimary_process_publishes_progress_but_not_replicated_tracker_metrics(exported, monkeypatch):
+def test_nonprimary_process_does_not_publish_training_telemetry(exported, monkeypatch):
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 1)
     monkeypatch.setattr(tracker_telemetry.runtime_telemetry, "configure", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr("levanter.tracker.telemetry.time", lambda: 1234.5)
     tracker = TelemetryConfig().init("run-42")
 
     tracker.log({"train/loss": 1.25, "throughput": 7.0}, step=3)
     telemetry.shutdown()
 
-    values = _values(exported.records)
-    assert values["step"] == 3.0
-    assert values["progress_time_seconds"] == 1234.5
-    assert "train_loss" not in values
-    assert "throughput" not in values
+    assert tracker.name == "telemetry"
+    assert exported.records == []
 
 
 @pytest.fixture


### PR DESCRIPTION
Nonzero JAX processes suppress generic tracker metrics today but still publish step, progress, and phase rows, including periodic heartbeats. This multiplies Levanter telemetry by the process count.

Return a named no-op telemetry tracker for nonzero processes so only process zero publishes training telemetry. The tracker remains discoverable as `telemetry`, while stall and NCCL publication stays on process zero.