### PR TITLE
[grug] Extend the H100 scaling ladder

### DIFF
--- a/.agents/logbooks/8679-h100-d2048.md
+++ b/.agents/logbooks/8679-h100-d2048.md
@@ -74,3 +74,15 @@ pending the clean source snapshot and follow-up pull request.
 - Stop criteria: Pause for review on a non-finite loss, OOM, repeated task failure, incomplete
   24-worker rendezvous, missing rolling checkpoint after the first interval, or sustained step time
   materially above the 5.5-to-7-day envelope. Do not automatically resubmit a failed run.
+
+## 2026-08-25 20:13 UTC - Submitted through federated Iris
+
+- Submitted pushed source revision `69f846c721` through the `marin` federation to
+  `cw-us-east-02a` at batch priority. The clean workspace bundle was 10.4 MB.
+- Coordinator: `/held/h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch-coord`.
+- Dashboard: [federated Iris job](https://iris.oa.dev/#/job/%2Fheld%2Fh100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch-coord).
+- Initial state: Pending while the east-02 peer reports free capacity. The full run needs 192 H100s;
+  the latest capacity observation before submission showed 128 free, so admission may wait for 64
+  additional H100s.
+- Next action: Verify peer handoff, coordinator startup, creation of the 24-worker child job, and
+  the first finite training loss. Do not submit a duplicate while this job is queued.

--- a/.agents/logbooks/8679-h100-d2048.md
+++ b/.agents/logbooks/8679-h100-d2048.md
@@ -1,0 +1,76 @@
+---
+topic: h100-d2048-scaling
+issue: https://github.com/marin-community/marin/issues/8679
+description: Run the d2048 Grug MoE H100 scaling rung on 192 H100s.
+author: held
+---
+
+# d2048 H100 Scaling Run: Task Logbook
+
+## Scope
+
+- Goal: Complete the d2048 H100 scaling rung at 791 tokens per active parameter.
+- Primary metrics: Finite loss, held-out evaluation, MFU, tokens per second, step time, checkpoint
+  integrity, and multi-node reliability.
+- Constraints: Use federated Iris, target `cw-us-east-02a`, submit at batch priority, and use EP8
+  across 24 eight-H100 workers.
+- Coordinating issue: [#8679](https://github.com/marin-community/marin/issues/8679).
+
+## Current TL;DR
+
+The launch contract is ready at code snapshot `ac174b3121`. The run requests 192 H100s at global
+batch 1536 for 147,192 steps, or 926,051,467,264 tokens and 9.20e21 analytic FLOPs. Submission is
+pending the clean source snapshot and follow-up pull request.
+
+## Baseline
+
+- Date: 2026-08-25.
+- Code refs: Merged H100 ladder [PR 8673](https://github.com/marin-community/marin/pull/8673)
+  and launcher snapshot `ac174b3121`.
+- Measured reference: The d1536 H100 rung at batch 1024 measured 2.947 seconds per step on 64
+  H100s. d2048 at batch 1536 keeps approximately the same analytic FLOPs per GPU per step.
+- Runtime estimate: 5.2 days at the measured reference rate; allow 5.5 to 7 days for admission,
+  evaluation, checkpoints, and runtime variance.
+
+## 2026-08-25 - Launch contract prepared
+
+- Hypothesis: The d2048 rung fits EP8 across 24 H100 workers and sustains finite training at a
+  useful MFU without a distributed startup or checkpointing failure.
+- Run ID: `h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch`.
+- Coordinator job: `/held/h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch-coord`.
+- Source snapshot: Launcher code `ac174b3121`; the submitted revision will also include this
+  logbook and will be recorded after submission. The source tree must be clean and pushed.
+- Command: `uv run iris --cluster=marin job run --no-wait --enable-extra-resources
+  --target-cluster cw-us-east-02a --priority batch --cpu 2 --memory 8GB --disk 32GB --job-name
+  h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch-coord -e WANDB_API_KEY
+  "$WANDB_API_KEY" -e WANDB_PROJECT "${WANDB_PROJECT:-marin_moe}" -e IRIS_PORT_JAX 32578 --
+  python -m experiments.grug.moe_hero_ep.launch_h100_scaling_ladder --run-id
+  h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch --size d2048 --wandb-project
+  "${WANDB_PROJECT:-marin_moe}" --version dev --run`.
+- Hardware and topology: 24 workers, eight H100s per worker, 192 H100s total, expert axis 8,
+  replica axis 24, and one process per GPU.
+- Model: Hidden width 2048, 22 layers, 16 query heads, four local KV heads, two global KV heads,
+  384 routed experts, and eight selected experts per token.
+- Training: Harrier mixture `2026.08.18`, Marin tokenizer, sequence length 4096, global batch 1536,
+  147,192 optimizer steps, 926,051,467,264 tokens, and 9.201e21 analytic FLOPs. The MuonH
+  optimizer values are compute-scaled from this batch and step budget.
+- W&B: Entity `marin-community`, project `marin_moe`, group
+  `moe-hero-ep-h100-scaling-ladder`, and run ID equal to the launch run ID. Resume mode is
+  `allow`; the run configuration is replicated to the durable output.
+- Durable output: `s3://marin-us-east-02a/marin/users/held/grug/h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch/dev`.
+- Checkpoints: Durable final checkpoint under `<output>/checkpoints`. One rolling hourly resume
+  checkpoint is retained under
+  `s3://marin-us-east-02a/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/users/held/grug/h100-ladder-d2048-ep8x24-bs1536-791tpp-20260825-east02a-batch/dev/checkpoints`.
+  The optimizer-inclusive checkpoint estimate is about 280 GB, so normal rolling storage is about
+  280 GB and peak storage after the final checkpoint is about 560 GB.
+- Evaluation: Run every 7,360 steps at batch 192 with Sonic dropless MoE on the fixed validation
+  and uncheatable datasets.
+- Raw diagnostics: Profiler traces are disabled. Iris task logs and W&B metrics are the durable
+  operational record; JAX distributed rendezvous is managed by Iris and does not use a separate
+  object-store path.
+- Monitoring: DRI and monitoring owner are `held` with the originating Codex session. Check
+  admission, all 24 workers, first finite loss, step-time and MFU stability, hourly checkpoint
+  creation, evaluations, and the final durable checkpoint.
+- Stop criteria: Pause for review on a non-finite loss, OOM, repeated task failure, incomplete
+  24-worker rendezvous, missing rolling checkpoint after the first interval, or sustained step time
+  materially above the 5.5-to-7-day envelope. Do not automatically resubmit a failed run.

--- a/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
@@ -3,13 +3,17 @@
 
 """H100 scaling ladder for the Grug MoE EP hero recipe.
 
-The two rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter
-scaling rules while mapping the expert and replica axes onto Hopper nodes. Every rung uses a global
-sequence batch of 1024.
+The rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter scaling
+rules while mapping the expert and replica axes onto Hopper nodes. d512 through d1536 use global
+batch 1024. d2048 uses batch 1536 so its 192 GPUs divide the batch evenly while retaining
+approximately the same per-GPU compute load measured by d1536 on 64 H100s at batch 1024.
 
     size   H100 GPUs  EP per task  global batch  steps  tokens
     d512       8           8           1024        3930    16B
     d768      16           8           1024       11420    48B
+    d1024     32           8           1024       30552   128B
+    d1536     64           8           1024       90767   381B
+    d2048    192           8           1536      147192   926B
 
 Use ``--batch-size`` for one-off batch comparisons. The step count and compute-scaled optimizer are
 recomputed from the override unless ``--num-steps`` is also set.
@@ -48,7 +52,12 @@ from experiments.grug.moe_hero_ep.launch_mfu_test import (
     HeroThroughputResult,
     _validation_datasets,
 )
-from experiments.grug.moe_hero_ep.launch_scaling_ladder import TENSORSTORE_CACHE_BYTES, TOKENS_PER_ACTIVE_PARAM
+from experiments.grug.moe_hero_ep.launch_scaling_ladder import (
+    LADDER_MAX_RETRIES_FAILURE,
+    LADDER_MAX_TASK_FAILURES,
+    TENSORSTORE_CACHE_BYTES,
+    TOKENS_PER_ACTIVE_PARAM,
+)
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
     _EP_CAPACITY_FACTOR,
     SEQ_LEN,
@@ -67,7 +76,7 @@ from experiments.grug.moe_hero_ep.train import (
 )
 from experiments.marin_tokenizer import marin_tokenizer
 
-H100_LADDER_SIZES = ("d512", "d768")
+H100_LADDER_SIZES = ("d512", "d768", "d1024", "d1536", "d2048")
 GLOBAL_BATCH_SIZE = 1024
 QB_HIST_BINS = 10_000
 WATCH_INTERVAL = 10
@@ -84,6 +93,9 @@ class H100LadderRung:
     shape: SmallShape
     gpus_per_task: int
     task_count: int
+    batch_size: int
+    max_retries_failure: int
+    max_task_failures: int
 
     @property
     def global_device_count(self) -> int:
@@ -92,9 +104,50 @@ class H100LadderRung:
 
 def _h100_ladder_rung(size: str) -> H100LadderRung:
     if size == "d512":
-        return H100LadderRung(SmallShape(512, 6, 4, 1, 1), gpus_per_task=8, task_count=1)
+        return H100LadderRung(
+            SmallShape(512, 6, 4, 1, 1),
+            gpus_per_task=8,
+            task_count=1,
+            batch_size=GLOBAL_BATCH_SIZE,
+            max_retries_failure=MAX_RETRIES_FAILURE,
+            max_task_failures=MAX_TASK_FAILURES,
+        )
     if size == "d768":
-        return H100LadderRung(SmallShape(768, 8, 6, 1, 1), gpus_per_task=8, task_count=2)
+        return H100LadderRung(
+            SmallShape(768, 8, 6, 1, 1),
+            gpus_per_task=8,
+            task_count=2,
+            batch_size=GLOBAL_BATCH_SIZE,
+            max_retries_failure=MAX_RETRIES_FAILURE,
+            max_task_failures=MAX_TASK_FAILURES,
+        )
+    if size == "d1024":
+        return H100LadderRung(
+            SmallShape(1024, 12, 8, 2, 1),
+            gpus_per_task=8,
+            task_count=4,
+            batch_size=GLOBAL_BATCH_SIZE,
+            max_retries_failure=MAX_RETRIES_FAILURE,
+            max_task_failures=MAX_TASK_FAILURES,
+        )
+    if size == "d1536":
+        return H100LadderRung(
+            SmallShape(1536, 16, 12, 3, 1),
+            gpus_per_task=8,
+            task_count=8,
+            batch_size=GLOBAL_BATCH_SIZE,
+            max_retries_failure=MAX_RETRIES_FAILURE,
+            max_task_failures=MAX_TASK_FAILURES,
+        )
+    if size == "d2048":
+        return H100LadderRung(
+            SmallShape(2048, 22, 16, 4, 2),
+            gpus_per_task=8,
+            task_count=24,
+            batch_size=1536,
+            max_retries_failure=LADDER_MAX_RETRIES_FAILURE,
+            max_task_failures=LADDER_MAX_TASK_FAILURES,
+        )
     raise ValueError(f"size must be one of {list(H100_LADDER_SIZES)}, got {size!r}")
 
 
@@ -122,7 +175,7 @@ def build_h100_ladder_run(
     run_id: str,
     size: str,
     num_steps: int | None = None,
-    batch_size: int = GLOBAL_BATCH_SIZE,
+    batch_size: int | None = None,
     checkpoint_every: int | None = None,
     wandb_project: str = DEFAULT_WANDB_PROJECT,
     version: str | None = None,
@@ -143,6 +196,8 @@ def build_h100_ladder_run(
     rung = _h100_ladder_rung(size)
     model = _h100_ladder_model(rung)
     training_tokens = TOKENS_PER_ACTIVE_PARAM * _active_params(model)
+    if batch_size is None:
+        batch_size = rung.batch_size
     if batch_size <= 0 or batch_size % rung.global_device_count != 0:
         raise ValueError(f"batch_size must be positive and divisible by {rung.global_device_count}, got {batch_size}")
 
@@ -268,8 +323,8 @@ def build_h100_ladder_run(
             ),
             stop_after_steps=num_steps,
             processes_per_task=rung.gpus_per_task,
-            max_retries_failure=MAX_RETRIES_FAILURE,
-            max_task_failures=MAX_TASK_FAILURES,
+            max_retries_failure=rung.max_retries_failure,
+            max_task_failures=rung.max_task_failures,
         )
 
     return ArtifactStep(
@@ -295,9 +350,8 @@ def build_h100_ladder_run(
 @click.option(
     "--batch-size",
     type=click.IntRange(min=1),
-    default=GLOBAL_BATCH_SIZE,
-    show_default=True,
-    help="Global sequence batch.",
+    default=None,
+    help="Global sequence batch. Defaults to the rung's configured batch.",
 )
 @click.option(
     "--checkpoint-every",
@@ -317,7 +371,7 @@ def main(
     run_id: str,
     size: str,
     num_steps: int | None,
-    batch_size: int,
+    batch_size: int | None,
     checkpoint_every: int | None,
     wandb_project: str,
 ) -> ArtifactStep[HeroThroughputResult]:


### PR DESCRIPTION
Extend the standalone H100 ladder from d512 and d768 through d1024, d1536, and d2048. The d1024 and d1536 rungs preserve the locally validated EP8 layouts on 32 and 64 H100s at global batch 1024. The d2048 rung uses EP8 across 24 workers and global batch 1536, which divides 192 GPUs evenly and keeps approximately the measured d1536 per-GPU compute load.

The 791-token-per-active-parameter rule resolves d2048 to 926,051,467,264 tokens, 147,192 optimizer steps, and 9.201e21 analytic FLOPs. Its optimizer schedule is recomputed from the rung batch and step budget. Production retries match the existing full scaling ladder, while the smaller diagnostic rungs retain their bounded retry policy.

The launch contract and monitoring thresholds are recorded in the linked logbook. This is part of #8679.
