### PR TITLE
[iac] Grant Iris job submission to the XLA fork's CI

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1640,6 +1640,7 @@ service_accounts:
     - principalSet://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/attribute.repository/marin-community/harbor
     - principalSet://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/attribute.repository/marin-community/tpu-inference
     - principalSet://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/attribute.repository/marin-community/vllm
+    - principalSet://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/attribute.repository/marin-community/xla
 - email: iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
   grants:
   - role: projects/hai-gcp-models/roles/marinServiceAccountIamManager


### PR DESCRIPTION
## What changed

One member added to `github-iris@hai-gcp-models`, for `roles/iam.workloadIdentityUser`:

```
principalSet://.../workloadIdentityPools/github-pool/attribute.repository/marin-community/xla
```

## Why

`marin-community/xla` is Marin's XLA fork. It carries a ragged all-to-all device-kernel change that expert-parallel MoE training on GB200 needs and that is not upstream, and it builds a patched `jax-cuda13-pjrt` wheel.

The fork's CI must run that wheel on a real GB200 before Marin can pin it. A wheel whose change is inert still passes a correctness test, and still benchmarks as a null result, so without a hardware check "the change did not help" and "the change was never present" look the same. That job submits to Iris, which needs this service account.

The grant matches what the other five fork repositories already have. It adds no new role and no new pool. It is scoped by `attribute.repository`, so only workflows running in `marin-community/xla` can use it.

## Related

- marin-community/xla#1 and marin-community/xla#3 carry the kernel change and the build.
- marin-community/marin#8684 is the Marin-side pin. It stays in draft until a validated wheel exists, which is what this grant unblocks.

## For the reviewer

Run `review-grant`, then `pulumi up` on the `marin` stack.

`infra/pulumi/tests` passes with this change: 89 passed, 1 failed. The 12 tests that read `iam_data.yaml` (`test_iam_targets.py`, `test_iam.py`, `test_iam_config.py`) all pass.

The one failure is `test_iris_service.py::TestCodeHash::test_content_change_changes_hash`, which fails identically on unmodified `main`. It is unrelated to IAM: `code_hash` returns the empty-input digest on both calls, so it never reads the file contents.

Run them with:

```bash
uv sync --package marin-iac --extra deploy --group test
uv run --package marin-iac --extra deploy --group test pytest infra/pulumi/tests -q
```
