### PR TITLE
[iac] Admit the XLA fork to the fork-ferry profile

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -80,6 +80,7 @@ config:
         - marin-community/marin
         - marin-community/tpu-inference
         - marin-community/vllm
+        - marin-community/xla
       allowedTools: []
       mcpAccess:
         mode: all


### PR DESCRIPTION
## What changed

One repository added to the `fork-ferry` profile's `githubRepositories` in `infra/loom/Pulumi.marin-loom.yaml`:

```
- marin-community/xla
```

## Why

`marin-community/xla` is Marin's XLA fork. It carries a ragged all-to-all device-kernel change that expert-parallel MoE training on GB200 needs and that is not upstream, and it builds a patched `jax-cuda13-pjrt` wheel. `config/external/migration.toml` gains an `[xla]` section in marin-community/marin#8684, so `ops-fork-ferry.yaml` will start refreshing that pin weekly.

Loom brokers short-lived GitHub App tokens only for a profile's configured repositories. Without this entry the ferry cannot clone the fork, stage `main-next`, or open its draft pull request.

The grant matches the five fork repositories already listed. It adds no permission that the profile does not already hold.

## An inconsistency a reviewer should decide on

This entry is necessary but may not be sufficient, and the repository documents the boundary two different ways.

`.agents/skills/refresh-fork/SKILL.md` says dispatching fork workflows needs `actions:write` on `marin-community/vllm`, "which the fork-ferry profile grants".

`infra/loom/README.md` says Loom brokers tokens "with contents, issues, and pull-request write access", and that the profile "does not store a GitHub token or grant Actions access".

If the README is right, the vLLM GPU refresh cannot dispatch `marin-gpu-candidate.yaml` either, and the skill's claim needs correcting. If the skill is right, the README is stale. The vLLM GPU pin has never been refreshed, so the path may never have run.

It matters more for `xla` than for `vllm`: `marin-pjrt.yaml` is one linear workflow, reachable only by dispatch on the staged ref, so an unattended refresh cannot build anything without Actions access.

This pull request does not attempt to resolve that. It adds the repository entry, which is required either way.

## Verification

`infra/loom/tests` passes with this change: 18 passed. `infra/pulumi/tests` is unaffected and unchanged at 89 passed, 1 failed, where the one failure (`test_iris_service.py::TestCodeHash::test_content_change_changes_hash`) fails identically on unmodified `main`.

```bash
uv sync --package marin-iac --extra deploy --group test
uv run --package marin-iac --extra deploy --group test pytest infra/loom/tests -q
```
