### PR TITLE
[datakit] Register Code Alchemy training subsets

### DIFF
--- a/lib/marin/src/marin/datakit/download/code_alchemy.py
+++ b/lib/marin/src/marin/datakit/download/code_alchemy.py
@@ -1,0 +1,286 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download and normalize the finalized Code Alchemy training subsets.
+
+The three source-complete subsets download from the pinned public release.
+``code-dev`` and ``code-dialogue`` consume a validated, pre-staged hydration
+because the public release replaces its seed source bytes with placeholders.
+The one-off source reconstruction is provenance for that raw boundary, not part
+of the repeatable registry chain.
+"""
+
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from fray.types import ResourceConfig
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import DedupMode, normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "open-alchemy/code-alchemy"
+HF_REVISION = "d367da91def5024929d0fa8d46d47d4ef616b467"
+HYDRATED_OUTPUT_PATH = "raw/code-alchemy-hydrated-d367da9"
+HYDRATED_REGISTRATION_MANIFEST = ".registration.json"
+HYDRATION_GIT_COMMIT = "e52fd794d3"
+HYDRATION_PROVENANCE_MD5_BASE64 = "0bqbZvfo9gv5OtiaI8cSjg=="
+HYDRATION_SUMMARY_MD5_BASE64 = "jsAtjeKbgHAJvt7jXU0BfQ=="
+
+_DIRECT_SUBSETS = ("code-enhance", "code-qa", "code-trace")
+_HYDRATED_SUBSETS = ("code-dev", "code-dialogue")
+_PARTITIONS_PER_HYDRATED_SUBSET = 256
+_EXPECTED_HYDRATION_TASKS = len(_HYDRATED_SUBSETS) * _PARTITIONS_PER_HYDRATED_SUBSET
+_EXPECTED_HYDRATED_ROWS_BY_SUBSET = {
+    "code-dev": 62_187_373,
+    "code-dialogue": 30_908_028,
+}
+_EXPECTED_HYDRATED_ROWS = sum(_EXPECTED_HYDRATED_ROWS_BY_SUBSET.values())
+_PARQUET_METADATA_WORKERS = 32
+_NORMALIZE_MAX_WORKERS = 128
+_NORMALIZE_HEARTBEAT_TIMEOUT = 30 * 60.0
+_HYDRATED_NORMALIZE_RESOURCES = ResourceConfig(cpu=4, ram="64g", disk="16g")
+_EXPECTED_PREFIXES = frozenset(f"{prefix:02x}" for prefix in range(_PARTITIONS_PER_HYDRATED_SUBSET))
+_HYDRATED_PARQUET_PATH = re.compile(r"subset=(?P<subset>[^/]+)/blob_prefix=(?P<prefix>[^/]+)/[^/]+\.parquet")
+_ZERO_HYDRATION_METRICS = (
+    "missing_source_rows",
+    "null_blob_id_rows",
+    "prefix_mismatch_rows",
+    "unresolved_placeholder_rows",
+    "unresolved_blob_ids",
+)
+
+
+def _load_json_object(
+    path: str,
+    *,
+    label: str,
+    expected_md5_base64: str | None = None,
+) -> Mapping[str, Any]:
+    storage_path = StoragePath(path)
+    if not storage_path.exists():
+        raise FileNotFoundError(f"Missing Code Alchemy hydration {label}: {path}")
+
+    payload = storage_path.read_bytes()
+    if expected_md5_base64 is not None:
+        digest = hashlib.md5(payload, usedforsecurity=False).digest()
+        actual_md5_base64 = base64.b64encode(digest).decode("ascii")
+        if actual_md5_base64 != expected_md5_base64:
+            raise ValueError(
+                f"Code Alchemy hydration {label} MD5 must be {expected_md5_base64}, found {actual_md5_base64}: {path}"
+            )
+    value = json.loads(payload)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Code Alchemy hydration {label} must contain a JSON object: {path}")
+    return value
+
+
+def _require_int_metric(summary: Mapping[str, Any], key: str, expected: int) -> None:
+    value = summary.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Code Alchemy hydration metric {key!r} must be an integer, found {value!r}")
+    if value != expected:
+        raise ValueError(f"Code Alchemy hydration metric {key!r} must be {expected:,}, found {value:,}")
+
+
+def _validate_registration_manifest(registration: Mapping[str, Any]) -> None:
+    expected = {
+        "schema_version": 1,
+        "source_dataset": HF_DATASET_ID,
+        "source_revision": HF_REVISION,
+        "hydration_git_commit": HYDRATION_GIT_COMMIT,
+        "hydration_provenance_md5_base64": HYDRATION_PROVENANCE_MD5_BASE64,
+        "hydrate_summary_md5_base64": HYDRATION_SUMMARY_MD5_BASE64,
+        "subsets": {
+            subset: {
+                "parquet_files": _PARTITIONS_PER_HYDRATED_SUBSET,
+                "rows": rows,
+            }
+            for subset, rows in _EXPECTED_HYDRATED_ROWS_BY_SUBSET.items()
+        },
+    }
+    for key, expected_value in expected.items():
+        if registration.get(key) != expected_value:
+            raise ValueError(
+                f"Code Alchemy hydration registration {key!r} must be {expected_value!r}, "
+                f"found {registration.get(key)!r}"
+            )
+
+
+def _read_parquet_metadata(path: str) -> int:
+    with StoragePath(path).open("rb") as source:
+        parquet = pq.ParquetFile(source)
+        schema = parquet.schema_arrow
+        missing = {"blob_id", "text_with_placeholders"} - set(schema.names)
+        if missing:
+            raise ValueError(f"Hydrated Code Alchemy Parquet {path} is missing columns: {sorted(missing)}")
+        for name in ("blob_id", "text_with_placeholders"):
+            data_type = schema.field(name).type
+            if not (pa.types.is_string(data_type) or pa.types.is_large_string(data_type)):
+                raise ValueError(f"Hydrated Code Alchemy Parquet {path} column {name!r} has type {data_type}")
+        return parquet.metadata.num_rows
+
+
+def _validate_hydrated_code_alchemy(output_path: str) -> None:
+    """Reject incomplete or unresolved copies of the pre-staged hydrated artifact."""
+    registration = _load_json_object(
+        prefix_join(output_path, HYDRATED_REGISTRATION_MANIFEST),
+        label="registration manifest",
+    )
+    provenance = _load_json_object(
+        prefix_join(output_path, ".provenance.json"),
+        label="provenance",
+        expected_md5_base64=HYDRATION_PROVENANCE_MD5_BASE64,
+    )
+    summary = _load_json_object(
+        prefix_join(output_path, ".metrics/hydrate-summary.json"),
+        label="summary",
+        expected_md5_base64=HYDRATION_SUMMARY_MD5_BASE64,
+    )
+    _validate_registration_manifest(registration)
+
+    if provenance.get("completion_status") != "complete":
+        raise ValueError(
+            "Code Alchemy hydration provenance 'completion_status' must be 'complete', "
+            f"found {provenance.get('completion_status')!r}"
+        )
+    if provenance.get("diagnostic_only") is not False:
+        raise ValueError(
+            "Code Alchemy hydration provenance 'diagnostic_only' must be false, "
+            f"found {provenance.get('diagnostic_only')!r}"
+        )
+    if provenance.get("subsets") != list(_HYDRATED_SUBSETS):
+        raise ValueError(
+            f"Code Alchemy hydration provenance must cover {list(_HYDRATED_SUBSETS)!r}, "
+            f"found {provenance.get('subsets')!r}"
+        )
+    if provenance.get("metrics") != summary:
+        raise ValueError("Code Alchemy hydration provenance metrics do not match hydrate-summary.json")
+
+    _require_int_metric(summary, "task_count", _EXPECTED_HYDRATION_TASKS)
+    _require_int_metric(summary, "input_rows", _EXPECTED_HYDRATED_ROWS)
+    _require_int_metric(summary, "output_rows", _EXPECTED_HYDRATED_ROWS)
+    for key in _ZERO_HYDRATION_METRICS:
+        _require_int_metric(summary, key, 0)
+    _require_int_metric(summary, "rows_with_available_source", _EXPECTED_HYDRATED_ROWS)
+    _require_int_metric(summary, "rows_with_placeholder", _EXPECTED_HYDRATED_ROWS)
+
+    parquet_glob = prefix_join(output_path, "**/*.parquet")
+    partitions: dict[str, list[str]] = {subset: [] for subset in _HYDRATED_SUBSETS}
+    parquet_subsets: dict[str, str] = {}
+    unexpected: list[str] = []
+    parquet_files = [str(path) for path in StoragePath(parquet_glob).glob()]
+    root_prefix = f"{output_path.rstrip('/')}/"
+    for parquet_file in parquet_files:
+        relative_path = parquet_file.removeprefix(root_prefix)
+        match = _HYDRATED_PARQUET_PATH.fullmatch(relative_path)
+        if not parquet_file.startswith(root_prefix) or match is None or match.group("subset") not in partitions:
+            unexpected.append(parquet_file)
+            continue
+        subset = match.group("subset")
+        partitions[subset].append(match.group("prefix"))
+        parquet_subsets[parquet_file] = subset
+
+    if len(parquet_files) != _EXPECTED_HYDRATION_TASKS:
+        raise FileNotFoundError(
+            f"Expected {_EXPECTED_HYDRATION_TASKS} hydrated Code Alchemy Parquet files under "
+            f"{output_path}, found {len(parquet_files)}"
+        )
+    if unexpected:
+        raise ValueError(f"Unexpected hydrated Code Alchemy Parquet path: {unexpected[0]}")
+
+    for subset, prefixes in partitions.items():
+        prefix_set = set(prefixes)
+        if len(prefixes) != _PARTITIONS_PER_HYDRATED_SUBSET or prefix_set != _EXPECTED_PREFIXES:
+            missing = sorted(_EXPECTED_PREFIXES - prefix_set)
+            duplicates = len(prefixes) - len(prefix_set)
+            raise FileNotFoundError(
+                f"Expected one Parquet file in each of {_PARTITIONS_PER_HYDRATED_SUBSET} blob-prefix "
+                f"partitions for {subset}; found {len(prefixes)} files across {len(prefix_set)} partitions "
+                f"(missing={missing[:5]}, duplicate_files={duplicates})"
+            )
+    row_counts = dict.fromkeys(_HYDRATED_SUBSETS, 0)
+    with ThreadPoolExecutor(max_workers=_PARQUET_METADATA_WORKERS) as pool:
+        for parquet_file, rows in zip(parquet_files, pool.map(_read_parquet_metadata, parquet_files), strict=True):
+            row_counts[parquet_subsets[parquet_file]] += rows
+    if row_counts != _EXPECTED_HYDRATED_ROWS_BY_SUBSET:
+        raise ValueError(
+            f"Hydrated Code Alchemy Parquet row counts are {row_counts}, expected {_EXPECTED_HYDRATED_ROWS_BY_SUBSET}"
+        )
+
+
+def _direct_download_step() -> StepSpec:
+    return download_hf_step(
+        "raw/code-alchemy-d367da9",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"{subset}/*.parquet" for subset in _DIRECT_SUBSETS],
+    )
+
+
+def _hydrated_source_step() -> StepSpec:
+    return StepSpec(
+        name=HYDRATED_OUTPUT_PATH,
+        override_output_path=HYDRATED_OUTPUT_PATH,
+        fn=_validate_hydrated_code_alchemy,
+        hash_attrs={
+            "version": "2026-08-25.2",
+            "source_dataset": HF_DATASET_ID,
+            "source_revision": HF_REVISION,
+            "hydration_git_commit": HYDRATION_GIT_COMMIT,
+            "registration_manifest": HYDRATED_REGISTRATION_MANIFEST,
+            "hydration_provenance_md5_base64": HYDRATION_PROVENANCE_MD5_BASE64,
+            "hydrate_summary_md5_base64": HYDRATION_SUMMARY_MD5_BASE64,
+            "format": "parquet",
+            "subsets": list(_HYDRATED_SUBSETS),
+            "partition_key": "blob_prefix",
+            "partitions_per_subset": _PARTITIONS_PER_HYDRATED_SUBSET,
+            "tasks": _EXPECTED_HYDRATION_TASKS,
+            "rows_by_subset": _EXPECTED_HYDRATED_ROWS_BY_SUBSET,
+            "rows": _EXPECTED_HYDRATED_ROWS,
+            "completion_status": "complete",
+        },
+    )
+
+
+def _normalize_subset(source: StepSpec, subset: str, *, hydrated: bool) -> StepSpec:
+    return normalize_step(
+        name=f"normalized/code-alchemy/{subset}",
+        download=source,
+        relative_input_path=f"subset={subset}" if hydrated else subset,
+        text_field="text_with_placeholders" if hydrated else "text",
+        id_field="blob_id",
+        file_extensions=(".parquet",),
+        dedup_mode=DedupMode.NONE,
+        max_workers=_NORMALIZE_MAX_WORKERS,
+        heartbeat_timeout=_NORMALIZE_HEARTBEAT_TIMEOUT,
+        worker_resources=_HYDRATED_NORMALIZE_RESOURCES if hydrated else None,
+    )
+
+
+def code_alchemy_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Return one shared source dependency and normalize terminal per registry subset."""
+    direct_download = _direct_download_step()
+    hydrated_source = _hydrated_source_step()
+
+    chains: dict[str, tuple[StepSpec, ...]] = {}
+    for subset in _DIRECT_SUBSETS:
+        chains[f"code-alchemy/{subset}"] = (
+            direct_download,
+            _normalize_subset(direct_download, subset, hydrated=False),
+        )
+    for subset in _HYDRATED_SUBSETS:
+        chains[f"code-alchemy/{subset}"] = (
+            hydrated_source,
+            _normalize_subset(hydrated_source, subset, hydrated=True),
+        )
+    return chains

--- a/lib/marin/src/marin/datakit/download/code_alchemy.py
+++ b/lib/marin/src/marin/datakit/download/code_alchemy.py
@@ -17,11 +17,10 @@ import re
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from fray.types import ResourceConfig
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-
+from fray.types import ResourceConfig
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 from marin.datakit.download.huggingface import download_hf_step

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -409,6 +409,7 @@ def normalize_to_parquet(
     max_whitespace_run_chars: int = DEFAULT_MAX_WHITESPACE_RUN_CHARS,
     worker_resources: ResourceConfig | None = None,
     max_workers: int = DEFAULT_MAX_WORKERS,
+    heartbeat_timeout: float = 120.0,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
     bare: bool = False,
@@ -448,6 +449,8 @@ def normalize_to_parquet(
             Scale up when increasing partition size.
         max_workers: Maximum number of Zephyr workers for the pipeline.
             Defaults to 1024.
+        heartbeat_timeout: Maximum seconds between worker heartbeats. Increase
+            this when one input shard can take longer than two minutes.
         file_extensions: Tuple of file extensions to include (e.g.
             ``(".parquet",)``).  Defaults to all extensions supported by
             ``zephyr.readers.load_file``.
@@ -492,7 +495,12 @@ def normalize_to_parquet(
         drop_fields=drop_fields,
         output_schema=output_schema,
     )
-    ctx = ZephyrContext(name="normalize", resources=resources, max_workers=max_workers)
+    ctx = ZephyrContext(
+        name="normalize",
+        resources=resources,
+        max_workers=max_workers,
+        heartbeat_timeout=heartbeat_timeout,
+    )
     outcome = ctx.execute(pipeline)
     counters_dict = dict(outcome.counters)
 
@@ -522,6 +530,7 @@ def normalize_step(
     max_whitespace_run_chars: int = DEFAULT_MAX_WHITESPACE_RUN_CHARS,
     worker_resources: ResourceConfig | None = None,
     max_workers: int = DEFAULT_MAX_WORKERS,
+    heartbeat_timeout: float = 120.0,
     output_path_prefix: str | None = None,
     override_output_path: str | None = None,
     relative_input_path: str | None = None,
@@ -543,6 +552,8 @@ def normalize_step(
             See :func:`normalize_to_parquet` for the default.
         max_workers: Maximum number of Zephyr workers. Defaults to
             ``DEFAULT_MAX_WORKERS`` (1024).
+        heartbeat_timeout: Maximum seconds between worker heartbeats. This is
+            execution policy and does not affect the normalized artifact hash.
         output_path_prefix: Optional prefix for the normalized step output.
         override_output_path: Override the computed output path.
         relative_input_path: Override the input path relative to the download output.
@@ -592,6 +603,7 @@ def normalize_step(
             max_whitespace_run_chars=max_whitespace_run_chars,
             worker_resources=worker_resources,
             max_workers=max_workers,
+            heartbeat_timeout=heartbeat_timeout,
             file_extensions=file_extensions,
             dedup_mode=dedup_mode,
             bare=bare,

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -256,16 +256,17 @@ def all_sources() -> dict[str, DatakitSource]:
     )
 
     # Code Alchemy: five independent training subsets from the pinned upstream
-    # release. Counts are the dataset-card estimates pending exact Marin-tokenizer
-    # measurements over the normalized artifacts.
+    # release. Exact counts measured by scanning every input_ids row in the
+    # marin-community/marin-tokenizer TokenizedAttrData artifacts:
+    # 916,537,885,580 tokens total.
     code_alchemy = _rows_flat(
         code_alchemy_normalize_steps,
         {
-            "code-alchemy/code-dev": 269.8,
-            "code-alchemy/code-dialogue": 544.7,
-            "code-alchemy/code-enhance": 124.5,
-            "code-alchemy/code-qa": 31.3,
-            "code-alchemy/code-trace": 6.3,
+            "code-alchemy/code-dev": 251.195609089,
+            "code-alchemy/code-dialogue": 509.618631817,
+            "code-alchemy/code-enhance": 112.823840552,
+            "code-alchemy/code-qa": 34.821683237,
+            "code-alchemy/code-trace": 8.078120885,
         },
     )
 

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -23,6 +23,7 @@ from marin.datakit.download.biocollection import biocollection_normalize_steps
 from marin.datakit.download.biocorpus import biocorpus_normalize_steps
 from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.climblab_ja import climblab_ja_normalize_steps
+from marin.datakit.download.code_alchemy import code_alchemy_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
 from marin.datakit.download.common_corpus import common_corpus_normalize_steps
 from marin.datakit.download.common_crawl_focus import common_crawl_focus_normalize_steps
@@ -251,6 +252,20 @@ def all_sources() -> dict[str, DatakitSource]:
         {
             "biocollection/free_text_stream": 33.186704843,
             "biocollection/instruction_stream": 18.123700603,
+        },
+    )
+
+    # Code Alchemy: five independent training subsets from the pinned upstream
+    # release. Counts are the dataset-card estimates pending exact Marin-tokenizer
+    # measurements over the normalized artifacts.
+    code_alchemy = _rows_flat(
+        code_alchemy_normalize_steps,
+        {
+            "code-alchemy/code-dev": 269.8,
+            "code-alchemy/code-dialogue": 544.7,
+            "code-alchemy/code-enhance": 124.5,
+            "code-alchemy/code-qa": 31.3,
+            "code-alchemy/code-trace": 6.3,
         },
     )
 
@@ -610,6 +625,7 @@ def all_sources() -> dict[str, DatakitSource]:
         *single_sources,
         *starcoder2_extras,
         *biocollection,
+        *code_alchemy,
         *common_pile,
         *finepdfs,
         *dolma4pdfs,

--- a/tests/datakit/download/test_code_alchemy.py
+++ b/tests/datakit/download/test_code_alchemy.py
@@ -1,0 +1,408 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from fray.types import ResourceConfig
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import marin.datakit.download.code_alchemy as code_alchemy
+import marin.datakit.normalize as normalize_module
+
+from marin.datakit.download.code_alchemy import (
+    HF_DATASET_ID,
+    HF_REVISION,
+    HYDRATED_OUTPUT_PATH,
+    HYDRATED_REGISTRATION_MANIFEST,
+    HYDRATION_GIT_COMMIT,
+    HYDRATION_PROVENANCE_MD5_BASE64,
+    HYDRATION_SUMMARY_MD5_BASE64,
+    _validate_hydrated_code_alchemy,
+    code_alchemy_normalize_steps,
+)
+from marin.datakit.normalize import DedupMode
+
+_EXPECTED_KEYS = {
+    "code-alchemy/code-enhance",
+    "code-alchemy/code-qa",
+    "code-alchemy/code-dev",
+    "code-alchemy/code-dialogue",
+    "code-alchemy/code-trace",
+}
+_DIRECT_KEYS = {
+    "code-alchemy/code-enhance",
+    "code-alchemy/code-qa",
+    "code-alchemy/code-trace",
+}
+_HYDRATED_KEYS = {
+    "code-alchemy/code-dev",
+    "code-alchemy/code-dialogue",
+}
+
+
+def _valid_summary(**overrides: object) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "task_count": 512,
+        "input_rows": 93_095_401,
+        "output_rows": 93_095_401,
+        "missing_source_rows": 0,
+        "null_blob_id_rows": 0,
+        "prefix_mismatch_rows": 0,
+        "unresolved_placeholder_rows": 0,
+        "unresolved_blob_ids": 0,
+        "rows_with_available_source": 93_095_401,
+        "rows_with_placeholder": 93_095_401,
+    }
+    summary.update(overrides)
+    return summary
+
+
+def _valid_registration(**overrides: object) -> dict[str, object]:
+    registration: dict[str, object] = {
+        "schema_version": 1,
+        "source_dataset": HF_DATASET_ID,
+        "source_revision": HF_REVISION,
+        "hydration_git_commit": HYDRATION_GIT_COMMIT,
+        "hydration_provenance_md5_base64": code_alchemy.HYDRATION_PROVENANCE_MD5_BASE64,
+        "hydrate_summary_md5_base64": code_alchemy.HYDRATION_SUMMARY_MD5_BASE64,
+        "subsets": {
+            "code-dev": {"parquet_files": 256, "rows": 62_187_373},
+            "code-dialogue": {"parquet_files": 256, "rows": 30_908_028},
+        },
+    }
+    registration.update(overrides)
+    return registration
+
+
+def _write_metadata(
+    root: Path,
+    summary: dict[str, object] | None = None,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    provenance_overrides: dict[str, object] | None = None,
+    registration_overrides: dict[str, object] | None = None,
+) -> None:
+    hydration_summary = summary if summary is not None else _valid_summary()
+    provenance: dict[str, object] = {
+        "completion_status": "complete",
+        "diagnostic_only": False,
+        "subsets": ["code-dev", "code-dialogue"],
+        "metrics": hydration_summary,
+    }
+    provenance.update(provenance_overrides or {})
+    provenance_payload = json.dumps(provenance).encode()
+    summary_payload = json.dumps(hydration_summary).encode()
+    provenance_digest = base64.b64encode(hashlib.md5(provenance_payload, usedforsecurity=False).digest()).decode("ascii")
+    summary_digest = base64.b64encode(hashlib.md5(summary_payload, usedforsecurity=False).digest()).decode("ascii")
+    monkeypatch.setattr(code_alchemy, "HYDRATION_PROVENANCE_MD5_BASE64", provenance_digest)
+    monkeypatch.setattr(code_alchemy, "HYDRATION_SUMMARY_MD5_BASE64", summary_digest)
+
+    (root / ".metrics").mkdir(parents=True)
+    (root / HYDRATED_REGISTRATION_MANIFEST).write_text(json.dumps(_valid_registration(**(registration_overrides or {}))))
+    (root / ".provenance.json").write_bytes(provenance_payload)
+    (root / ".metrics" / "hydrate-summary.json").write_bytes(summary_payload)
+
+
+def _write_partitions(root: Path, *, omit: tuple[str, str] | None = None) -> None:
+    for subset in ("code-dev", "code-dialogue"):
+        for prefix in range(256):
+            blob_prefix = f"{prefix:02x}"
+            if omit == (subset, blob_prefix):
+                continue
+            partition = root / f"subset={subset}" / f"blob_prefix={blob_prefix}"
+            partition.mkdir(parents=True)
+            (partition / "part-00000.parquet").touch()
+
+
+def _mock_valid_parquet_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected_rows = {
+        "code-dev": 62_187_373,
+        "code-dialogue": 30_908_028,
+    }
+
+    def rows_for_path(path: str) -> int:
+        subset = next(subset for subset in expected_rows if f"subset={subset}/" in path)
+        prefix = int(path.split("blob_prefix=", 1)[1].split("/", 1)[0], 16)
+        quotient, remainder = divmod(expected_rows[subset], 256)
+        return quotient + int(prefix < remainder)
+
+    monkeypatch.setattr(code_alchemy, "_read_parquet_metadata", rows_for_path)
+
+
+def test_factory_has_exact_keys_and_shared_source_dependencies():
+    chains = code_alchemy_normalize_steps()
+
+    assert set(chains) == _EXPECTED_KEYS
+    assert all(len(chain) == 2 for chain in chains.values())
+
+    direct_sources = [chains[key][0] for key in _DIRECT_KEYS]
+    hydrated_sources = [chains[key][0] for key in _HYDRATED_KEYS]
+    assert all(source is direct_sources[0] for source in direct_sources)
+    assert all(source is hydrated_sources[0] for source in hydrated_sources)
+    assert direct_sources[0] is not hydrated_sources[0]
+    assert all(chain[-1].deps == [chain[0]] for chain in chains.values())
+
+
+def test_direct_download_is_pinned_to_only_public_subset_parquet_globs():
+    chains = code_alchemy_normalize_steps()
+    download = chains["code-alchemy/code-enhance"][0]
+
+    assert download.name == "raw/code-alchemy-d367da9"
+    assert download.hash_attrs == {
+        "hf_dataset_id": HF_DATASET_ID,
+        "revision": HF_REVISION,
+        "hf_urls_glob": [
+            "code-enhance/*.parquet",
+            "code-qa/*.parquet",
+            "code-trace/*.parquet",
+        ],
+        "append_sha_to_path": False,
+    }
+
+
+def test_hydrated_source_uses_durable_override_and_complete_identity():
+    chains = code_alchemy_normalize_steps()
+    hydrated = chains["code-alchemy/code-dev"][0]
+
+    assert hydrated.name == HYDRATED_OUTPUT_PATH
+    assert hydrated.override_output_path == HYDRATED_OUTPUT_PATH
+    assert hydrated.hash_attrs == {
+        "version": "2026-08-25.2",
+        "source_dataset": HF_DATASET_ID,
+        "source_revision": HF_REVISION,
+        "hydration_git_commit": HYDRATION_GIT_COMMIT,
+        "registration_manifest": HYDRATED_REGISTRATION_MANIFEST,
+        "hydration_provenance_md5_base64": HYDRATION_PROVENANCE_MD5_BASE64,
+        "hydrate_summary_md5_base64": HYDRATION_SUMMARY_MD5_BASE64,
+        "format": "parquet",
+        "subsets": ["code-dev", "code-dialogue"],
+        "partition_key": "blob_prefix",
+        "partitions_per_subset": 256,
+        "tasks": 512,
+        "rows_by_subset": {
+            "code-dev": 62_187_373,
+            "code-dialogue": 30_908_028,
+        },
+        "rows": 93_095_401,
+        "completion_status": "complete",
+    }
+
+
+def test_normalize_terminals_have_subset_specific_identities():
+    chains = code_alchemy_normalize_steps()
+
+    for registry_name, (source, normalized) in chains.items():
+        subset = registry_name.removeprefix("code-alchemy/")
+        hydrated = registry_name in _HYDRATED_KEYS
+        assert normalized.name == f"normalized/code-alchemy/{subset}"
+        assert normalized.deps == [source]
+        assert normalized.hash_attrs["relative_input_path"] == (f"subset={subset}" if hydrated else subset)
+        assert normalized.hash_attrs["text_field"] == ("text_with_placeholders" if hydrated else "text")
+        assert normalized.hash_attrs["id_field"] == "blob_id"
+        assert normalized.hash_attrs["file_extensions"] == (".parquet",)
+        assert normalized.hash_attrs["dedup_mode"] is DedupMode.NONE
+        assert "bare" not in normalized.hash_attrs
+        assert "drop_fields" not in normalized.hash_attrs
+
+
+def test_normalize_execution_policy_is_forwarded_without_rekeying(monkeypatch: pytest.MonkeyPatch):
+    calls: dict[str, object] = {}
+
+    def fake_normalize_to_parquet(**kwargs: object) -> None:
+        calls.update(kwargs)
+
+    monkeypatch.setattr(normalize_module, "normalize_to_parquet", fake_normalize_to_parquet)
+    normalized = code_alchemy_normalize_steps()["code-alchemy/code-dev"][-1]
+    assert normalized.fn is not None
+    normalized.fn("normalized-output")
+
+    assert calls["max_workers"] == 128
+    assert calls["heartbeat_timeout"] == 30 * 60.0
+    assert calls["worker_resources"] == ResourceConfig(cpu=4, ram="64g", disk="16g")
+    assert "max_workers" not in normalized.hash_attrs
+    assert "heartbeat_timeout" not in normalized.hash_attrs
+    assert "worker_resources" not in normalized.hash_attrs
+
+
+def test_hydrated_validator_accepts_complete_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    _write_partitions(tmp_path)
+    _mock_valid_parquet_rows(monkeypatch)
+
+    _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        HYDRATED_REGISTRATION_MANIFEST,
+        ".provenance.json",
+        ".metrics/hydrate-summary.json",
+    ],
+)
+def test_hydrated_validator_rejects_missing_metadata(
+    tmp_path: Path, relative_path: str, monkeypatch: pytest.MonkeyPatch
+):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    (tmp_path / relative_path).unlink()
+
+    with pytest.raises(FileNotFoundError):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("override", "metric"),
+    [
+        ({"task_count": 511}, "task_count"),
+        ({"input_rows": 93_095_400}, "input_rows"),
+        ({"output_rows": 93_095_400}, "output_rows"),
+        ({"missing_source_rows": 1}, "missing_source_rows"),
+        ({"null_blob_id_rows": 1}, "null_blob_id_rows"),
+        ({"prefix_mismatch_rows": 1}, "prefix_mismatch_rows"),
+        ({"unresolved_placeholder_rows": 1}, "unresolved_placeholder_rows"),
+        ({"unresolved_blob_ids": 1}, "unresolved_blob_ids"),
+    ],
+)
+def test_hydrated_validator_rejects_incomplete_or_unresolved_metrics(
+    tmp_path: Path,
+    override: dict[str, object],
+    metric: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_metadata(tmp_path, _valid_summary(**override), monkeypatch=monkeypatch)
+
+    with pytest.raises(ValueError, match=metric):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+@pytest.mark.parametrize("metric", ["rows_with_available_source", "rows_with_placeholder"])
+def test_hydrated_validator_rejects_missing_hydration_metrics(
+    tmp_path: Path, metric: str, monkeypatch: pytest.MonkeyPatch
+):
+    summary = _valid_summary()
+    summary.pop(metric)
+    _write_metadata(tmp_path, summary, monkeypatch=monkeypatch)
+
+    with pytest.raises(ValueError, match=metric):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("override", "field"),
+    [
+        ({"completion_status": "partial"}, "completion_status"),
+        ({"diagnostic_only": True}, "diagnostic_only"),
+        ({"subsets": ["code-dev"]}, "cover"),
+        ({"metrics": {}}, "metrics do not match"),
+    ],
+)
+def test_hydrated_validator_rejects_incomplete_provenance(
+    tmp_path: Path,
+    override: dict[str, object],
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch, provenance_overrides=override)
+
+    with pytest.raises(ValueError, match=field):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("override", "field"),
+    [
+        ({"source_dataset": "other/dataset"}, "source_dataset"),
+        ({"source_revision": "other-revision"}, "source_revision"),
+        ({"hydration_git_commit": "other-commit"}, "hydration_git_commit"),
+    ],
+)
+def test_hydrated_validator_binds_registration_identity(
+    tmp_path: Path,
+    override: dict[str, object],
+    field: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch, registration_overrides=override)
+
+    with pytest.raises(ValueError, match=field):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+def test_hydrated_validator_rejects_wrong_parquet_row_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    _write_partitions(tmp_path)
+    monkeypatch.setattr(code_alchemy, "_read_parquet_metadata", lambda _path: 0)
+
+    with pytest.raises(ValueError, match="row counts"):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+def test_read_parquet_metadata_validates_schema_and_rows(tmp_path: Path):
+    parquet_path = tmp_path / "part.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "blob_id": ["a", "b"],
+                "text_with_placeholders": ["first", "second"],
+            }
+        ),
+        parquet_path,
+    )
+
+    assert code_alchemy._read_parquet_metadata(str(parquet_path)) == 2
+
+
+def test_read_parquet_metadata_rejects_missing_columns(tmp_path: Path):
+    parquet_path = tmp_path / "part.parquet"
+    pq.write_table(pa.table({"blob_id": ["a"]}), parquet_path)
+
+    with pytest.raises(ValueError, match="text_with_placeholders"):
+        code_alchemy._read_parquet_metadata(str(parquet_path))
+
+
+def test_hydrated_validator_rejects_wrong_file_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    _write_partitions(tmp_path, omit=("code-dev", "ff"))
+
+    with pytest.raises(FileNotFoundError, match="512.*found 511"):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+def test_hydrated_validator_rejects_missing_partition_even_with_512_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    _write_partitions(tmp_path, omit=("code-dev", "ff"))
+    duplicate_partition = tmp_path / "subset=code-dev" / "blob_prefix=fe"
+    (duplicate_partition / "part-00001.parquet").touch()
+
+    with pytest.raises(FileNotFoundError, match="code-dev"):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+def test_hydrated_validator_rejects_nested_partition_substitute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _write_metadata(tmp_path, monkeypatch=monkeypatch)
+    _write_partitions(tmp_path, omit=("code-dev", "ff"))
+    nested_partition = tmp_path / "archive" / "subset=code-dev" / "blob_prefix=ff"
+    nested_partition.mkdir(parents=True)
+    (nested_partition / "part-00000.parquet").touch()
+
+    with pytest.raises(ValueError, match="Unexpected"):
+        _validate_hydrated_code_alchemy(str(tmp_path))
+
+
+def test_load_json_object_rejects_digest_mismatch(tmp_path: Path):
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text("{}")
+
+    with pytest.raises(ValueError, match="MD5"):
+        code_alchemy._load_json_object(
+            str(metadata),
+            label="test",
+            expected_md5_base64="AAAAAAAAAAAAAAAAAAAAAA==",
+        )

--- a/tests/datakit/download/test_code_alchemy.py
+++ b/tests/datakit/download/test_code_alchemy.py
@@ -6,14 +6,12 @@ import hashlib
 import json
 from pathlib import Path
 
-from fray.types import ResourceConfig
+import marin.datakit.download.code_alchemy as code_alchemy
+import marin.datakit.normalize as normalize_module
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-
-import marin.datakit.download.code_alchemy as code_alchemy
-import marin.datakit.normalize as normalize_module
-
+from fray.types import ResourceConfig
 from marin.datakit.download.code_alchemy import (
     HF_DATASET_ID,
     HF_REVISION,
@@ -369,7 +367,7 @@ def test_hydrated_validator_rejects_wrong_file_count(tmp_path: Path, monkeypatch
     _write_metadata(tmp_path, monkeypatch=monkeypatch)
     _write_partitions(tmp_path, omit=("code-dev", "ff"))
 
-    with pytest.raises(FileNotFoundError, match="512.*found 511"):
+    with pytest.raises(FileNotFoundError, match=r"512.*found 511"):
         _validate_hydrated_code_alchemy(str(tmp_path))
 
 

--- a/tests/datakit/test_sources.py
+++ b/tests/datakit/test_sources.py
@@ -20,11 +20,11 @@ def test_every_source_normalizes_its_output():
 def test_code_alchemy_registry_components():
     """Code Alchemy subsets remain independent normalized mixture components."""
     expected_counts = {
-        "code-alchemy/code-dev": 269.8,
-        "code-alchemy/code-dialogue": 544.7,
-        "code-alchemy/code-enhance": 124.5,
-        "code-alchemy/code-qa": 31.3,
-        "code-alchemy/code-trace": 6.3,
+        "code-alchemy/code-dev": 251.195609089,
+        "code-alchemy/code-dialogue": 509.618631817,
+        "code-alchemy/code-enhance": 112.823840552,
+        "code-alchemy/code-qa": 34.821683237,
+        "code-alchemy/code-trace": 8.078120885,
     }
 
     sources = all_sources()

--- a/tests/datakit/test_sources.py
+++ b/tests/datakit/test_sources.py
@@ -15,3 +15,25 @@ def test_every_source_normalizes_its_output():
         if not NORMALIZE_IDENTITY_ATTRS <= source.normalized.hash_attrs.keys() or not source.normalized.deps
     ]
     assert unnormalized == []
+
+
+def test_code_alchemy_registry_components():
+    """Code Alchemy subsets remain independent normalized mixture components."""
+    expected_counts = {
+        "code-alchemy/code-dev": 269.8,
+        "code-alchemy/code-dialogue": 544.7,
+        "code-alchemy/code-enhance": 124.5,
+        "code-alchemy/code-qa": 31.3,
+        "code-alchemy/code-trace": 6.3,
+    }
+
+    sources = all_sources()
+    code_alchemy_names = {name for name in sources if name.startswith("code-alchemy/")}
+
+    assert code_alchemy_names == expected_counts.keys()
+    assert len([source.name for source in sources.values()]) == len({source.name for source in sources.values()})
+    for name, expected_count in expected_counts.items():
+        source = sources[name]
+        assert source.rough_token_count_b == expected_count
+        assert source.normalized.name == f"normalized/{name}"
+        assert NORMALIZE_IDENTITY_ATTRS <= source.normalized.hash_attrs.keys()


### PR DESCRIPTION
🤖
## Summary

- register the five Code Alchemy training subsets as independent Datakit sources
- download `code-enhance`, `code-qa`, and `code-trace` from pinned `open-alchemy/code-alchemy@d367da91def5024929d0fa8d46d47d4ef616b467`
- adopt the completed `code-dev` and `code-dialogue` hydration at `s3://marin-us-east-02a/marin/raw/code-alchemy-hydrated-d367da9`
- validate registered provenance digests, exact root partition layout, Parquet schemas, and exact per-subset row counts before normalization
- preserve all published rows with `DedupMode.NONE`
- allow long-running normalize shards to raise the Zephyr heartbeat timeout without changing artifact identity

The one-off Stack/SWH reconstruction remains outside this PR, following the pre-staged Nemotron Code v1 precedent. The durable hydration records 93,095,401 rows and zero unresolved placeholders.

## Exact Marin-tokenizer counts

Full scans of every `input_ids` row in the five `TokenizedAttrData` artifacts produced:

| source | tokens |
|---|---:|
| `code-alchemy/code-dev` | 251,195,609,089 |
| `code-alchemy/code-dialogue` | 509,618,631,817 |
| `code-alchemy/code-enhance` | 112,823,840,552 |
| `code-alchemy/code-qa` | 34,821,683,237 |
| `code-alchemy/code-trace` | 8,078,120,885 |
| **total** | **916,537,885,580** |

The canonical tokenizer is `marin-community/marin-tokenizer` with the reference-pipeline revision identity `a5ca45f2feb6c959bd87b81689aa7279b5bdcaa2`. No Levanter store was built.

## Produced artifacts

`/muchanem/code-alchemy-tokenize-count-v8` succeeded with 512 token workers. Normalized, tokenized, and exact-count artifacts are under:

- `s3://marin-us-east-02a/marin/normalized/code-alchemy/`
- `s3://marin-us-east-02a/marin/datakit/tokenize/code-alchemy/`
- `s3://marin-us-east-02a/marin/datakit/token-count/code-alchemy/`

Every normalized artifact preserved its published input row count. Every token artifact is `TokenizedAttrData` v4 with tokenizer backend `hf`, and its Parquet shard count exactly matches its normalized source.

## Verification

- [x] durable hydrated data promoted and source-verified
- [x] five source chains registered
- [x] real cw-us-east-02a validator smoke succeeded
- [x] five normalized artifacts materialized
- [x] five canonical token-attribute artifacts materialized
- [x] exact token counts recorded in the registry
- [x] focused tests pass (`55 passed`)
- [x] Ruff, Black, license, AST, conflict, whitespace, and file-size checks pass for the PR files
- [x] Pyrefly reports 0 errors for the changed source files
- [x] mark ready for review after owner checks the draft

Refs #8671