### PR TITLE
Drop RunDisabled from the WandbRun type alias

### DIFF
--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-WandbRun = Union["wandb.sdk.wandb_run.Run", "wandb.sdk.lib.disabled.RunDisabled"]
+WandbRun = "wandb.sdk.wandb_run.Run"
 
 
 _WANDB_ARTIFACT_NAME_MAX_LENGTH = 128


### PR DESCRIPTION
wandb deprecated `RunDisabled` in v0.17.6 (wandb/wandb#8064): since then, `wandb.init(mode="disabled")` returns a regular no-op `wandb.Run`, and `RunDisabled` has been an empty compatibility shim that emits a deprecation warning on attribute access. The shim is being removed in an upcoming wandb release (wandb/wandb#12586), after which importing it raises `ImportError`.

Details: the `WandbRun` union alias in the vendored levanter tracker uses a string forward ref to `wandb.sdk.lib.disabled.RunDisabled`; there is no runtime break, but type checkers would fail to resolve it. The alias becomes a plain forward ref to `wandb.sdk.wandb_run.Run`.
