### PR TITLE
[infra] Move Echo and Evaldash health checks to /health

### DIFF
--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -311,7 +311,7 @@ work-log entries), `/feedback` (recent result grades), `/wiki/<id>` (a note), an
 `/chunk/<id>` (an activity chunk). Conversation details load when an entry is opened.
 The feedback table links each grade to its source and keeps explanation-only submissions
 visible. The API's catch-all route serves `index.html` for any path that isn't
-`/api/...`, `/healthz`, `/static/...`, `/docs`, or `/openapi.json`, so vue-router's
+`/api/...`, `/health`, `/static/...`, `/docs`, or `/openapi.json`, so vue-router's
 history-mode navigation and reloads resolve correctly.
 
 Dashboard search uses the federated endpoint and exposes checkboxes for files, wiki,

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -1061,8 +1061,9 @@ def wiki_filter_clauses(tags: list[str]) -> list[str]:
     return ["w.tags @> CAST(:tags AS text[])"] if tags else []
 
 
-@app.get("/healthz")
-def healthz(engine: Engine) -> dict[str, str]:
+# Cloud Run reserves some paths ending in "z" before they reach the container.
+@app.get("/health")
+def health(engine: Engine) -> dict[str, str]:
     with engine.connect() as conn:
         conn.execute(sqlalchemy.text("SELECT 1"))
     return {"status": "ok"}

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -135,6 +135,13 @@ def client_with():
     echo.app.dependency_overrides.clear()
 
 
+def test_health_reports_database_availability(client_with):
+    response = client_with([]).client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_grep_escapes_like_wildcards():
     assert echo.escape_like("ragged_all_to_all") == "ragged\\_all\\_to\\_all"
     assert echo.escape_like("50%") == "50\\%"

--- a/infra/evaldash/README.md
+++ b/infra/evaldash/README.md
@@ -69,7 +69,7 @@ IAP is the only access gate; there is no application auth.
 ## API
 
 ```
-GET  /healthz               liveness
+GET  /health                liveness
 GET  /api/runs?model=&eval=&user=&status=&group=&limit=   filtered run rows
 GET  /api/groups?model=&user=&limit=   runs collapsed into launches (one row per group_id) with per-eval members
 GET  /api/runs/{run_id}     the full record.json for one run (404 if absent)

--- a/infra/evaldash/src/server.py
+++ b/infra/evaldash/src/server.py
@@ -977,7 +977,7 @@ def create_app(
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
 
-    async def healthz(_request: Request) -> JSONResponse:
+    async def health(_request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "store": store.backend})
 
     async def api_runs(request: Request) -> JSONResponse:
@@ -1174,7 +1174,8 @@ def create_app(
         return _index_html(dist, request.headers.get("x-forwarded-prefix", ""))
 
     routes = [
-        Route("/healthz", healthz),
+        # Cloud Run reserves some paths ending in "z" before they reach the container.
+        Route("/health", health),
         Route("/api/runs", api_runs),
         Route("/api/groups", api_groups),
         Route("/api/models/{model_name:str}/archive", api_model_archive, methods=["POST"]),

--- a/tests/evaluation/test_evaldash_local_store.py
+++ b/tests/evaluation/test_evaldash_local_store.py
@@ -117,7 +117,7 @@ def test_ungraded_sample_does_not_count_as_incorrect_answer(store):
 
 
 def test_api_surface_over_fixtures(client):
-    assert client.get("/healthz").json()["store"] == "memory"
+    assert client.get("/health").json()["store"] == "memory"
 
     meta = client.get("/api/meta").json()
     assert meta["store"] == "memory"


### PR DESCRIPTION
Serve the Echo and Evaldash liveness endpoints at `/health`. Cloud Run
[reserves some paths ending in `z`](https://docs.cloud.google.com/run/docs/known-issues)
before requests reach the container, so both documented `/healthz` endpoints
return a platform 404.

The checks keep their existing application behavior: Echo verifies its database
connection, and Evaldash reports its configured store. Their current Cloud Run
startup probes use TCP and do not depend on either HTTP path.
