### PR TITLE
[finelog] Partition Levanter metrics online

### DIFF
--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -56,13 +56,14 @@ a training run with no signal that it happened. That is what `iris_state_stale` 
 Uniform routing over the hero rung's experts is 5.951 entropy, so falling entropy is expert collapse.
 The 7% drop limit sits above the intermittent 5% spikes a healthy MoE run shows.
 
-One bounded `levanter.metrics` scan per bridge cache interval feeds all three rules, reduced over a
-single execution: the newest attempt process zero reports. `loss_jump` reads its two loss windows
-against each other, so it filters them to that same execution. A retry keeps the run ID and takes a
-new `execution_uid`, so partitioning on the run alone would sum one attempt's skipped steps into the
-next and compare evaluations across a restore that redid steps. Process zero is the stable choice
-because Levanter publishes tracker metrics only from it. A check reads a newest sample only while it
-is under 15 minutes old.
+The enrollment query returns the latest `execution_uid` with each phase heartbeat. One subsequent,
+bounded `levanter.metrics` scan per bridge cache interval feeds all three rules, using exact
+cluster, run, and execution predicates rather than scanning the table again to rediscover the
+attempt. `loss_jump` reads its two loss windows against each other, so it filters them to that same
+execution. A retry keeps the run ID and takes a new `execution_uid`, so partitioning on the run alone
+would sum one attempt's skipped steps into the next and compare evaluations across a restore that
+redid steps. Process zero is the stable choice because Levanter publishes tracker metrics only from
+it. A check reads a newest sample only while it is under 15 minutes old.
 
 The throughput checks count how much of the window sat below the floor rather than averaging it —
 the median comparison the Pushover monitor makes, which keeps one restart step at zero from reading

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -291,8 +291,11 @@ job it is that job's queue over time.
 
 `training.json` shows whether one run is on track. `runs.json` compares runs. The
 single-value selector puts the newest hero run first. It uses `run_id` across
-clusters. The status strip uses one 15-minute query over the semantic
-`levanter.metrics` table for ten fields. The strip includes the two hero
+clusters and discovers runs from a fixed 12-hour window, so widening the graph
+range does not turn the selector into a whole-store scan. A `run_id` supplied in
+the dashboard URL remains available for older graph windows. The status strip
+uses one 15-minute query over the semantic `levanter.metrics` table for ten
+fields. The strip includes the two hero
 alert inputs: time
 since the last completed step and
 train loss, plus step time, throughput, schedule progress, and token count.

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -1,7 +1,7 @@
 {
   "uid": "marin-training",
   "title": "Training run",
-  "description": "The status of one training run. The run selector lists Levanter runs that reported a step in the dashboard window. Hero runs come first. The current hero run is the initial selection. Run identity uses run_id, so a run keeps one series set across clusters. Use the Runs dashboard to compare runs.",
+  "description": "The status of one training run. The run selector lists Levanter runs active in the last 12 hours. Hero runs come first. The current hero run is the initial selection. Run identity uses run_id, so a run keeps one series set across clusters. A run supplied in the dashboard URL remains selectable for older graph windows. Use the Runs dashboard to compare runs.",
   "tags": [
     "marin",
     "generated"
@@ -20,7 +20,7 @@
         "name": "run",
         "label": "Run",
         "type": "query",
-        "description": "Levanter runs that reported a step inside the dashboard window, hero runs first and newest first within each group. Sorting is left to the query, so the default selection is the newest hero run.",
+        "description": "Levanter runs active in the last 12 hours, hero runs first and newest first within each group. A run supplied in the dashboard URL remains selectable for older graph windows. Sorting is left to the query, so the default selection is the newest hero run.",
         "datasource": {
           "type": "yesoreyeram-infinity-datasource",
           "uid": "finelog-marin"
@@ -41,15 +41,7 @@
               "params": [
                 {
                   "key": "sql",
-                  "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT run_id AS value FROM telemetry WHERE step IS NOT NULL AND run_id IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY run_id ORDER BY CASE WHEN run_id LIKE 'hero-%' THEN 0 ELSE 1 END, MAX(timestamp_ms) DESC"
-                },
-                {
-                  "key": "from",
-                  "value": "${__from}"
-                },
-                {
-                  "key": "to",
-                  "value": "${__to}"
+                  "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT run_id AS value FROM telemetry WHERE step IS NOT NULL AND run_id IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '12 hours') * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT) GROUP BY run_id ORDER BY CASE WHEN run_id LIKE 'hero-%' THEN 0 ELSE 1 END, MAX(timestamp_ms) DESC"
                 }
               ]
             },

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -19,6 +19,7 @@ import pyarrow as pa
 from hero_runs import (
     HERO_ROOT_PATTERNS,
     LEVANTER_METRICS_TABLE,
+    PHASE_ENROLLMENT_LOOKBACK,
     PHASE_METRIC,
     TASK_STATE_FRESHNESS,
     TELEMETRY_GONE_AGE,
@@ -27,11 +28,11 @@ from hero_runs import (
     as_utc,
     hero_run_id,
     root_job_for,
-    run_id_predicate,
     sql_epoch_ms,
     sql_timestamp,
 )
 from loss_spikes import LossWindows, loss_spike_reason, windows_by_run
+from vllm_observability import sql_string
 
 # Past this the rollup no longer enrolls a run, so the rules that read it go blind.
 IRIS_STATE_STALE_AGE = timedelta(minutes=5)
@@ -96,6 +97,7 @@ class WatchedRun:
     run_id: str
     iris_running: bool
     iris_state_age: timedelta | None
+    execution_uid: str | None
 
 
 @dataclass(frozen=True)
@@ -129,7 +131,16 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     partitioning on the run alone would sum one attempt's skipped steps into the
     next. Process zero because Levanter publishes tracker metrics only from it.
     """
-    run_predicate = run_id_predicate(runs)
+    execution_predicates = [
+        "("
+        f"COALESCE(NULLIF(cluster,''),'unknown') = {sql_string(run.cluster)} "
+        f"AND run_id = {sql_string(run.run_id)} "
+        f"AND execution_uid = {sql_string(run.execution_uid)}"
+        ")"
+        for run in runs
+        if run.execution_uid is not None
+    ]
+    execution_predicate = " OR ".join(execution_predicates) or "FALSE"
     signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
     liveness_since = sql_epoch_ms(now - _LIVENESS_LOOKBACK)
     health_since = sql_epoch_ms(now - HEALTH_WINDOW)
@@ -137,29 +148,15 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     metric_names = ", ".join(f"'{name}'" for name in _SIGNAL_METRICS)
     below_floor = " OR ".join(f"(name = '{name}' AND value < {floor})" for name, floor in _FLOORS.items())
     return (
-        "WITH attempts AS ("
+        "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, run_id, execution_uid, "
-        "ROW_NUMBER() OVER ("
-        "PARTITION BY COALESCE(NULLIF(cluster,''),'unknown'), run_id "
-        "ORDER BY timestamp_ms DESC, seq DESC"
-        ") AS rn "
+        "name, value, timestamp_ms, seq "
         f"FROM {LEVANTER_METRICS_TABLE} "
-        f"WHERE name = '{PHASE_METRIC}' AND process_index = 0 "
-        f"AND {run_predicate} AND execution_uid IS NOT NULL "
-        f"AND timestamp_ms >= {liveness_since} AND timestamp_ms < {end}"
-        "), execution AS ("
-        "SELECT origin_cluster, run_id, execution_uid FROM attempts WHERE rn = 1"
-        "), samples AS ("
-        "SELECT execution.origin_cluster, execution.run_id, execution.execution_uid, "
-        "telemetry.name, telemetry.value, telemetry.timestamp_ms, telemetry.seq "
-        f"FROM {LEVANTER_METRICS_TABLE} AS telemetry JOIN execution "
-        "ON COALESCE(NULLIF(telemetry.cluster,''),'unknown') = execution.origin_cluster "
-        "AND telemetry.run_id = execution.run_id "
-        "AND telemetry.execution_uid = execution.execution_uid "
-        f"WHERE telemetry.name IN ({metric_names}) "
-        f"AND telemetry.timestamp_ms >= {liveness_since} AND telemetry.timestamp_ms < {end} "
-        f"AND (telemetry.name IN ('{PHASE_METRIC}', '{_EVAL_LOSS}') "
-        f"OR telemetry.timestamp_ms >= {signal_since})"
+        f"WHERE ({execution_predicate}) AND process_index = 0 "
+        f"AND name IN ({metric_names}) "
+        f"AND timestamp_ms >= {liveness_since} AND timestamp_ms < {end} "
+        f"AND (name IN ('{PHASE_METRIC}', '{_EVAL_LOSS}') "
+        f"OR timestamp_ms >= {signal_since})"
         "), ranked AS ("
         "SELECT origin_cluster, run_id, execution_uid, name, value, timestamp_ms, "
         "ROW_NUMBER() OVER ("
@@ -220,12 +217,14 @@ def watched_runs(task_states: pa.Table, phase_runs: pa.Table, now: datetime) -> 
         states[(str(row["cluster"]), root_job)] = (age, int(row["running"] or 0) > 0)
 
     enrolled = [key for key, (age, running) in states.items() if running and age <= TASK_STATE_FRESHNESS]
+    executions: dict[tuple[str, str], str] = {}
     for row in phase_runs.to_pylist():
         root_job = root_job_for(str(row["telemetry_job"]))
         if root_job is None:
             continue
         key = (str(row["cluster"]), root_job)
-        if key not in enrolled:
+        executions[key] = str(row["execution_uid"])
+        if key not in enrolled and now - as_utc(row["phase_at"]) <= PHASE_ENROLLMENT_LOOKBACK:
             enrolled.append(key)
 
     runs = []
@@ -241,6 +240,7 @@ def watched_runs(task_states: pa.Table, phase_runs: pa.Table, now: datetime) -> 
                 run_id=run_id,
                 iris_running=running and age is not None and age <= TASK_STATE_FRESHNESS,
                 iris_state_age=age,
+                execution_uid=executions.get((cluster, root_job)),
             )
         )
     return tuple(runs)

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -126,10 +126,9 @@ Signals = dict[tuple[str, str], RunSignals]
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     """Return the newest sample and health-window reductions per run and metric.
 
-    Everything reduces over one execution: the newest attempt process zero
-    reports. A retry keeps the run ID and takes a new `execution_uid`, so
-    partitioning on the run alone would sum one attempt's skipped steps into the
-    next. Process zero because Levanter publishes tracker metrics only from it.
+    Each watched run supplies its current execution. A retry keeps the run ID
+    and takes a new `execution_uid`, so reductions must also match that identity.
+    Process zero reports the Levanter tracker metrics.
     """
     execution_predicates = [
         "("

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -28,6 +28,7 @@ from hero_runs import (
     as_utc,
     hero_run_id,
     root_job_for,
+    run_id_predicate,
     sql_epoch_ms,
     sql_timestamp,
 )
@@ -140,6 +141,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         if run.execution_uid is not None
     ]
     execution_predicate = " OR ".join(execution_predicates) or "FALSE"
+    run_predicate = run_id_predicate(runs)
     signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
     liveness_since = sql_epoch_ms(now - _LIVENESS_LOOKBACK)
     health_since = sql_epoch_ms(now - HEALTH_WINDOW)
@@ -151,7 +153,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, run_id, execution_uid, "
         "name, value, timestamp_ms, seq "
         f"FROM {LEVANTER_METRICS_TABLE} "
-        f"WHERE ({execution_predicate}) AND process_index = 0 "
+        f"WHERE {run_predicate} AND ({execution_predicate}) AND process_index = 0 "
         f"AND name IN ({metric_names}) "
         f"AND timestamp_ms >= {liveness_since} AND timestamp_ms < {end} "
         f"AND (name IN ('{PHASE_METRIC}', '{_EVAL_LOSS}') "

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -127,9 +127,9 @@ Signals = dict[tuple[str, str], RunSignals]
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     """Return the newest sample and health-window reductions per run and metric.
 
-    Each watched run supplies its current execution. A retry keeps the run ID
-    and takes a new `execution_uid`, so reductions must also match that identity.
-    Process zero reports the Levanter tracker metrics.
+    Runs without a current execution are omitted. A retry keeps the run ID and
+    takes a new `execution_uid`, so reductions also match that identity. Process
+    zero reports the Levanter tracker metrics.
     """
     execution_predicates = [
         "("

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -27,6 +27,10 @@ TASK_STATE_LOOKBACK = timedelta(hours=1)
 # Long enough that a run which goes silent stays watched while
 # `TrainingTelemetryGone` counts out its threshold and pending period.
 PHASE_ENROLLMENT_LOOKBACK = timedelta(minutes=60)
+# Keep enough phase history to identify the current execution after a telemetry
+# outage has outlasted the enrollment window. `watched_runs` only enrolls a
+# phase-only run for `PHASE_ENROLLMENT_LOOKBACK`.
+PHASE_EXECUTION_LOOKBACK = timedelta(hours=24)
 # Silence this long is the telemetry path or the process. `TrainingTelemetryGone`
 # owns that case; the other projections defer rather than page for it again.
 TELEMETRY_GONE_AGE = timedelta(minutes=10)
@@ -121,24 +125,25 @@ def task_state_query(now: datetime) -> str:
 
 
 def phase_enrollment_query(now: datetime) -> str:
-    """Return each hero run that still publishes Levanter phase telemetry."""
-    start = sql_epoch_ms(now - PHASE_ENROLLMENT_LOOKBACK)
+    """Return the latest Levanter phase and execution identity for each hero run."""
+    start = sql_epoch_ms(now - PHASE_EXECUTION_LOOKBACK)
     end = sql_epoch_ms(now)
     return (
         "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
-        "run_id, job_id, timestamp_ms, seq "
+        "run_id, job_id, execution_uid, timestamp_ms, seq "
         f"FROM {LEVANTER_METRICS_TABLE} "
         f"WHERE name = '{PHASE_METRIC}' AND process_index = 0 "
-        f"AND run_id LIKE '{HERO_RUN_PREFIX}%' AND job_id IS NOT NULL "
+        f"AND run_id LIKE '{HERO_RUN_PREFIX}%' AND job_id IS NOT NULL AND execution_uid IS NOT NULL "
         f"AND timestamp_ms >= {start} AND timestamp_ms < {end}"
         "), ranked AS ("
-        "SELECT origin_cluster, run_id, job_id, "
+        "SELECT origin_cluster, run_id, job_id, execution_uid, timestamp_ms, "
         "ROW_NUMBER() OVER ("
         "PARTITION BY origin_cluster, run_id ORDER BY timestamp_ms DESC, seq DESC"
         ") AS rn FROM samples"
         ") "
-        "SELECT origin_cluster AS cluster, run_id, job_id AS telemetry_job "
+        "SELECT origin_cluster AS cluster, run_id, job_id AS telemetry_job, execution_uid, "
+        "to_timestamp_millis(timestamp_ms) AS phase_at "
         "FROM ranked WHERE rn = 1"
     )
 

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -1006,15 +1006,6 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
     assert (evaluation.latest, evaluation.previous) == (2.31, 2.17)
 
 
-def test_signal_query_exposes_multi_run_partition_constraint():
-    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
-
-    query = signal_query(now, (_watched("hero-a"), _watched("hero-b")))
-
-    assert "WHERE run_id IN ('hero-a', 'hero-b') AND (" in query
-    assert query.count('FROM "levanter.metrics"') == 1
-
-
 def test_signal_query_reduces_one_task_attempt_at_a_time():
     # A retry keeps the run ID and takes a new execution_uid. Summing across both
     # would charge the new attempt with the steps the old one skipped.

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -995,7 +995,6 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
     )
 
     query = signal_query(now, (_watched(),))
-    assert query.count('FROM "levanter.metrics"') == 1
     run = signals_by_run(database.execute(query).fetch_arrow_table())["cw-a", "hero-a"]
     signals = run.metrics
 

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -639,6 +639,7 @@ def _watched(
     *,
     iris_running: bool = True,
     iris_state_age: timedelta | None = timedelta(seconds=30),
+    execution_uid: str | None = "attempt-1",
 ) -> WatchedRun:
     return WatchedRun(
         cluster="cw-a",
@@ -646,6 +647,7 @@ def _watched(
         run_id=run_id,
         iris_running=iris_running,
         iris_state_age=iris_state_age,
+        execution_uid=execution_uid,
     )
 
 
@@ -685,7 +687,13 @@ def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
         running_since=[now - timedelta(hours=3)],
         running=[64],
     )
-    phase_runs = finelog_result(cluster=["cw-a"], run_id=["hero-a"], telemetry_job=["/u/hero-a-coord/train"])
+    phase_runs = finelog_result(
+        cluster=["cw-a"],
+        run_id=["hero-a"],
+        telemetry_job=["/u/hero-a-coord/train"],
+        execution_uid=["attempt-1"],
+        phase_at=[now - timedelta(seconds=30)],
+    )
 
     assert active_hero_runs(task_states, now) == ()
     runs = watched_runs(task_states, phase_runs, now)
@@ -693,6 +701,28 @@ def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
 
     signals = _signals(now, {"phase": {"latest": 1.0}})
     assert "iris_state_stale" in _reasons(health_alert_rows(runs, signals, pa.table({}), now))
+
+
+def test_watched_run_keeps_an_old_phase_execution_without_phase_only_enrollment():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    task_states = finelog_result(
+        cluster=["cw-a"],
+        job=["/u/hero-a-coord"],
+        state_at=[now],
+        running_since=[now - timedelta(hours=3)],
+        running=[64],
+    )
+    old_phase = finelog_result(
+        cluster=["cw-a", "cw-b"],
+        run_id=["hero-a", "hero-old"],
+        telemetry_job=["/u/hero-a-coord/train", "/u/hero-old-coord/train"],
+        execution_uid=["attempt-1", "attempt-old"],
+        phase_at=[now - timedelta(hours=2), now - timedelta(hours=2)],
+    )
+
+    runs = watched_runs(task_states, old_phase, now)
+
+    assert [(run.run_id, run.execution_uid) for run in runs] == [("hero-a", "attempt-1")]
 
 
 def test_silent_telemetry_pages_whether_or_not_iris_still_runs_the_tasks():
@@ -964,7 +994,9 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
         ]
     )
 
-    run = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+    query = signal_query(now, (_watched(),))
+    assert query.count('FROM "levanter.metrics"') == 1
+    run = signals_by_run(database.execute(query).fetch_arrow_table())["cw-a", "hero-a"]
     signals = run.metrics
 
     throughput = signals["throughput_tokens_per_second"]
@@ -989,7 +1021,9 @@ def test_signal_query_reduces_one_task_attempt_at_a_time():
         ]
     )
 
-    run = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+    run = signals_by_run(
+        database.execute(signal_query(now, (_watched(execution_uid="attempt-2"),))).fetch_arrow_table()
+    )["cw-a", "hero-a"]
 
     assert run.execution_uid == "attempt-2"
     assert run.metrics["optim_skipped_step"].recent_total == 1.0

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -1006,6 +1006,15 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
     assert (evaluation.latest, evaluation.previous) == (2.31, 2.17)
 
 
+def test_signal_query_exposes_multi_run_partition_constraint():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+
+    query = signal_query(now, (_watched("hero-a"), _watched("hero-b")))
+
+    assert "WHERE run_id IN ('hero-a', 'hero-b') AND (" in query
+    assert query.count('FROM "levanter.metrics"') == 1
+
+
 def test_signal_query_reduces_one_task_attempt_at_a_time():
     # A retry keeps the run ID and takes a new execution_uid. Summing across both
     # would charge the new attempt with the steps the old one skipped.

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -702,6 +702,18 @@ def test_cluster_variable_lists_every_configured_cluster():
         assert set(variables["cluster"]["query"].split(",")) == expected, name
 
 
+def test_training_run_selector_uses_a_fixed_discovery_window():
+    dashboard = _stitched_dashboards()["training.json"]
+    variable = next(variable for variable in dashboard["templating"]["list"] if variable["name"] == "run")
+    sql = next(
+        param["value"] for param in variable["query"]["infinityQuery"]["url_options"]["params"] if param["key"] == "sql"
+    )
+
+    assert "now() - INTERVAL '12 hours'" in sql
+    assert "{{from}}" not in sql
+    assert "{{to}}" not in sql
+
+
 def test_cluster_series_keep_one_colour_across_dashboards():
     # Colour follows the entity, not its rank: a cluster filtered out of one panel must
     # not repaint the survivors, and the same cluster reads the same on every dashboard.

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -708,10 +708,21 @@ def test_training_run_selector_uses_a_fixed_discovery_window():
     sql = next(
         param["value"] for param in variable["query"]["infinityQuery"]["url_options"]["params"] if param["key"] == "sql"
     )
+    at = datetime(2026, 8, 26, 12, tzinfo=UTC)
+    database = duckdb.connect()
+    database.execute('CREATE TABLE "levanter.metrics"(run_id VARCHAR, step BIGINT, timestamp_ms BIGINT)')
+    database.executemany(
+        'INSERT INTO "levanter.metrics" VALUES (?, ?, ?)',
+        [
+            ("recent-run", 100, int((at.timestamp() - 3_600) * 1_000)),
+            ("old-run", 200, int((at.timestamp() - 3 * 86_400) * 1_000)),
+        ],
+    )
+    sql = sql.replace("now()", "TIMESTAMP '2026-08-26 12:00:00+00:00'")
+    sql = sql.replace("{{from}}", "TIMESTAMP '2026-08-19 12:00:00+00:00'")
+    sql = sql.replace("{{to}}", "TIMESTAMP '2026-08-26 12:00:00+00:00'")
 
-    assert "now() - INTERVAL '12 hours'" in sql
-    assert "{{from}}" not in sql
-    assert "{{to}}" not in sql
+    assert database.execute(sql).fetchall() == [("recent-run",)]
 
 
 def test_cluster_series_keep_one_colour_across_dashboards():

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -224,7 +224,9 @@ benchmark; there is no free-form plugin registry.
 A column declared with `ColumnIndex.trigram` gets a span-granular substring
 section. That index makes `contains(col, …)`, `col LIKE '%…%'`, and regexes with
 required literal runs prune instead of full-scan. Today it is on `log.key`,
-`log.data`, and the `name` columns of `telemetry_v1` and `levanter.metrics`.
+`log.data`, and telemetry `name` columns. `levanter.metrics` deliberately
+disables all secondary indexes until its broken index policy is replaced; its
+exact hidden `run_id` partition remains active.
 
 Sorting by a column does not cover substring search of it. A log key is
 `/user/<job>-coord/<job>/<task>:<attempt>`, so the job an operator searches for

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -224,9 +224,12 @@ benchmark; there is no free-form plugin registry.
 A column declared with `ColumnIndex.trigram` gets a span-granular substring
 section. That index makes `contains(col, …)`, `col LIKE '%…%'`, and regexes with
 required literal runs prune instead of full-scan. Today it is on `log.key`,
-`log.data`, and telemetry `name` columns. `levanter.metrics` deliberately
-disables all secondary indexes until its broken index policy is replaced; its
-exact hidden `run_id` partition remains active.
+`log.data`, and telemetry `name` columns. `levanter.metrics` intentionally has no
+secondary indexes: its queries use exact `run_id` and `name` predicates, which
+are served by the hidden exact run partition and Parquet sort/statistics. Its
+managed policy also disables adaptive string value counts and removes stale
+bundles written under the old telemetry-derived schema in bounded maintenance
+batches.
 
 Sorting by a column does not cover substring search of it. A log key is
 `/user/<job>-coord/<job>/<task>:<attempt>`, so the job an operator searches for

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -189,11 +189,13 @@ physical layout `levanter.metrics/run_id/00..31/`, while each footer and catalog
 row retains the full run id for exact pruning and future run deletion. The
 bucket only limits directory fanout; it does not replace the logical partition.
 
-Secondary indexes are disabled for `levanter.metrics` while its index layout is
-redesigned. The server-owned registration removes index declarations, queries
-ignore existing `.fidx` bundles, compaction writes no new bundles, and backfill
-is a no-op. Source Parquet remains authoritative. Existing derived files can be
-removed separately and rebuilt only after a corrected policy is registered.
+`levanter.metrics` intentionally has no secondary indexes. Exact `run_id`
+partition pruning and the `(run_id, name, step, timestamp_ms)` Parquet order
+serve its deployed exact-match queries without telemetry's `name` trigram,
+`kind` postings, or adaptive string value counts. Server-owned registration
+removes the old declarations, queries ignore old `.fidx` bundles, and bounded
+maintenance deletes those derived files online. Source Parquet remains
+authoritative throughout cleanup.
 
 Maintenance converges older layouts online. It merges migration-produced or
 partition-stamped L0s into partitioned L1, rebuilds stale local partition

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -201,7 +201,7 @@ metadata, and moves current local L1 files into their bucket directory under the
 query-visibility lock. Evicted objects move with an in-bucket copy, atomic
 catalog swap, then old-key deletion, so the server does not download archived
 bytes. Startup reconciliation resolves a crash between those phases by keeping
-the key named by the catalog. One process-wide L0 rebuild wave runs two
+the key named by the catalog. One store-wide L0 rebuild wave runs two
 independent workers; each coalesces about 32 MiB of compressed inputs, sorts and
 partitions that bounded stream, then publishes its source span atomically. The
 global permit prevents several namespaces from multiplying that memory

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -183,6 +183,34 @@ It retains unpartitioned, malformed, or older-spec files, so a rolling
 conversion cannot hide rows. A partition transform change requires a new spec
 id rather than reinterpreting existing metadata.
 
+L0 remains flat and unpartitioned so a busy run cannot strand a separate stream
+of tiny files. Compaction writes L1 and higher segments under the bounded
+physical layout `levanter.metrics/run_id/00..31/`, while each footer and catalog
+row retains the full run id for exact pruning and future run deletion. The
+bucket only limits directory fanout; it does not replace the logical partition.
+
+Secondary indexes are disabled for `levanter.metrics` while its index layout is
+redesigned. The server-owned registration removes index declarations, queries
+ignore existing `.fidx` bundles, compaction writes no new bundles, and backfill
+is a no-op. Source Parquet remains authoritative. Existing derived files can be
+removed separately and rebuilt only after a corrected policy is registered.
+
+Maintenance converges older layouts online. It merges migration-produced or
+partition-stamped L0s into partitioned L1, rebuilds stale local partition
+metadata, and moves current local L1 files into their bucket directory under the
+query-visibility lock. Evicted objects move with an in-bucket copy, atomic
+catalog swap, then old-key deletion, so the server does not download archived
+bytes. Startup reconciliation resolves a crash between those phases by keeping
+the key named by the catalog. One process-wide L0 rebuild wave runs two
+independent workers; each coalesces about 32 MiB of compressed inputs, sorts and
+partitions that bounded stream, then publishes its source span atomically. The
+global permit prevents several namespaces from multiplying that memory
+envelope and leaves half of the four-core hub available for queries. A cycle starts work for at most three seconds, flushes and syncs live
+writes, and resumes after 100 ms while local migration remains. Remote copies retain their separate
+three-second budget. An individual job already in flight may exceed its budget.
+Watch `physical layout migration advanced` and `remote physical layout migration
+advanced` until their remaining counts reach zero.
+
 `telemetry_v1` exposes stable resource dimensions as nullable columns:
 `run_id`, `job_id`, `execution_uid`, `region`, `node_name`, and `process_index`.
 Producers may send them directly in the request's `resource`
@@ -221,8 +249,10 @@ serving. It takes a consistent SQLite snapshot and hard-links exactly the local
 root Parquets named by that catalog under
 `.finelog-telemetry-v1-migration/source`. If compaction removes one during the
 snapshot, preparation retries from a newer catalog. Rewritten Parquets land
-under `.finelog-telemetry-v1-migration/staged` with a negative `seq` range
-disjoint from live ingestion.
+under `.finelog-telemetry-v1-migration/staged` as flat, unpartitioned L0s with a
+negative `seq` range disjoint from live ingestion. After publication, ordinary
+runtime maintenance performs the L0-to-L1 partitioning and bounded physical
+placement described above.
 
 ```bash
 finelog-migrate prepare-telemetry-v1 \

--- a/lib/finelog/config/marin.yaml
+++ b/lib/finelog/config/marin.yaml
@@ -5,7 +5,7 @@ remote_log_dir: gs://marin-us-central2/finelog/marin
 client_url: iap+https://iris.oa.dev/proxy/system.log-server
 query_metadata_cache_mb: 3072
 query_index_cache_mb: 1024
-telemetry_migration_mode: dual-write
+telemetry_migration_mode: normal
 deployment:
   gcp:
     project: hai-gcp-models

--- a/lib/finelog/rust/src/levanter_metrics_policy.rs
+++ b/lib/finelog/rust/src/levanter_metrics_policy.rs
@@ -43,6 +43,8 @@ pub(crate) const LEVANTER_RUN_PARTITION_POLICY: StringIdentityPartitionPolicy =
         spec_id: 1,
         column: RUN_ID_COLUMN,
         partition_field: RUN_ID_COLUMN,
+        directory_prefix: RUN_ID_COLUMN,
+        directory_buckets: 32,
     };
 
 #[derive(Clone, Copy, Debug)]
@@ -277,10 +279,8 @@ pub(crate) fn levanter_metrics_schema() -> Schema {
             nullable_column("node_name", ColumnType::COLUMN_TYPE_STRING),
             nullable_column("process_index", ColumnType::COLUMN_TYPE_INT64),
             nullable_column(STEP_COLUMN, ColumnType::COLUMN_TYPE_INT64),
-            nullable_column(NAME_COLUMN, ColumnType::COLUMN_TYPE_STRING).with_trigram_index(),
-            nullable_column(KIND_COLUMN, ColumnType::COLUMN_TYPE_STRING)
-                .with_exact_values(["scalar", "summary", "histogram"])
-                .with_value_counts(),
+            nullable_column(NAME_COLUMN, ColumnType::COLUMN_TYPE_STRING),
+            nullable_column(KIND_COLUMN, ColumnType::COLUMN_TYPE_STRING),
             nullable_column(VALUE_COLUMN, ColumnType::COLUMN_TYPE_FLOAT64),
             nullable_column(MIN_COLUMN, ColumnType::COLUMN_TYPE_FLOAT64),
             nullable_column(MAX_COLUMN, ColumnType::COLUMN_TYPE_FLOAT64),

--- a/lib/finelog/rust/src/migrations/telemetry_v1.rs
+++ b/lib/finelog/rust/src/migrations/telemetry_v1.rs
@@ -21,8 +21,7 @@ use crate::errors::StatsError;
 use crate::ingestion_policy::IngestionBatchSource;
 use crate::partition_policy::{select_rows, SegmentPartition};
 use crate::policies::{
-    eager_storage_namespaces_for, physical_partition_policy_for, schema_for_namespace,
-    storage_policy_for, PolicyRegistry,
+    eager_storage_namespaces_for, schema_for_namespace, storage_policy_for, PolicyRegistry,
 };
 use crate::server::telemetry::TELEMETRY_MAX_ROW_GROUP_ROWS;
 use crate::store::catalog::{Catalog, CATALOG_DB_FILENAME};
@@ -1118,10 +1117,9 @@ fn write_source_outputs(
             IngestionBatchSource::Stored(source.namespace.as_str()),
             &batch,
         )? {
-            for (destination, batch) in physical_migration_batches(
-                partition.destination.logical_namespace,
-                partition.batch,
-            )? {
+            for (destination, batch) in
+                physical_migration_batches(partition.destination.logical_namespace, partition.batch)
+            {
                 if !writers.contains_key(&destination) {
                     let writer = create_destination_writer(
                         &destination,
@@ -1343,30 +1341,17 @@ fn record_source_outputs(
 fn physical_migration_batches(
     namespace: String,
     batch: RecordBatch,
-) -> Result<Vec<(MigrationDestination, RecordBatch)>, StatsError> {
-    let Some(policy) = physical_partition_policy_for(&namespace) else {
-        return Ok(vec![(
-            MigrationDestination {
-                namespace,
-                partition: None,
-            },
-            batch,
-        )]);
-    };
-    Ok(policy
-        .partition_batches(&[batch])?
-        .into_iter()
-        .flat_map(|output| {
-            let destination = MigrationDestination {
-                namespace: namespace.clone(),
-                partition: Some(output.partition),
-            };
-            output
-                .batches
-                .into_iter()
-                .map(move |batch| (destination.clone(), batch))
-        })
-        .collect())
+) -> Vec<(MigrationDestination, RecordBatch)> {
+    // Migration publishes ordinary flat, unpartitioned L0 segments. The live
+    // maintenance path owns the L0 -> sorted/partitioned L1 transition, exactly
+    // as it does for new ingestion.
+    vec![(
+        MigrationDestination {
+            namespace,
+            partition: None,
+        },
+        batch,
+    )]
 }
 
 fn align_migrated_batch(
@@ -2190,7 +2175,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_in_place_indexes_steps_independently_of_physical_row_order() {
+    fn prepare_in_place_indexes_steps_and_stages_unpartitioned_l0() {
         let dirs = TestDirs::new("legacy_levanter_metrics");
         let catalog = Catalog::open(Some(&dirs.store)).unwrap();
         let chronological =
@@ -2223,13 +2208,7 @@ mod tests {
             crate::levanter_metrics_policy::LEVANTER_METRICS_NAMESPACE
         );
         assert_eq!(output.rows, 1);
-        assert_eq!(
-            output
-                .partition
-                .as_ref()
-                .and_then(|partition| partition.value("run_id")),
-            Some("run/+long")
-        );
+        assert!(output.partition.is_none());
 
         let staged_path = dirs
             .store

--- a/lib/finelog/rust/src/migrations/telemetry_v1.rs
+++ b/lib/finelog/rust/src/migrations/telemetry_v1.rs
@@ -1117,25 +1117,21 @@ fn write_source_outputs(
             IngestionBatchSource::Stored(source.namespace.as_str()),
             &batch,
         )? {
-            for (destination, batch) in
-                physical_migration_batches(partition.destination.logical_namespace, partition.batch)
-            {
-                if !writers.contains_key(&destination) {
-                    let writer = create_destination_writer(
-                        &destination,
-                        writers.len(),
-                        source_offset,
-                        config,
-                    )?;
-                    writers.insert(destination.clone(), writer);
-                }
-                write_destination_batch(
-                    writers
-                        .get_mut(&destination)
-                        .expect("destination writer was just created"),
-                    &batch,
-                )?;
+            let destination = MigrationDestination {
+                namespace: partition.destination.logical_namespace,
+                partition: None,
+            };
+            if !writers.contains_key(&destination) {
+                let writer =
+                    create_destination_writer(&destination, writers.len(), source_offset, config)?;
+                writers.insert(destination.clone(), writer);
             }
+            write_destination_batch(
+                writers
+                    .get_mut(&destination)
+                    .expect("destination writer was just created"),
+                &partition.batch,
+            )?;
         }
         if last_progress.elapsed() >= PROGRESS_LOG_INTERVAL {
             tracing::info!(
@@ -1336,22 +1332,6 @@ fn record_source_outputs(
     source.outputs = outputs;
     source.complete = true;
     Ok(())
-}
-
-fn physical_migration_batches(
-    namespace: String,
-    batch: RecordBatch,
-) -> Vec<(MigrationDestination, RecordBatch)> {
-    // Migration publishes ordinary flat, unpartitioned L0 segments. The live
-    // maintenance path owns the L0 -> sorted/partitioned L1 transition, exactly
-    // as it does for new ingestion.
-    vec![(
-        MigrationDestination {
-            namespace,
-            partition: None,
-        },
-        batch,
-    )]
 }
 
 fn align_migrated_batch(

--- a/lib/finelog/rust/src/migrations/telemetry_v1.rs
+++ b/lib/finelog/rust/src/migrations/telemetry_v1.rs
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 
 use crate::errors::StatsError;
 use crate::ingestion_policy::IngestionBatchSource;
-use crate::partition_policy::{select_rows, SegmentPartition};
+use crate::partition_policy::select_rows;
 use crate::policies::{
     eager_storage_namespaces_for, schema_for_namespace, storage_policy_for, PolicyRegistry,
 };
@@ -182,8 +182,6 @@ pub struct SourceSegment {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlannedOutput {
     pub namespace: String,
-    #[serde(default)]
-    pub partition: Option<SegmentPartition>,
     pub relative_path: String,
     pub min_seq: i64,
     pub max_seq: i64,
@@ -197,7 +195,6 @@ pub struct PlannedOutput {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct MigrationDestination {
     namespace: String,
-    partition: Option<SegmentPartition>,
 }
 
 struct DestinationWriter {
@@ -662,7 +659,7 @@ fn replace_catalog_for_publish(
                 created_at_ms,
                 min_key_value: Some(output.min_timestamp_ms.to_string()),
                 max_key_value: Some(output.max_timestamp_ms.to_string()),
-                partition: output.partition.clone(),
+                partition: None,
                 location: SegmentLocation::Local,
             })
         })
@@ -1119,7 +1116,6 @@ fn write_source_outputs(
         )? {
             let destination = MigrationDestination {
                 namespace: partition.destination.logical_namespace,
-                partition: None,
             };
             if !writers.contains_key(&destination) {
                 let writer =
@@ -1216,7 +1212,7 @@ fn create_destination_writer(
         ArrowWriterOptions::new().with_properties(segment_writer_properties_with_partition(
             usize::try_from(TELEMETRY_MAX_ROW_GROUP_ROWS)
                 .expect("telemetry row-group limit fits usize"),
-            destination.partition.as_ref(),
+            None,
         )?);
     let writer = ArrowWriter::try_new_with_options(file, Arc::clone(&target_schema), options)
         .map_err(internal_error("create output parquet writer"))?;
@@ -1294,7 +1290,6 @@ fn finish_destination_writers(
             .into_owned();
         outputs.push(PlannedOutput {
             namespace: writer.destination.namespace,
-            partition: writer.destination.partition,
             relative_path,
             min_seq: writer.min_seq,
             max_seq: writer.next_seq - 1,
@@ -1309,9 +1304,7 @@ fn finish_destination_writers(
             file_sha256: Some(file_sha256(&writer.final_path)?),
         });
     }
-    outputs.sort_by(|left, right| {
-        (&left.namespace, &left.partition).cmp(&(&right.namespace, &right.partition))
-    });
+    outputs.sort_by(|left, right| left.namespace.cmp(&right.namespace));
     Ok(outputs)
 }
 
@@ -1499,7 +1492,7 @@ fn verify_output_file(
     if footer.row_count != output.rows
         || footer.min_seq != output.min_seq
         || footer.max_seq != output.max_seq
-        || footer.partition != output.partition
+        || footer.partition.is_some()
     {
         return Err(validation_error(format!(
             "output segment metadata differs from plan: {}",
@@ -2068,7 +2061,6 @@ mod tests {
             .filter(|output| output.namespace == LEVANTER_NAMESPACE)
             .collect::<Vec<_>>();
         assert_eq!(levanter_outputs.len(), 1);
-        assert!(levanter_outputs[0].partition.is_none());
         let staged_dir = dirs.store.join(MIGRATION_DIRECTORY).join(STAGED_DIRECTORY);
         assert!(manifest
             .source_segments
@@ -2188,7 +2180,6 @@ mod tests {
             crate::levanter_metrics_policy::LEVANTER_METRICS_NAMESPACE
         );
         assert_eq!(output.rows, 1);
-        assert!(output.partition.is_none());
 
         let staged_path = dirs
             .store

--- a/lib/finelog/rust/src/migrations/telemetry_v1.rs
+++ b/lib/finelog/rust/src/migrations/telemetry_v1.rs
@@ -192,13 +192,8 @@ pub struct PlannedOutput {
     pub file_sha256: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct MigrationDestination {
-    namespace: String,
-}
-
 struct DestinationWriter {
-    destination: MigrationDestination,
+    namespace: String,
     min_seq: i64,
     next_seq: i64,
     rows: i64,
@@ -1114,9 +1109,7 @@ fn write_source_outputs(
             IngestionBatchSource::Stored(source.namespace.as_str()),
             &batch,
         )? {
-            let destination = MigrationDestination {
-                namespace: partition.destination.logical_namespace,
-            };
+            let destination = partition.destination.logical_namespace;
             if !writers.contains_key(&destination) {
                 let writer =
                     create_destination_writer(&destination, writers.len(), source_offset, config)?;
@@ -1178,7 +1171,7 @@ fn migrated_source_offset(source_index: usize) -> Result<i64, StatsError> {
 }
 
 fn create_destination_writer(
-    destination: &MigrationDestination,
+    namespace: &str,
     output_index: usize,
     source_offset: i64,
     config: &PrepareConfig,
@@ -1192,7 +1185,7 @@ fn create_destination_writer(
         .checked_mul(MIGRATED_SEQ_ROWS_PER_OUTPUT)
         .and_then(|offset| source_offset.checked_add(offset))
         .ok_or_else(|| validation_error("migrated sequence range overflowed"))?;
-    let relative_path = Path::new(&destination.namespace).join(seg_filename(OUTPUT_LEVEL, min_seq));
+    let relative_path = Path::new(namespace).join(seg_filename(OUTPUT_LEVEL, min_seq));
     let final_path = config.output_dir.join(relative_path);
     let parent = final_path
         .parent()
@@ -1206,8 +1199,7 @@ fn create_destination_writer(
         }
     }
     let file = File::create(&temporary_path).map_err(internal_error("create output segment"))?;
-    let target_schema =
-        schema_to_arrow(&stored_form(migration_schema_for(&destination.namespace)?));
+    let target_schema = schema_to_arrow(&stored_form(migration_schema_for(namespace)?));
     let options =
         ArrowWriterOptions::new().with_properties(segment_writer_properties_with_partition(
             usize::try_from(TELEMETRY_MAX_ROW_GROUP_ROWS)
@@ -1217,7 +1209,7 @@ fn create_destination_writer(
     let writer = ArrowWriter::try_new_with_options(file, Arc::clone(&target_schema), options)
         .map_err(internal_error("create output parquet writer"))?;
     Ok(DestinationWriter {
-        destination: destination.clone(),
+        namespace: namespace.to_string(),
         min_seq,
         next_seq: min_seq,
         rows: 0,
@@ -1269,7 +1261,7 @@ fn write_destination_batch(
 }
 
 fn finish_destination_writers(
-    writers: BTreeMap<MigrationDestination, DestinationWriter>,
+    writers: BTreeMap<String, DestinationWriter>,
     output_dir: &Path,
 ) -> Result<Vec<PlannedOutput>, StatsError> {
     let mut outputs = Vec::with_capacity(writers.len());
@@ -1289,7 +1281,7 @@ fn finish_destination_writers(
             .to_string_lossy()
             .into_owned();
         outputs.push(PlannedOutput {
-            namespace: writer.destination.namespace,
+            namespace: writer.namespace,
             relative_path,
             min_seq: writer.min_seq,
             max_seq: writer.next_seq - 1,

--- a/lib/finelog/rust/src/partition_policy.rs
+++ b/lib/finelog/rust/src/partition_policy.rs
@@ -1,11 +1,13 @@
 //! Versioned physical partitioning inside a logical namespace.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
 
 use arrow::array::{Array, StringArray, UInt32Array};
 use arrow::compute::take;
 use arrow::record_batch::RecordBatch;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::errors::StatsError;
 
@@ -48,6 +50,13 @@ pub trait PhysicalPartitionPolicy: std::fmt::Debug + Sync {
         &self,
         exact_values: &HashMap<String, Vec<String>>,
     ) -> Option<BTreeSet<SegmentPartition>>;
+
+    /// Relative directory for an L1+ segment carrying `partition`.
+    ///
+    /// Partition metadata remains exact even when this path uses a bounded
+    /// bucket. L0 never calls this method: it stays flat and unpartitioned until
+    /// compaction sorts and partitions it.
+    fn segment_directory(&self, partition: &SegmentPartition) -> PathBuf;
 }
 
 /// An exact hidden partition over one required UTF-8 column.
@@ -56,6 +65,8 @@ pub struct StringIdentityPartitionPolicy {
     pub spec_id: u32,
     pub column: &'static str,
     pub partition_field: &'static str,
+    pub directory_prefix: &'static str,
+    pub directory_buckets: u32,
 }
 
 impl StringIdentityPartitionPolicy {
@@ -64,6 +75,13 @@ impl StringIdentityPartitionPolicy {
             spec_id: self.spec_id,
             values: BTreeMap::from([(self.partition_field.to_string(), value.to_string())]),
         }
+    }
+
+    fn bucket(&self, value: &str) -> u32 {
+        assert!(self.directory_buckets > 0);
+        let digest = Sha256::digest(value.as_bytes());
+        u32::from_be_bytes(digest[..4].try_into().expect("sha256 prefix is four bytes"))
+            % self.directory_buckets
     }
 }
 
@@ -87,6 +105,36 @@ impl PhysicalPartitionPolicy for StringIdentityPartitionPolicy {
     ) -> Option<BTreeSet<SegmentPartition>> {
         let values = exact_values.get(self.column)?;
         Some(values.iter().map(|value| self.partition(value)).collect())
+    }
+
+    fn segment_directory(&self, partition: &SegmentPartition) -> PathBuf {
+        assert!(self.is_current_partition(partition));
+        let value = partition
+            .value(self.partition_field)
+            .expect("current identity partition carries its field");
+        Path::new(self.directory_prefix).join(format!("{:02}", self.bucket(value)))
+    }
+}
+
+/// Final path for a segment under a namespace directory.
+///
+/// L0 is deliberately flat regardless of any partition metadata. L1+ follows
+/// the active physical policy when the footer carries a current partition.
+pub fn segment_path(
+    namespace_dir: &Path,
+    filename: &str,
+    level: i32,
+    partition: Option<&SegmentPartition>,
+    policy: Option<&dyn PhysicalPartitionPolicy>,
+) -> PathBuf {
+    if level == 0 {
+        return namespace_dir.join(filename);
+    }
+    match (partition, policy) {
+        (Some(partition), Some(policy)) if policy.is_current_partition(partition) => namespace_dir
+            .join(policy.segment_directory(partition))
+            .join(filename),
+        _ => namespace_dir.join(filename),
     }
 }
 
@@ -162,6 +210,8 @@ mod tests {
         spec_id: 4,
         column: "name",
         partition_field: "name",
+        directory_prefix: "name",
+        directory_buckets: 32,
     };
 
     fn batch(names: &[&str]) -> RecordBatch {
@@ -228,6 +278,42 @@ mod tests {
                 )]))
                 .unwrap(),
             BTreeSet::from([IDENTITY_POLICY.partition("run+long")])
+        );
+    }
+
+    #[test]
+    fn physical_path_is_bounded_while_partition_metadata_stays_exact() {
+        let first = IDENTITY_POLICY.partition("run/with/slashes");
+        let second = IDENTITY_POLICY.partition("a different run");
+        let first_path = segment_path(
+            Path::new("levanter.metrics"),
+            "seg_L1_0001.parquet",
+            1,
+            Some(&first),
+            Some(&IDENTITY_POLICY),
+        );
+        assert_eq!(first.value("name"), Some("run/with/slashes"));
+        assert_eq!(first_path.components().count(), 4);
+        assert_eq!(
+            first_path
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "name"
+        );
+        assert_ne!(first, second);
+        assert_eq!(
+            segment_path(
+                Path::new("levanter.metrics"),
+                "seg_L0_0001.parquet",
+                0,
+                Some(&first),
+                Some(&IDENTITY_POLICY),
+            ),
+            Path::new("levanter.metrics/seg_L0_0001.parquet")
         );
     }
 }

--- a/lib/finelog/rust/src/partition_policy.rs
+++ b/lib/finelog/rust/src/partition_policy.rs
@@ -284,7 +284,6 @@ mod tests {
     #[test]
     fn physical_path_is_bounded_while_partition_metadata_stays_exact() {
         let first = IDENTITY_POLICY.partition("run/with/slashes");
-        let second = IDENTITY_POLICY.partition("a different run");
         let first_path = segment_path(
             Path::new("levanter.metrics"),
             "seg_L1_0001.parquet",
@@ -304,7 +303,6 @@ mod tests {
                 .unwrap(),
             "name"
         );
-        assert_ne!(first, second);
         assert_eq!(
             segment_path(
                 Path::new("levanter.metrics"),

--- a/lib/finelog/rust/src/policies.rs
+++ b/lib/finelog/rust/src/policies.rs
@@ -39,6 +39,10 @@ trait SchemaPolicy: IngestionPolicy + NamespaceStoragePolicy {
         &self,
         namespace: &str,
     ) -> Option<&'static dyn PhysicalPartitionPolicy>;
+
+    fn segment_indexes_enabled(&self, _namespace: &str) -> bool {
+        true
+    }
 }
 
 // Rules are evaluated in declaration order. Each rule owns the complete policy
@@ -157,6 +161,11 @@ pub(crate) fn physical_partition_policy_for(
         .and_then(|policy| policy.physical_partition_policy(namespace))
 }
 
+pub(crate) fn segment_indexes_enabled_for(namespace: &str) -> bool {
+    matching_policy(&SCHEMA_POLICIES, namespace)
+        .is_none_or(|policy| policy.segment_indexes_enabled(namespace))
+}
+
 pub(crate) fn eager_storage_namespaces_for(namespace: &str) -> Vec<&'static str> {
     match matching_policy(&SCHEMA_POLICIES, namespace) {
         Some(policy) => policy.eager_namespaces(),
@@ -183,6 +192,11 @@ impl SchemaPolicy for LevanterMetricsPolicy {
         namespace: &str,
     ) -> Option<&'static dyn PhysicalPartitionPolicy> {
         self.physical_partition_policy(namespace)
+    }
+
+    fn segment_indexes_enabled(&self, namespace: &str) -> bool {
+        debug_assert!(matches_levanter_metrics_namespace(namespace));
+        false
     }
 }
 

--- a/lib/finelog/rust/src/query/provider.rs
+++ b/lib/finelog/rust/src/query/provider.rs
@@ -54,6 +54,7 @@ pub struct NamespaceProvider {
     segment_partitions: BTreeMap<String, SegmentPartition>,
     index_cache: Arc<IndexCache>,
     exact_postings_policy: Option<BTreeMap<String, Vec<String>>>,
+    segment_indexes_enabled: bool,
 }
 
 #[derive(Debug)]
@@ -192,6 +193,7 @@ impl NamespaceProvider {
                 segment_partitions: BTreeMap::new(),
                 index_cache,
                 exact_postings_policy: None,
+                segment_indexes_enabled: true,
             });
         }
 
@@ -206,6 +208,7 @@ impl NamespaceProvider {
             segment_partitions: BTreeMap::new(),
             index_cache,
             exact_postings_policy: None,
+            segment_indexes_enabled: true,
         })
     }
 
@@ -239,6 +242,16 @@ impl NamespaceProvider {
             values.dedup();
         }
         self.exact_postings_policy = Some(policy);
+        self
+    }
+
+    /// Enable or disable every derived segment index for this provider.
+    ///
+    /// Source Parquet remains authoritative. Disabling this ignores even an
+    /// existing `.fidx` bundle, which is required while a broken policy is
+    /// withdrawn and its artifacts await a later rebuild.
+    pub fn with_segment_indexes_enabled(mut self, enabled: bool) -> Self {
+        self.segment_indexes_enabled = enabled;
         self
     }
 }
@@ -290,6 +303,9 @@ impl TableProvider for NamespaceProvider {
                         .scan(state, projection, filters, limit)
                         .await?
                 };
+                if !self.segment_indexes_enabled {
+                    return Ok(plan);
+                }
                 let needles = crate::query::trigram_prune::substring_needles_by_column(filters);
                 let mut exact = crate::query::exact_prune::values_by_column(filters);
                 if let Some(policy) = &self.exact_postings_policy {
@@ -1411,6 +1427,49 @@ mod tests {
         .unwrap();
         let plan = probe.scan(&state, None, &[filter], None).await.unwrap();
         assert_prunes_to_span1(&plan, rg1_rows);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn disabled_segment_indexes_ignore_existing_bundle() {
+        use datafusion::execution::FunctionRegistry;
+        use datafusion::logical_expr::{col, expr::ScalarFunction, lit, Expr};
+
+        let dir = tempdir("disabled_segment_indexes");
+        let needle = "Bootstrap completed for TPU-xyz";
+        let path = write_two_span_log_segment(
+            &dir,
+            "data",
+            "idle heartbeat ok",
+            &["Bootstrap completed for TPU-xyz"],
+        );
+        let ctx = crate::query::make_ctx();
+        let udf = ctx.udf("contains").unwrap();
+        let filter =
+            Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![col("data"), lit(needle)]));
+        let plan = NamespaceProvider::build(
+            log_arrow(),
+            std::slice::from_ref(&path),
+            crate::query::index_cache::test_index_cache(),
+        )
+        .unwrap()
+        .with_segment_indexes_enabled(false)
+        .scan(&ctx.state(), None, &[filter], None)
+        .await
+        .unwrap();
+        let config = plan
+            .as_any()
+            .downcast_ref::<DataSourceExec>()
+            .expect("scan returns a parquet DataSourceExec")
+            .data_source()
+            .as_any()
+            .downcast_ref::<FileScanConfig>()
+            .expect("a FileScanConfig");
+        assert!(config
+            .file_groups
+            .iter()
+            .flat_map(|group| group.files())
+            .all(|file| file.extensions.is_none()));
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/lib/finelog/rust/src/query/provider.rs
+++ b/lib/finelog/rust/src/query/provider.rs
@@ -247,9 +247,8 @@ impl NamespaceProvider {
 
     /// Enable or disable every derived segment index for this provider.
     ///
-    /// Source Parquet remains authoritative. Disabling this ignores even an
-    /// existing `.fidx` bundle, which is required while a broken policy is
-    /// withdrawn and its artifacts await a later rebuild.
+    /// Source Parquet remains authoritative. A disabled managed policy ignores
+    /// any derived files that an older schema left beside its segments.
     pub fn with_segment_indexes_enabled(mut self, enabled: bool) -> Self {
         self.segment_indexes_enabled = enabled;
         self

--- a/lib/finelog/rust/src/query/provider.rs
+++ b/lib/finelog/rust/src/query/provider.rs
@@ -387,9 +387,11 @@ mod tests {
     use crate::store::trigram::SIDECAR_SPAN_ROWS;
     use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
     use arrow::record_batch::RecordBatch;
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
     use datafusion::datasource::physical_plan::FileScanConfig;
     use datafusion::datasource::source::DataSourceExec;
-    use datafusion::logical_expr::{col, lit};
+    use datafusion::execution::FunctionRegistry;
+    use datafusion::logical_expr::{col, expr::ScalarFunction, lit};
     use datafusion::prelude::SessionContext;
 
     use super::*;
@@ -1277,9 +1279,6 @@ mod tests {
     /// rather than the rendered text, which qualifies column names inconsistently
     /// across plan stages and would make a substring check pass vacuously.
     fn casts_the_data_column(plan: &datafusion::logical_expr::LogicalPlan) -> bool {
-        use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-        use datafusion::logical_expr::Expr;
-
         let mut found = false;
         plan.apply(|node| {
             for e in node.expressions() {
@@ -1362,9 +1361,6 @@ mod tests {
 
     #[tokio::test]
     async fn contains_query_returns_matches_and_prunes_row_groups() {
-        use datafusion::logical_expr::{col, lit};
-        use datafusion::logical_expr::{expr::ScalarFunction, Expr};
-
         let dir = tempdir("contains_prune");
         // The needle lives only in row group 1 (rows 2 and 4 of the tail).
         let needle = "Bootstrap completed for TPU-xyz";
@@ -1413,10 +1409,7 @@ mod tests {
         // 2) Evidence of pruning: the injected access plan skips row group 0 and
         //    keeps row group 1.
         let state = ctx.state();
-        let udf = {
-            use datafusion::execution::FunctionRegistry;
-            ctx.udf("contains").unwrap()
-        };
+        let udf = ctx.udf("contains").unwrap();
         let filter =
             Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![col("data"), lit(needle)]));
         let probe = NamespaceProvider::build(
@@ -1432,9 +1425,6 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_segment_indexes_ignore_existing_bundle() {
-        use datafusion::execution::FunctionRegistry;
-        use datafusion::logical_expr::{col, expr::ScalarFunction, lit, Expr};
-
         let dir = tempdir("disabled_segment_indexes");
         let needle = "Bootstrap completed for TPU-xyz";
         let path = write_two_span_log_segment(
@@ -1541,9 +1531,6 @@ mod tests {
 
     #[tokio::test]
     async fn regex_query_returns_matches_and_prunes_row_groups() {
-        use datafusion::logical_expr::{col, lit};
-        use datafusion::logical_expr::{expr::ScalarFunction, Expr};
-
         let dir = tempdir("regex_prune");
         let pattern = r"Bootstrap.*TPU-[a-z]+";
         let rg1 = vec![
@@ -1580,10 +1567,7 @@ mod tests {
             vec!["E0601 Bootstrap completed for TPU-xyz started".to_string()]
         );
 
-        let udf = {
-            use datafusion::execution::FunctionRegistry;
-            ctx.udf("regexp_matches").unwrap()
-        };
+        let udf = ctx.udf("regexp_matches").unwrap();
         let filter = Expr::ScalarFunction(ScalarFunction::new_udf(
             udf,
             vec![col("data"), lit(pattern)],
@@ -1660,9 +1644,6 @@ mod tests {
     async fn non_contains_query_leaves_plan_unchanged() {
         // A query with no contains() filter must not be rewritten — the hot path
         // pays nothing. The returned plan is the untouched ListingTable scan.
-        use datafusion::datasource::source::DataSourceExec;
-        use datafusion::logical_expr::{col, lit};
-
         let dir = tempdir("no_contains");
         let path =
             write_two_span_log_segment(&dir, "data", "idle heartbeat ok", &["one match here"]);

--- a/lib/finelog/rust/src/server/telemetry.rs
+++ b/lib/finelog/rust/src/server/telemetry.rs
@@ -378,7 +378,7 @@ impl TelemetryState {
                             "no server-owned schema is registered for {namespace:?}"
                         ))
                     })?;
-                    store.register_table(&namespace, schema, policy)
+                    store.register_managed_table(&namespace, schema, policy)
                 })
                 .await
                 {

--- a/lib/finelog/rust/src/store/adopt.rs
+++ b/lib/finelog/rust/src/store/adopt.rs
@@ -262,8 +262,15 @@ pub fn adopt_namespace_from_disk(
 /// Returns `None` when the directory has no readable segment (a namespace dir
 /// with no parquet contributes nothing — the caller skips it).
 pub fn recover_schema_from_segments(ns_dir: &Path) -> Option<Schema> {
-    // Newest segment = highest min_seq = last after the sorted discover.
-    let newest = discover_segments(ns_dir).into_iter().next_back()?;
+    let newest = discover_segments(ns_dir)
+        .into_iter()
+        .filter_map(|path| {
+            let (_, min_seq) =
+                crate::store::types::parse_seg_filename(path.file_name()?.to_str()?)?;
+            Some((min_seq, path))
+        })
+        .max_by_key(|(min_seq, _)| *min_seq)?
+        .1;
     let file = std::fs::File::open(&newest).ok()?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).ok()?;
     let arrow_schema = builder.schema();
@@ -982,7 +989,15 @@ mod tests {
         let staging = tempdir("staging");
         let (l1_path, _) =
             write_segment_to_dir(&staging, 1, 1, &worker_batch(1, vec![10, 20])).unwrap();
-        assert!(remote.upload("iris.worker", &l1_path).await);
+        assert!(
+            remote
+                .upload(
+                    "iris.worker",
+                    l1_path.file_name().unwrap().to_str().unwrap(),
+                    &l1_path,
+                )
+                .await
+        );
 
         let catalog = Catalog::open(Some(&data_dir)).unwrap();
         adopt_remote_segments(

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -31,7 +31,7 @@ use parquet::arrow::arrow_writer::{ArrowWriter, ArrowWriterOptions};
 use parquet::arrow::ProjectionMask;
 
 use crate::errors::StatsError;
-use crate::partition_policy::{PhysicalPartitionPolicy, SegmentPartition};
+use crate::partition_policy::{segment_path, PhysicalPartitionPolicy, SegmentPartition};
 use crate::store::compaction::config::CompactionJob;
 use crate::store::compaction::merge::{
     kway_merge, project_to_schema, sort_batch_by, sort_col_indices,
@@ -136,7 +136,13 @@ pub fn run_job_with_partition_policy(
             .is_none_or(|partition| !policy.is_current_partition(partition))
     });
     if job.inputs.len() == 1 && !needs_repartition {
-        apply_level_bump(&job.inputs[0], job.output_level, dir, &input_key_bounds)
+        apply_level_bump(
+            &job.inputs[0],
+            job.output_level,
+            dir,
+            execution.partition_policy,
+            &input_key_bounds,
+        )
     } else {
         apply_merge(
             job,
@@ -166,6 +172,7 @@ fn apply_level_bump(
     old: &SegmentRow,
     output_level: i32,
     dir: &Path,
+    partition_policy: Option<&dyn PhysicalPartitionPolicy>,
     input_key_bounds: &impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
     if !Path::new(&old.path).exists() {
@@ -176,7 +183,13 @@ fn apply_level_bump(
         return Ok(drop_missing_input(old));
     }
     let new_filename = seg_filename(output_level, old.min_seq);
-    let new_path = dir.join(&new_filename);
+    let new_path = segment_path(
+        dir,
+        &new_filename,
+        output_level,
+        old.partition.as_ref(),
+        partition_policy,
+    );
     let (min_key, max_key) = input_key_bounds(&old.path);
     let bumped = LocalSegment {
         path: new_path.to_string_lossy().into_owned(),
@@ -282,7 +295,13 @@ fn apply_merge(
                         error = %e,
                         "unreadable merge input at run head; promoting or dropping it"
                     );
-                    return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
+                    return apply_level_bump(
+                        inp,
+                        job.output_level,
+                        dir,
+                        execution.partition_policy,
+                        input_key_bounds,
+                    );
                 }
                 tracing::warn!(
                     path = %inp.path,
@@ -320,7 +339,13 @@ fn apply_merge(
     // so it costs no merge memory and its level still advances.
     if consumed.len() == 1 && !needs_repartition {
         drop(projected);
-        return apply_level_bump(consumed[0], job.output_level, dir, input_key_bounds);
+        return apply_level_bump(
+            consumed[0],
+            job.output_level,
+            dir,
+            execution.partition_policy,
+            input_key_bounds,
+        );
     }
 
     let merged = kway_merge(&projected, &sort_cols)
@@ -347,8 +372,23 @@ fn apply_merge(
             StatsError::Internal("compaction produced an empty physical partition".to_string())
         })?;
         let merged_filename = seg_filename(job.output_level, min_seq);
-        let merged_path = dir.join(&merged_filename);
-        let staging_path = dir.join(format!("{merged_filename}.tmp"));
+        let merged_path = segment_path(
+            dir,
+            &merged_filename,
+            job.output_level,
+            partition.as_ref(),
+            execution.partition_policy,
+        );
+        let output_dir = merged_path
+            .parent()
+            .expect("physical segment path has a parent");
+        std::fs::create_dir_all(output_dir).map_err(|error| {
+            StatsError::Internal(format!(
+                "create physical segment directory {}: {error}",
+                output_dir.display()
+            ))
+        })?;
+        let staging_path = output_dir.join(format!("{merged_filename}.tmp"));
         write_merged_segment(
             &staging_path,
             arrow_schema,

--- a/lib/finelog/rust/src/store/compaction/planner.rs
+++ b/lib/finelog/rust/src/store/compaction/planner.rs
@@ -101,7 +101,7 @@ fn take_until_target<'a>(run: &[&'a SegmentRow], target: i64) -> Vec<&'a Segment
     out
 }
 
-fn build_job(run: Vec<&SegmentRow>, output_level: i32) -> CompactionJob {
+pub(crate) fn build_job(run: Vec<&SegmentRow>, output_level: i32) -> CompactionJob {
     let output_min_seq = run.iter().map(|s| s.min_seq).min().expect("run non-empty");
     CompactionJob {
         inputs: run.into_iter().cloned().collect(),

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -42,7 +42,7 @@ use crate::store::compaction::executor::{
     read_segment_projected, run_job_with_partition_policy, CompactionExecution, CompactionLayout,
     PlannedSwap,
 };
-use crate::store::compaction::planner::plan;
+use crate::store::compaction::planner::{build_job, plan};
 use crate::store::exact::{ExactIndexConfig, NAMED_PROJECTION_MARKER};
 use crate::store::policy::StoragePolicy;
 use crate::store::ram_buffer::{stamp_seq_and_build, RamBuffers, SealedBuffer};
@@ -951,16 +951,9 @@ impl Namespace {
                 && compressed_bytes.saturating_add(segment.size_bytes)
                     > PHYSICAL_LAYOUT_MIGRATION_WORKER_COMPRESSED_BYTES
             {
-                let output_min_seq = inputs
-                    .iter()
-                    .map(|input: &SegmentRow| input.min_seq)
-                    .min()
-                    .expect("migration job has inputs");
-                jobs.push(CompactionJob {
-                    inputs: std::mem::take(&mut inputs),
-                    output_level: 1,
-                    output_min_seq,
-                });
+                let input_refs = inputs.iter().collect();
+                jobs.push(build_job(input_refs, 1));
+                inputs.clear();
                 compressed_bytes = 0;
                 if jobs.len() >= limit {
                     break;
@@ -975,16 +968,7 @@ impl Namespace {
             inputs.push(row);
         }
         if jobs.len() < limit && !inputs.is_empty() {
-            let output_min_seq = inputs
-                .iter()
-                .map(|input| input.min_seq)
-                .min()
-                .expect("migration job has inputs");
-            jobs.push(CompactionJob {
-                inputs,
-                output_level: 1,
-                output_min_seq,
-            });
+            jobs.push(build_job(inputs.iter().collect(), 1));
         }
         jobs
     }
@@ -1871,6 +1855,7 @@ impl Namespace {
         true
     }
 
+    /// Advance local layout work and report whether another fast retry is due.
     fn advance_physical_layout_migration(&self) -> Result<bool, StatsError> {
         let migration_slot = match self.physical_layout_migration_slot.try_lock() {
             Ok(slot) => slot,

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -3165,6 +3165,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn boot_reconcile_removes_missing_remote_catalog_pointer() {
+        let dir = tempdir();
+        let remote_dir = dir.join("remote");
+        let ns_dir = dir.join("levanter.metrics");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns_remote(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            catalog,
+            remote_dir.to_str().unwrap(),
+            StoragePolicy::default(),
+        );
+        ns.append_aligned_batch(&metrics_aligned(&["run-a"]));
+        ns.flush_once().unwrap();
+        ns.run_maintenance(true).await.unwrap();
+
+        let segment = ns
+            .catalog
+            .list_segments("levanter.metrics")
+            .unwrap()
+            .remove(0);
+        let evict_ns = Arc::clone(&ns);
+        let evict_path = segment.path.clone();
+        tokio::task::spawn_blocking(move || evict_ns.evict_segment(&evict_path))
+            .await
+            .unwrap();
+        let remote_key = segment_relative_key(&ns_dir, &segment.path).unwrap();
+        std::fs::remove_file(remote_dir.join("levanter.metrics").join(remote_key)).unwrap();
+
+        ns.boot_reconcile().await.unwrap();
+
+        assert!(ns
+            .catalog
+            .list_segments("levanter.metrics")
+            .unwrap()
+            .is_empty());
+        ns.shutdown(Duration::from_secs(10)).await;
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
     async fn implicit_timestamp_key_captures_segment_bounds() {
         let dir = tempdir();
         let mut schema = worker_schema();

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -2554,7 +2554,7 @@ fn spawn_flush_task(ns: Arc<Namespace>) -> tokio::task::JoinHandle<()> {
     })
 }
 
-/// Spawn the per-namespace maintenance task.
+/// Run remote reconciliation before periodic maintenance when requested.
 ///
 /// When `reconcile_first` is set, the task FIRST runs the boot remote reconcile
 /// (adopt unknown remote parquet, redundancy-drop covered segments), then enters
@@ -2568,11 +2568,10 @@ fn spawn_flush_task(ns: Arc<Namespace>) -> tokio::task::JoinHandle<()> {
 /// Every `check_interval` the loop runs one `run_maintenance` cycle (compaction
 /// drain, then sync, then evict). A physical-layout backlog shortens only the
 /// next delay to 100 ms, so the streaming rebuild continues without a 30 s gap
-/// while each cycle still flushes and syncs live writes. The cycle's heavy work
-/// is dispatched onto `spawn_blocking` inside `run_maintenance`, so the reactor
-/// is never stalled. On the stop notify the task exits immediately WITHOUT a
-/// final maintenance cycle; the final drain-to-disk and reconcile on shutdown
-/// are handled by [`Namespace::shutdown`].
+/// while each cycle still flushes and syncs live writes. On the stop notify the
+/// task exits immediately WITHOUT a final maintenance cycle; the final
+/// drain-to-disk and reconcile on shutdown are handled by
+/// [`Namespace::shutdown`].
 fn spawn_maintenance_task(
     ns: Arc<Namespace>,
     reconcile_first: bool,

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -32,8 +32,8 @@ use arrow::datatypes::SchemaRef;
 use tokio::sync::{watch, Notify, RwLock};
 
 use crate::errors::StatsError;
-use crate::partition_policy::SegmentPartition;
-use crate::policies::physical_partition_policy_for;
+use crate::partition_policy::{segment_path, SegmentPartition};
+use crate::policies::{physical_partition_policy_for, segment_indexes_enabled_for};
 use crate::proto::finelog::stats::ColumnType;
 use crate::query::index_cache::IndexCache;
 use crate::store::catalog::Catalog;
@@ -62,7 +62,9 @@ use crate::store::segment_index::{
     needs_rebuild as segment_index_needs_rebuild, remove_if_exists, write_segment_index,
     SegmentIndexConfig, SegmentIndexWrite,
 };
-use crate::store::types::{basename, LocalSegment, NamespaceStats, SegmentLocation, SegmentRow};
+use crate::store::types::{
+    basename, segment_relative_key, LocalSegment, NamespaceStats, SegmentLocation, SegmentRow,
+};
 
 /// Best-effort removal of a segment's derived index files, co-located with every
 /// parquet unlink. Missing artifacts are not errors.
@@ -157,6 +159,26 @@ pub const BACKFILL_INDEX_BUNDLES_PER_TICK: usize = 4;
 /// The work is a storage and footer-size win rather than a correctness fix, so it
 /// stays a minority of the 30 s tick.
 const REWRITE_LAYOUT_BUDGET: Duration = Duration::from_secs(3);
+
+/// Per-maintenance budget for converging legacy physical placement.
+///
+/// Each rewrite already in flight may overrun this budget. The bound controls
+/// how many additional jobs start before ordinary compaction and remote sync get
+/// their turn.
+const PHYSICAL_LAYOUT_MIGRATION_BUDGET: Duration = Duration::from_secs(3);
+const PHYSICAL_LAYOUT_MIGRATION_CONCURRENCY: usize = 2;
+const PHYSICAL_LAYOUT_MIGRATION_WORKER_COMPRESSED_BYTES: i64 = 32 * 1024 * 1024;
+const PHYSICAL_LAYOUT_MIGRATION_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Process-wide permit for physical-layout migration waves.
+///
+/// Maintenance is per namespace. Without a global permit, every namespace with
+/// a legacy backlog starts several workers at once; the production hub then ran
+/// Levanter, RPC, node-agent, and vLLM waves concurrently and exhausted its
+/// 30 GiB cgroup. One permit retains two-way streaming inside the active
+/// namespace while bounding the whole process to one wave and leaving half of
+/// the four-core hub available for queries.
+static PHYSICAL_LAYOUT_MIGRATION_SLOT: Mutex<()> = Mutex::new(());
 
 /// Process-wide permit for the layout rewrite, so only one namespace re-encodes
 /// at a time.
@@ -861,6 +883,331 @@ impl Namespace {
         Ok(true)
     }
 
+    /// Select independent legacy L0 rebuild jobs up to one parallel wave.
+    ///
+    /// Each worker coalesces about 32 MiB of compressed inputs. Two workers
+    /// partition in parallel while leaving half of the production hub's CPUs
+    /// available for queries, and each publishes its input span atomically.
+    /// Coalescing matters because a migration source file contains many runs:
+    /// one output set per source would replace a 12K-file backlog with hundreds
+    /// of thousands of tiny L1s.
+    fn physical_layout_migration_l0_jobs(&self, limit: usize) -> Vec<CompactionJob> {
+        if physical_partition_policy_for(&self.name).is_none() {
+            return Vec::new();
+        }
+        let inner = self.inner.lock().unwrap();
+        let mut jobs = Vec::new();
+        let mut inputs = Vec::new();
+        let mut compressed_bytes: i64 = 0;
+        for segment in inner.local_segments.iter().filter(|segment| {
+            segment.level == 0 && (segment.min_seq < 0 || segment.partition.is_some())
+        }) {
+            if !inputs.is_empty()
+                && compressed_bytes.saturating_add(segment.size_bytes)
+                    > PHYSICAL_LAYOUT_MIGRATION_WORKER_COMPRESSED_BYTES
+            {
+                let output_min_seq = inputs
+                    .iter()
+                    .map(|input: &SegmentRow| input.min_seq)
+                    .min()
+                    .expect("migration job has inputs");
+                jobs.push(CompactionJob {
+                    inputs: std::mem::take(&mut inputs),
+                    output_level: 1,
+                    output_min_seq,
+                });
+                compressed_bytes = 0;
+                if jobs.len() >= limit {
+                    break;
+                }
+            }
+            let mut row = segment_to_row(&self.name, segment);
+            // An unpartitioned job forces the executor through its sort and
+            // partition path. This also repairs the legacy version that stamped
+            // an L0 footer before L0 was defined as policy-free.
+            row.partition = None;
+            compressed_bytes = compressed_bytes.saturating_add(segment.size_bytes);
+            inputs.push(row);
+        }
+        if jobs.len() < limit && !inputs.is_empty() {
+            let output_min_seq = inputs
+                .iter()
+                .map(|input| input.min_seq)
+                .min()
+                .expect("migration job has inputs");
+            jobs.push(CompactionJob {
+                inputs,
+                output_level: 1,
+                output_min_seq,
+            });
+        }
+        jobs
+    }
+
+    /// Rebuild one parallel wave of legacy L0s and atomically publish each input.
+    fn physical_layout_migration_l0_wave(&self) -> Result<usize, StatsError> {
+        let Some(dir) = self.data_dir.as_deref() else {
+            return Ok(0);
+        };
+        let jobs = self.physical_layout_migration_l0_jobs(PHYSICAL_LAYOUT_MIGRATION_CONCURRENCY);
+        if jobs.is_empty() {
+            return Ok(0);
+        }
+        let results = std::thread::scope(|scope| {
+            jobs.into_iter()
+                .map(|job| scope.spawn(move || self.run_one_job(dir, &job)))
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|handle| handle.join())
+                .collect::<Vec<_>>()
+        });
+        let mut completed = 0;
+        for result in results {
+            result.map_err(|_| {
+                StatsError::Internal("physical layout migration worker panicked".to_string())
+            })??;
+            completed += 1;
+        }
+        Ok(completed)
+    }
+
+    /// Converge one non-L0 legacy placement operation online.
+    ///
+    /// The order encodes the storage contract:
+    /// 1. migration L0 (negative synthetic seq or legacy partition stamp) is
+    ///    rewritten into sorted/partitioned L1;
+    /// 2. stale or absent L1+ partition metadata is rebuilt in place;
+    /// 3. correctly partitioned L1+ is relocated into its bounded directory.
+    fn physical_layout_migration_non_l0_step(&self) -> Result<bool, StatsError> {
+        let Some(dir) = self.data_dir.as_deref() else {
+            return Ok(false);
+        };
+        let Some(policy) = physical_partition_policy_for(&self.name) else {
+            return Ok(false);
+        };
+
+        let stale_partition = {
+            let inner = self.inner.lock().unwrap();
+            inner
+                .local_segments
+                .iter()
+                .find(|segment| {
+                    segment.level >= 1
+                        && segment
+                            .partition
+                            .as_ref()
+                            .is_none_or(|partition| !policy.is_current_partition(partition))
+                })
+                .map(|segment| {
+                    let mut row = segment_to_row(&self.name, segment);
+                    row.partition = None;
+                    row
+                })
+        };
+        if let Some(input) = stale_partition {
+            let output_level = input.level;
+            let output_min_seq = input.min_seq;
+            self.run_one_job(
+                dir,
+                &CompactionJob {
+                    inputs: vec![input],
+                    output_level,
+                    output_min_seq,
+                },
+            )?;
+            return Ok(true);
+        }
+
+        let relocation = {
+            let inner = self.inner.lock().unwrap();
+            inner.local_segments.iter().find_map(|segment| {
+                let partition = segment.partition.as_ref()?;
+                if segment.level < 1 || !policy.is_current_partition(partition) {
+                    return None;
+                }
+                let filename = Path::new(&segment.path).file_name()?.to_str()?;
+                let destination =
+                    segment_path(dir, filename, segment.level, Some(partition), Some(policy));
+                (Path::new(&segment.path) != destination).then(|| (segment.clone(), destination))
+            })
+        };
+        let Some((segment, destination)) = relocation else {
+            return Ok(false);
+        };
+        let mut moved = segment.clone();
+        moved.path = destination.to_string_lossy().into_owned();
+        // The durable copy, if any, still has the old flat object key. Mark the
+        // moved row LOCAL so sync uploads the new key before orphan cleanup can
+        // delete the old one.
+        moved.location = SegmentLocation::Local;
+        self.commit_swap(PlannedSwap {
+            removed: vec![segment.path.clone()],
+            added: vec![moved],
+            unlink_removed: false,
+            bump_rename: Some((PathBuf::from(segment.path), destination)),
+            input_arrow_bytes: 0,
+        })?;
+        Ok(true)
+    }
+
+    /// Converge one legacy operation. Tests use this serial form; production
+    /// runs L0 inputs through [`Self::physical_layout_migration_l0_wave`].
+    #[cfg(test)]
+    fn physical_layout_migration_step(&self) -> Result<bool, StatsError> {
+        if let Some(job) = self.physical_layout_migration_l0_jobs(1).pop() {
+            let dir = self
+                .data_dir
+                .as_deref()
+                .expect("migration L0 job requires a data directory");
+            self.run_one_job(dir, &job)?;
+            return Ok(true);
+        }
+        self.physical_layout_migration_non_l0_step()
+    }
+
+    fn physical_layout_migration_pending(&self) -> (usize, usize, usize) {
+        let Some(dir) = self.data_dir.as_deref() else {
+            return (0, 0, 0);
+        };
+        let Some(policy) = physical_partition_policy_for(&self.name) else {
+            return (0, 0, 0);
+        };
+        let inner = self.inner.lock().unwrap();
+        let mut migration_l0 = 0;
+        let mut stale_partition = 0;
+        let mut misplaced = 0;
+        for segment in &inner.local_segments {
+            if segment.level == 0 {
+                migration_l0 += usize::from(segment.min_seq < 0 || segment.partition.is_some());
+                continue;
+            }
+            let Some(partition) = segment.partition.as_ref() else {
+                stale_partition += 1;
+                continue;
+            };
+            if !policy.is_current_partition(partition) {
+                stale_partition += 1;
+                continue;
+            }
+            let Some(filename) = Path::new(&segment.path)
+                .file_name()
+                .and_then(|filename| filename.to_str())
+            else {
+                misplaced += 1;
+                continue;
+            };
+            let destination =
+                segment_path(dir, filename, segment.level, Some(partition), Some(policy));
+            misplaced += usize::from(Path::new(&segment.path) != destination);
+        }
+        (migration_l0, stale_partition, misplaced)
+    }
+
+    fn physical_layout_migration_is_pending(&self) -> bool {
+        let pending = self.physical_layout_migration_pending();
+        pending.0 > 0 || pending.1 > 0 || pending.2 > 0
+    }
+
+    /// Relocate one evicted segment to its current object key without routing
+    /// the bytes through this process.
+    ///
+    /// The copy is published before the catalog pointer changes. The old key is
+    /// deleted only after that atomic swap, so queries always have a durable
+    /// source. Boot reconciliation resolves a crash in either gap by retaining
+    /// the key named by the catalog and deleting the other copy.
+    async fn remote_layout_migration_step(&self) -> Result<bool, StatsError> {
+        let (Some(dir), Some(remote), Some(policy)) = (
+            self.data_dir.as_deref(),
+            self.remote.as_ref(),
+            physical_partition_policy_for(&self.name),
+        ) else {
+            return Ok(false);
+        };
+
+        let candidate = self
+            .catalog
+            .list_segments_min_level(&self.name, 1)?
+            .into_iter()
+            .filter(|row| row.location == SegmentLocation::Remote)
+            .find_map(|row| {
+                let partition = row.partition.as_ref()?;
+                if !policy.is_current_partition(partition) {
+                    return None;
+                }
+                let filename = Path::new(&row.path).file_name()?.to_str()?;
+                let destination =
+                    segment_path(dir, filename, row.level, Some(partition), Some(policy));
+                (Path::new(&row.path) != destination).then_some((row, destination))
+            });
+        let Some((row, destination)) = candidate else {
+            return Ok(false);
+        };
+        let source_key = segment_relative_key(dir, &row.path).ok_or_else(|| {
+            StatsError::Internal(format!(
+                "remote layout source is outside namespace directory: {}",
+                row.path
+            ))
+        })?;
+        let destination_path = destination.to_string_lossy().into_owned();
+        let destination_key = segment_relative_key(dir, &destination_path).ok_or_else(|| {
+            StatsError::Internal(format!(
+                "remote layout destination is outside namespace directory: {destination_path}"
+            ))
+        })?;
+
+        if !remote.copy(&self.name, &source_key, &destination_key).await {
+            return Ok(false);
+        }
+
+        let mut moved = row.clone();
+        moved.path = destination_path;
+        {
+            let _write_guard = self.query_visibility.write().await;
+            self.catalog
+                .replace_segments(&self.name, std::slice::from_ref(&row.path), &[moved])?;
+        }
+        remote.delete(&self.name, &source_key).await;
+        tracing::info!(
+            namespace = %self.name,
+            from = %source_key,
+            to = %destination_key,
+            rows = row.row_count,
+            "remote physical layout segment relocated"
+        );
+        Ok(true)
+    }
+
+    fn remote_layout_migration_pending(&self) -> Result<usize, StatsError> {
+        let (Some(dir), Some(policy)) = (
+            self.data_dir.as_deref(),
+            physical_partition_policy_for(&self.name),
+        ) else {
+            return Ok(0);
+        };
+        Ok(self
+            .catalog
+            .list_segments_min_level(&self.name, 1)?
+            .into_iter()
+            .filter(|row| row.location == SegmentLocation::Remote)
+            .filter(|row| {
+                let Some(partition) = row.partition.as_ref() else {
+                    return false;
+                };
+                if !policy.is_current_partition(partition) {
+                    return false;
+                }
+                let Some(filename) = Path::new(&row.path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                else {
+                    return false;
+                };
+                Path::new(&row.path)
+                    != segment_path(dir, filename, row.level, Some(partition), Some(policy))
+            })
+            .count())
+    }
+
     /// Synthesize and apply a single L0->L1 merge of every L0 segment that fits
     /// `max_merge_arrow_bytes` (all of them, at test data sizes).
     ///
@@ -946,7 +1293,6 @@ impl Namespace {
             );
             return Ok(());
         }
-        let output_paths: Vec<String> = swap.added.iter().map(|added| added.path.clone()).collect();
         let output_bytes: i64 = swap.added.iter().map(|added| added.size_bytes).sum();
         let output_rows: i64 = swap.added.iter().map(|added| added.row_count).sum();
         let output_segments = swap.added.len();
@@ -964,7 +1310,6 @@ impl Namespace {
             namespace = %self.name,
             kind,
             output_level = job.output_level,
-            ?output_paths,
             output_segments,
             output_bytes,
             output_rows,
@@ -1014,6 +1359,9 @@ impl Namespace {
     }
 
     fn segment_index_config(&self) -> SegmentIndexConfig {
+        if !segment_indexes_enabled_for(&self.name) {
+            return SegmentIndexConfig::from_policies(Vec::<String>::new(), &[], &[], None);
+        }
         SegmentIndexConfig::from_policies(
             self.indexed_columns(),
             &self.exact_indexes(),
@@ -1058,6 +1406,18 @@ impl Namespace {
         //    propagated BEFORE any deque/catalog mutation, so the swap aborts
         //    with nothing changed.
         if let Some((from, to)) = &swap.bump_rename {
+            let destination_dir = to.parent().ok_or_else(|| {
+                StatsError::Internal(format!(
+                    "segment destination has no parent: {}",
+                    to.display()
+                ))
+            })?;
+            std::fs::create_dir_all(destination_dir).map_err(|e| {
+                StatsError::Internal(format!(
+                    "create segment destination directory {}: {e}",
+                    destination_dir.display()
+                ))
+            })?;
             std::fs::rename(from, to).map_err(|e| {
                 StatsError::Internal(format!(
                     "level-bump rename {} -> {} failed: {e}",
@@ -1080,16 +1440,14 @@ impl Namespace {
                     remove_orphaned_index_artifact(&self.name, &bundle_from, "index bundle");
                 }
             }
-            if let (Some(directory), Some(from_name), Some(to_name)) =
-                (from.parent(), from.file_name(), to.file_name())
-            {
+            if let (Some(from_name), Some(to_name)) = (from.file_name(), to.file_name()) {
                 let prefix = format!("{}{NAMED_PROJECTION_MARKER}", from_name.to_string_lossy());
                 match covering_projection_paths(from) {
                     Ok(projections) => {
                         for source in projections {
                             let name = source.file_name().and_then(|name| name.to_str()).unwrap();
                             let suffix = name.strip_prefix(&prefix).unwrap();
-                            let destination = directory.join(format!(
+                            let destination = destination_dir.join(format!(
                                 "{}{NAMED_PROJECTION_MARKER}{suffix}",
                                 to_name.to_string_lossy()
                             ));
@@ -1167,7 +1525,7 @@ impl Namespace {
     /// fails, `all_durable` is `false`.
     ///
     /// Phase 2 (orphan delete): runs ONLY if `all_durable`. Delete remote files
-    /// whose basename has no catalog row — those are compaction inputs whose row
+    /// whose relative key has no catalog row — those are compaction inputs whose row
     /// was dropped at commit. The ordering is the data-safety invariant: by the
     /// time phase 2 runs, the merged output subsuming those inputs is durable in
     /// the bucket (uploaded in phase 1), so the durable copy is in place before
@@ -1180,8 +1538,8 @@ impl Namespace {
         let Some(remote) = &self.remote else {
             return Ok(());
         };
-        let remote_basenames: std::collections::HashSet<String> =
-            match remote.list_basenames(&self.name).await {
+        let remote_keys: std::collections::HashSet<String> =
+            match remote.list_keys(&self.name).await {
                 Ok(names) => names.into_iter().collect(),
                 Err(e) => {
                     tracing::warn!(namespace = %self.name, error = %e, "remote sync list failed");
@@ -1190,19 +1548,27 @@ impl Namespace {
             };
 
         let rows = self.catalog.list_segments_min_level(&self.name, 1)?;
+        let namespace_dir = self
+            .data_dir
+            .as_deref()
+            .expect("disk-backed namespace with remote store has a data directory");
         let mut all_durable = true;
         for row in &rows {
             if row.location != SegmentLocation::Local {
                 continue;
             }
-            let base = basename(&row.path);
-            if remote_basenames.contains(&base) {
+            let Some(key) = segment_relative_key(namespace_dir, &row.path) else {
+                tracing::warn!(namespace = %self.name, path = %row.path, "catalog segment is outside its namespace directory");
+                all_durable = false;
+                continue;
+            };
+            if remote_keys.contains(&key) {
                 // Uploaded but the catalog never flipped — adopt, no re-upload.
                 self.mark_uploaded(&row.path)?;
                 continue;
             }
             if remote
-                .upload(&self.name, std::path::Path::new(&row.path))
+                .upload(&self.name, &key, std::path::Path::new(&row.path))
                 .await
             {
                 self.mark_uploaded(&row.path)?;
@@ -1215,19 +1581,19 @@ impl Namespace {
             return Ok(());
         }
 
-        // Re-snapshot the L>=1 catalog rows (phase 1 may have added basenames) and
+        // Re-snapshot the L>=1 catalog rows (phase 1 may have added keys) and
         // delete only genuine orphans. min_level=1 is equivalent to scanning all
         // levels here because remote files are exclusively L>=1 (L0 is never
-        // uploaded), so an L0 basename can never appear in `remote_basenames`.
-        let catalog_basenames: std::collections::HashSet<String> = self
+        // uploaded), so an L0 key can never appear in the remote set.
+        let catalog_keys: std::collections::HashSet<String> = self
             .catalog
             .list_segments_min_level(&self.name, 1)?
             .iter()
-            .map(|r| basename(&r.path))
+            .filter_map(|row| segment_relative_key(namespace_dir, &row.path))
             .collect();
-        for base in remote_basenames.difference(&catalog_basenames) {
-            remote.delete(&self.name, base).await;
-            tracing::info!(namespace = %self.name, segment = %base, "deleted orphan remote segment");
+        for key in remote_keys.difference(&catalog_keys) {
+            remote.delete(&self.name, key).await;
+            tracing::info!(namespace = %self.name, segment = %key, "deleted orphan remote segment");
         }
         Ok(())
     }
@@ -1479,6 +1845,40 @@ impl Namespace {
         let ns = Arc::clone(self);
         tokio::task::spawn_blocking(move || -> Result<(), StatsError> {
             ns.flush_once()?;
+            let migration_slot = PHYSICAL_LAYOUT_MIGRATION_SLOT.try_lock().ok();
+            let migration_started = Instant::now();
+            let mut migrated = 0;
+            if migration_slot.is_some() {
+                while !ns.stopped.load(Ordering::SeqCst)
+                    && migration_started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
+                {
+                    let rebuilt = ns.physical_layout_migration_l0_wave()?;
+                    if rebuilt > 0 {
+                        migrated += rebuilt;
+                        continue;
+                    }
+                    if ns.physical_layout_migration_non_l0_step()? {
+                        migrated += 1;
+                        continue;
+                    }
+                    break;
+                }
+            }
+            let migration_pending = ns.physical_layout_migration_is_pending();
+            if migrated > 0 {
+                let (migration_l0, stale_partition, misplaced) =
+                    ns.physical_layout_migration_pending();
+                tracing::info!(
+                    namespace = %ns.name,
+                    jobs = migrated,
+                    remaining_migration_l0 = migration_l0,
+                    remaining_stale_partition = stale_partition,
+                    remaining_misplaced = misplaced,
+                    elapsed_ms = migration_started.elapsed().as_millis() as u64,
+                    "physical layout migration advanced"
+                );
+            }
+            drop(migration_slot);
             // An optional forced L0->L1 merge, then the planner-drain loop runs so
             // a forced compaction that leaves >= 32 L1 segments still promotes
             // L1->L2 in the same maintenance call. The drain checks the stop latch
@@ -1496,6 +1896,13 @@ impl Namespace {
                 if !ns.compaction_step()? {
                     break;
                 }
+                // While the rebuild is active, one ordinary job is enough to
+                // keep live L0 bounded. Spend the remaining CPU on releasing
+                // legacy inputs; partition-local L1 consolidation can catch up
+                // after the source backlog is gone.
+                if migration_pending {
+                    break;
+                }
             }
             Ok(())
         })
@@ -1504,6 +1911,27 @@ impl Namespace {
 
         // Sync (async object_store).
         self.sync_step().await?;
+
+        // Relocate evicted objects after local outputs are durable. Each copy is
+        // server-side and crash-safe; the time budget prevents a cold archive
+        // backlog from monopolizing the maintenance cycle.
+        let remote_migration_started = Instant::now();
+        let mut remote_migrated = 0;
+        while !self.stopped.load(Ordering::SeqCst)
+            && remote_migration_started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
+            && self.remote_layout_migration_step().await?
+        {
+            remote_migrated += 1;
+        }
+        if remote_migrated > 0 {
+            tracing::info!(
+                namespace = %self.name,
+                segments = remote_migrated,
+                remaining = self.remote_layout_migration_pending()?,
+                elapsed_ms = remote_migration_started.elapsed().as_millis() as u64,
+                "remote physical layout migration advanced"
+            );
+        }
 
         // Evict (blocking; evict_segment takes blocking_write per segment).
         let ns = Arc::clone(self);
@@ -1834,19 +2262,31 @@ fn segment_to_row(namespace: &str, seg: &LocalSegment) -> SegmentRow {
 /// the final path, and `discover_segments` ignores the extension, so a survivor
 /// is disk the namespace's own byte accounting cannot see.
 fn discard_staging_files(dir: &std::path::Path, namespace: &str) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("tmp") {
+    let mut pending = vec![dir.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(directory) else {
             continue;
-        }
-        match std::fs::remove_file(&path) {
-            Ok(()) => tracing::info!(namespace = %namespace, file = %path.display(),
-                "discarded an abandoned staging file"),
-            Err(e) => tracing::warn!(namespace = %namespace, file = %path.display(), error = %e,
-                "could not discard an abandoned staging file"),
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if file_type.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.extension().and_then(|extension| extension.to_str()) != Some("tmp") {
+                continue;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => tracing::info!(namespace = %namespace, file = %path.display(),
+                    "discarded an abandoned staging file"),
+                Err(e) => {
+                    tracing::warn!(namespace = %namespace, file = %path.display(), error = %e,
+                    "could not discard an abandoned staging file")
+                }
+            }
         }
     }
 }
@@ -2086,11 +2526,13 @@ fn spawn_flush_task(ns: Arc<Namespace>) -> tokio::task::JoinHandle<()> {
 /// in-flight reconcile future is cancelled when the task is aborted on shutdown).
 ///
 /// Every `check_interval` the loop runs one `run_maintenance` cycle (compaction
-/// drain, then sync, then evict). The cycle's heavy work is dispatched onto
-/// `spawn_blocking` inside `run_maintenance`, so the reactor is never stalled. On
-/// the stop notify the task exits immediately WITHOUT a final maintenance cycle;
-/// the final drain-to-disk and reconcile on shutdown are handled by
-/// [`Namespace::shutdown`].
+/// drain, then sync, then evict). A physical-layout backlog shortens only the
+/// next delay to 100 ms, so the streaming rebuild continues without a 30 s gap
+/// while each cycle still flushes and syncs live writes. The cycle's heavy work
+/// is dispatched onto `spawn_blocking` inside `run_maintenance`, so the reactor
+/// is never stalled. On the stop notify the task exits immediately WITHOUT a
+/// final maintenance cycle; the final drain-to-disk and reconcile on shutdown
+/// are handled by [`Namespace::shutdown`].
 fn spawn_maintenance_task(
     ns: Arc<Namespace>,
     reconcile_first: bool,
@@ -2102,6 +2544,7 @@ fn spawn_maintenance_task(
             }
         }
         let interval = ns.compaction_config.check_interval;
+        let mut migration_pending = ns.physical_layout_migration_is_pending();
         loop {
             // Stop latch: a stop signalled while a maintenance cycle was running
             // (and thus missed the Notify wake) still exits here.
@@ -2109,8 +2552,13 @@ fn spawn_maintenance_task(
                 return;
             }
             let stopped = ns.stop.notified();
+            let delay = if migration_pending {
+                PHYSICAL_LAYOUT_MIGRATION_RETRY_INTERVAL
+            } else {
+                interval
+            };
             tokio::select! {
-                _ = tokio::time::sleep(interval) => {}
+                _ = tokio::time::sleep(delay) => {}
                 _ = stopped => {
                     return;
                 }
@@ -2118,8 +2566,16 @@ fn spawn_maintenance_task(
             if ns.stopped.load(Ordering::SeqCst) {
                 return;
             }
-            if let Err(e) = ns.run_maintenance(false).await {
-                tracing::warn!(namespace = %ns.name, error = %e, "maintenance task: run_maintenance failed");
+            match ns.run_maintenance(false).await {
+                Ok(()) => {
+                    migration_pending = ns.physical_layout_migration_is_pending();
+                }
+                Err(e) => {
+                    // Fall back to the ordinary interval after an error. A bad
+                    // input must not turn the recovery worker into a hot loop.
+                    migration_pending = false;
+                    tracing::warn!(namespace = %ns.name, error = %e, "maintenance task: run_maintenance failed");
+                }
             }
         }
     })
@@ -2129,12 +2585,14 @@ fn spawn_maintenance_task(
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{Int64Array, StringArray};
+    use arrow::array::{Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field};
 
     use super::*;
+    use crate::levanter_metrics_policy::levanter_metrics_schema;
     use crate::proto::finelog::stats::ColumnType;
-    use crate::store::schema::{with_implicit_seq, Column, Schema};
+    use crate::store::schema::{stored_form, with_implicit_seq, Column, Schema};
+    use crate::store::types::seg_filename;
 
     fn worker_schema() -> Schema {
         with_implicit_seq(Schema::new(
@@ -2160,6 +2618,32 @@ mod tests {
             ],
             num_rows: n as usize,
             byte_size: 16 * n,
+        }
+    }
+
+    fn metrics_aligned(run_ids: &[&str]) -> AlignedBatch {
+        let schema = schema_to_arrow(&levanter_metrics_schema());
+        let rows = run_ids.len();
+        let column_names = ["timestamp_ms", "run_id", "step", "name", "kind", "value"];
+        AlignedBatch {
+            arrays: vec![
+                Arc::new(Int64Array::from_iter_values(
+                    (0..rows).map(|row| 1_700_000_000_000 + row as i64),
+                )),
+                Arc::new(StringArray::from(run_ids.to_vec())),
+                Arc::new(Int64Array::from_iter_values(0..rows as i64)),
+                Arc::new(StringArray::from(vec!["training_loss"; rows])),
+                Arc::new(StringArray::from(vec!["scalar"; rows])),
+                Arc::new(Float64Array::from_iter_values(
+                    (0..rows).map(|row| row as f64 / 10.0),
+                )),
+            ],
+            fields: column_names
+                .iter()
+                .map(|name| schema.field_with_name(name).unwrap().clone())
+                .collect(),
+            num_rows: rows,
+            byte_size: 128 * rows as i64,
         }
     }
 
@@ -2272,6 +2756,311 @@ mod tests {
         assert_eq!(stats.min_seq, 1);
         assert_eq!(stats.max_seq, 3);
         assert_eq!(stats.segment_count, 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn levanter_l0_stays_flat_and_compaction_writes_bucketed_l1() {
+        let dir = tempdir();
+        let ns_dir = dir.join("levanter.metrics");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            catalog,
+        );
+        ns.append_aligned_batch(&metrics_aligned(&["run-a", "run-b"]));
+        ns.flush_once().unwrap();
+
+        let l0 = discover_segments(&ns_dir);
+        assert_eq!(l0.len(), 1);
+        assert_eq!(l0[0].parent(), Some(ns_dir.as_path()));
+        assert!(read_segment_footer(&l0[0], Some("timestamp_ms"))
+            .unwrap()
+            .partition
+            .is_none());
+
+        ns.run_maintenance(true).await.unwrap();
+        let l1 = discover_segments(&ns_dir);
+        assert_eq!(l1.len(), 2);
+        for path in &l1 {
+            assert_eq!(
+                path.parent().unwrap().parent(),
+                Some(ns_dir.join("run_id").as_path())
+            );
+            let bucket: u32 = path
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert!(bucket < 32);
+            assert!(read_segment_footer(path, Some("timestamp_ms"))
+                .unwrap()
+                .partition
+                .is_some());
+        }
+        assert_eq!(ns.stats().row_count, 2);
+        ns.shutdown(Duration::from_secs(10)).await;
+        let reopened = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            Arc::new(Catalog::open(Some(&dir)).unwrap()),
+        );
+        assert_eq!(reopened.stats().row_count, 2);
+        assert_eq!(reopened.query_snapshot().paths.len(), 2);
+        reopened.shutdown(Duration::from_secs(10)).await;
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn levanter_runtime_layout_migration_repairs_legacy_l0_and_flat_l1() {
+        let dir = tempdir();
+        let ns_dir = dir.join("levanter.metrics");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            catalog,
+        );
+        ns.append_aligned_batch(&metrics_aligned(&["run-a", "run-b"]));
+        ns.flush_once().unwrap();
+        ns.run_maintenance(true).await.unwrap();
+
+        let first = ns.inner.lock().unwrap().local_segments[0].clone();
+        let legacy_l0_path = ns_dir.join(seg_filename(0, first.min_seq));
+        let mut legacy_l0 = first.clone();
+        legacy_l0.path = legacy_l0_path.to_string_lossy().into_owned();
+        legacy_l0.level = 0;
+        legacy_l0.location = SegmentLocation::Local;
+        let swap = PlannedSwap {
+            removed: vec![first.path.clone()],
+            added: vec![legacy_l0],
+            unlink_removed: false,
+            bump_rename: Some((PathBuf::from(first.path), legacy_l0_path)),
+            input_arrow_bytes: 0,
+        };
+        let commit_ns = Arc::clone(&ns);
+        tokio::task::spawn_blocking(move || commit_ns.commit_swap(swap))
+            .await
+            .unwrap()
+            .unwrap();
+        let migration_ns = Arc::clone(&ns);
+        assert!(
+            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
+                .await
+                .unwrap()
+                .unwrap()
+        );
+
+        let second = ns.inner.lock().unwrap().local_segments[1].clone();
+        let flat_l1_path = ns_dir.join(seg_filename(1, second.min_seq));
+        let mut flat_l1 = second.clone();
+        flat_l1.path = flat_l1_path.to_string_lossy().into_owned();
+        flat_l1.location = SegmentLocation::Local;
+        let swap = PlannedSwap {
+            removed: vec![second.path.clone()],
+            added: vec![flat_l1],
+            unlink_removed: false,
+            bump_rename: Some((PathBuf::from(second.path), flat_l1_path.clone())),
+            input_arrow_bytes: 0,
+        };
+        let commit_ns = Arc::clone(&ns);
+        tokio::task::spawn_blocking(move || commit_ns.commit_swap(swap))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(flat_l1_path.parent(), Some(ns_dir.as_path()));
+        let migration_ns = Arc::clone(&ns);
+        assert!(
+            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
+                .await
+                .unwrap()
+                .unwrap()
+        );
+        let migration_ns = Arc::clone(&ns);
+        assert!(
+            !tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
+                .await
+                .unwrap()
+                .unwrap()
+        );
+
+        let segments = ns.inner.lock().unwrap().local_segments.clone();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(
+            segments
+                .iter()
+                .map(|segment| segment.row_count)
+                .sum::<i64>(),
+            2
+        );
+        for segment in segments {
+            assert!(segment.level >= 1);
+            assert!(segment.partition.is_some());
+            assert_eq!(
+                Path::new(&segment.path).parent().unwrap().parent(),
+                Some(ns_dir.join("run_id").as_path())
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn levanter_streaming_rebuild_publishes_unindexed_outputs() {
+        let dir = tempdir();
+        let ns_dir = dir.join("levanter.metrics");
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        let schema = stored_form(levanter_metrics_schema());
+        let arrow_schema = schema_to_arrow(&schema);
+        for input in 0..6_i64 {
+            let first_seq = -1_000_000 + input * 10;
+            let batch = stamp_seq_and_build(
+                &metrics_aligned(&["run-a", "run-b"]),
+                first_seq,
+                &arrow_schema,
+            );
+            write_segment_to_dir(&ns_dir, 0, first_seq, &batch).unwrap();
+        }
+        let ns = open_ns(
+            "levanter.metrics",
+            schema,
+            Some(ns_dir.clone()),
+            Arc::new(Catalog::open(Some(&dir)).unwrap()),
+        );
+        assert_eq!(ns.physical_layout_migration_pending().0, 6);
+
+        let migration_ns = Arc::clone(&ns);
+        let rebuilt =
+            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_l0_wave())
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(rebuilt, 1);
+        assert_eq!(ns.physical_layout_migration_pending().0, 0);
+        assert_eq!(ns.stats().row_count, 12);
+
+        for path in discover_segments(&ns_dir) {
+            if read_segment_footer(&path, Some("timestamp_ms"))
+                .unwrap()
+                .level
+                >= 1
+            {
+                assert!(path.starts_with(ns_dir.join("run_id")));
+                assert!(!crate::store::index_bundle::bundle_path(&path).exists());
+            }
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn runtime_layout_migration_ignores_namespaces_without_a_partition_policy() {
+        let dir = tempdir();
+        let ns_dir = dir.join("telemetry_v1.vllm");
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        let schema = worker_schema();
+        let batch = stamp_seq_and_build(&aligned(2), -10, &schema_to_arrow(&schema));
+        write_segment_to_dir(&ns_dir, 0, -10, &batch).unwrap();
+        let ns = open_ns(
+            "telemetry_v1.vllm",
+            schema,
+            Some(ns_dir),
+            Arc::new(Catalog::open(Some(&dir)).unwrap()),
+        );
+
+        assert_eq!(ns.physical_layout_migration_pending(), (0, 0, 0));
+        let migration_ns = Arc::clone(&ns);
+        assert_eq!(
+            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_l0_wave())
+                .await
+                .unwrap()
+                .unwrap(),
+            0
+        );
+        assert_eq!(ns.stats().row_count, 2);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn levanter_runtime_layout_migration_relocates_remote_only_l1() {
+        let dir = tempdir();
+        let remote_dir = dir.join("remote");
+        let ns_dir = dir.join("levanter.metrics");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns_remote(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            catalog,
+            remote_dir.to_str().unwrap(),
+            StoragePolicy::default(),
+        );
+        ns.append_aligned_batch(&metrics_aligned(&["run-a"]));
+        ns.flush_once().unwrap();
+        ns.run_maintenance(true).await.unwrap();
+
+        let current = ns
+            .catalog
+            .list_segments("levanter.metrics")
+            .unwrap()
+            .remove(0);
+        assert_eq!(current.location, SegmentLocation::Both);
+        let current_key = segment_relative_key(&ns_dir, &current.path).unwrap();
+        let current_remote_path = remote_dir.join("levanter.metrics").join(&current_key);
+        assert!(current_remote_path.exists());
+
+        let evict_ns = Arc::clone(&ns);
+        let evict_path = current.path.clone();
+        tokio::task::spawn_blocking(move || evict_ns.evict_segment(&evict_path))
+            .await
+            .unwrap();
+        let mut legacy = ns
+            .catalog
+            .list_segments("levanter.metrics")
+            .unwrap()
+            .remove(0);
+        assert_eq!(legacy.location, SegmentLocation::Remote);
+
+        let filename = Path::new(&legacy.path).file_name().unwrap();
+        let legacy_remote_path = remote_dir.join("levanter.metrics").join(filename);
+        std::fs::rename(&current_remote_path, &legacy_remote_path).unwrap();
+        let old_path = legacy.path.clone();
+        legacy.path = ns_dir.join(filename).to_string_lossy().into_owned();
+        ns.catalog
+            .replace_segments("levanter.metrics", &[old_path], &[legacy.clone()])
+            .unwrap();
+
+        assert_eq!(ns.remote_layout_migration_pending().unwrap(), 1);
+        assert!(ns.remote_layout_migration_step().await.unwrap());
+        assert_eq!(ns.remote_layout_migration_pending().unwrap(), 0);
+        assert!(!ns.remote_layout_migration_step().await.unwrap());
+
+        let relocated = ns
+            .catalog
+            .list_segments("levanter.metrics")
+            .unwrap()
+            .remove(0);
+        assert_eq!(relocated.location, SegmentLocation::Remote);
+        assert_eq!(
+            Path::new(&relocated.path).parent().unwrap().parent(),
+            Some(ns_dir.join("run_id").as_path())
+        );
+        let relocated_key = segment_relative_key(&ns_dir, &relocated.path).unwrap();
+        assert!(remote_dir
+            .join("levanter.metrics")
+            .join(relocated_key)
+            .exists());
+        assert!(!legacy_remote_path.exists());
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -54,8 +54,8 @@ use crate::store::schema::{
 #[cfg(test)]
 use crate::store::segment::write_segment_to_dir;
 use crate::store::segment::{
-    discover_segments, read_segment_footer, segment_layout_is_current, stage_rewritten_segment,
-    write_segment_to_dir_with_max_row_group_rows, MAX_ROW_GROUP_ROWS,
+    discover_files, discover_segments, read_segment_footer, segment_layout_is_current,
+    stage_rewritten_segment, write_segment_to_dir_with_max_row_group_rows, MAX_ROW_GROUP_ROWS,
 };
 use crate::store::segment_index::{
     covering_projection_paths, covering_projection_staging_paths, legacy_artifact_paths,
@@ -108,6 +108,14 @@ fn remove_index_artifacts(parquet_path: &str) {
     }
 }
 
+fn fixed_index_artifacts_exist(parquet_path: &Path) -> bool {
+    crate::store::index_bundle::bundle_path(parquet_path).exists()
+        || crate::store::index_bundle::staging_path(parquet_path).exists()
+        || legacy_artifact_paths(parquet_path)
+            .into_iter()
+            .any(|path| path.exists())
+}
+
 fn remove_orphaned_index_artifact(namespace: &str, path: &Path, kind: &str) {
     if let Err(error) = remove_if_exists(path) {
         tracing::warn!(
@@ -138,14 +146,14 @@ pub const MIN_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 /// Default durability-await budget when the RPC carries no deadline.
 pub const DEFAULT_PERSIST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Segment index bundles rebuilt per maintenance tick by the background backfill.
+/// Segment index bundles rebuilt or removed per maintenance tick.
 ///
 /// A single index build over a terminal-level segment is heavy (substantial CPU
 /// and RAM), and the backfill is the lowest-priority maintenance work, so this
 /// stays small enough never to starve compaction/sync/eviction. It is four rather
 /// than one so a namespace whose bundles all need rebuilding converges in tens
 /// of minutes instead of hours while queries safely use partial coverage.
-pub const BACKFILL_INDEX_BUNDLES_PER_TICK: usize = 4;
+pub const INDEX_BUNDLES_PER_TICK: usize = 4;
 
 /// Wall-clock a maintenance tick spends re-encoding stale-layout segments.
 ///
@@ -1075,20 +1083,6 @@ impl Namespace {
         Ok(true)
     }
 
-    /// Advance one legacy layout operation.
-    #[cfg(test)]
-    fn physical_layout_migration_step(&self) -> Result<bool, StatsError> {
-        if let Some(job) = self.physical_layout_migration_l0_jobs(1).pop() {
-            let dir = self
-                .data_dir
-                .as_deref()
-                .expect("migration L0 job requires a data directory");
-            self.run_one_job(dir, &job)?;
-            return Ok(true);
-        }
-        self.physical_layout_migration_non_l0_step()
-    }
-
     fn physical_layout_migration_pending(&self) -> PhysicalLayoutMigrationPending {
         let Some(dir) = self.data_dir.as_deref() else {
             return PhysicalLayoutMigrationPending::default();
@@ -1130,29 +1124,14 @@ impl Namespace {
 
     /// Relocate one archived segment to its current physical path.
     async fn remote_layout_migration_step(&self) -> Result<bool, StatsError> {
-        let (Some(dir), Some(remote), Some(policy)) = (
-            self.data_dir.as_deref(),
-            self.remote.as_ref(),
-            physical_partition_policy_for(&self.name),
-        ) else {
+        let (Some(dir), Some(remote)) = (self.data_dir.as_deref(), self.remote.as_ref()) else {
             return Ok(false);
         };
 
         let candidate = self
-            .catalog
-            .list_segments_min_level(&self.name, 1)?
+            .remote_layout_migration_candidates()?
             .into_iter()
-            .filter(|row| row.location == SegmentLocation::Remote)
-            .find_map(|row| {
-                current_layout_destination(
-                    dir,
-                    &row.path,
-                    row.level,
-                    row.partition.as_ref(),
-                    policy,
-                )
-                .map(|destination| (row, destination))
-            });
+            .next();
         let Some((row, destination)) = candidate else {
             return Ok(false);
         };
@@ -1169,9 +1148,9 @@ impl Namespace {
             ))
         })?;
 
-        if !remote.copy(&self.name, &source_key, &destination_key).await {
-            return Ok(false);
-        }
+        remote
+            .copy(&self.name, &source_key, &destination_key)
+            .await?;
 
         let mut moved = row.clone();
         moved.path = destination_path;
@@ -1191,19 +1170,19 @@ impl Namespace {
         Ok(true)
     }
 
-    fn remote_layout_migration_remaining_count(&self) -> Result<usize, StatsError> {
+    fn remote_layout_migration_candidates(&self) -> Result<Vec<(SegmentRow, PathBuf)>, StatsError> {
         let (Some(dir), Some(policy)) = (
             self.data_dir.as_deref(),
             physical_partition_policy_for(&self.name),
         ) else {
-            return Ok(0);
+            return Ok(Vec::new());
         };
         Ok(self
             .catalog
             .list_segments_min_level(&self.name, 1)?
             .into_iter()
             .filter(|row| row.location == SegmentLocation::Remote)
-            .filter(|row| {
+            .filter_map(|row| {
                 current_layout_destination(
                     dir,
                     &row.path,
@@ -1211,9 +1190,13 @@ impl Namespace {
                     row.partition.as_ref(),
                     policy,
                 )
-                .is_some()
+                .map(|destination| (row, destination))
             })
-            .count())
+            .collect())
+    }
+
+    fn remote_layout_migration_remaining_count(&self) -> Result<usize, StatsError> {
+        Ok(self.remote_layout_migration_candidates()?.len())
     }
 
     /// Synthesize and apply a single L0->L1 merge of every L0 segment that fits
@@ -1814,6 +1797,66 @@ impl Namespace {
         built
     }
 
+    /// Remove derived index files from a namespace whose policy disables them.
+    fn cleanup_disabled_index_bundles(&self, max: usize) -> usize {
+        if self.data_dir.is_none() || max == 0 || segment_indexes_enabled_for(&self.name) {
+            return 0;
+        }
+        let Ok(_slot) = self.index_backfill_slot.try_lock() else {
+            return 0;
+        };
+        let segments: Vec<LocalSegment> = self
+            .inner
+            .lock()
+            .unwrap()
+            .local_segments
+            .iter()
+            .cloned()
+            .collect();
+        let candidates = {
+            let mut skips = self.index_backfill_skips.lock().unwrap();
+            let live: HashSet<&str> = segments
+                .iter()
+                .map(|segment| segment.path.as_str())
+                .collect();
+            skips.reconcile(&["disabled"], &live);
+            let mut candidates = Vec::new();
+            for segment in segments.iter().rev() {
+                if skips.paths.contains(&segment.path) {
+                    continue;
+                }
+                if fixed_index_artifacts_exist(Path::new(&segment.path)) {
+                    candidates.push(segment.path.clone());
+                    if candidates.len() >= max {
+                        break;
+                    }
+                } else {
+                    skips.paths.insert(segment.path.clone());
+                }
+            }
+            candidates
+        };
+        let mut cleaned = 0;
+        for path in candidates {
+            remove_index_artifacts(&path);
+            if fixed_index_artifacts_exist(Path::new(&path)) {
+                continue;
+            }
+            self.index_cache
+                .invalidate(&crate::store::index_bundle::bundle_path(Path::new(&path)));
+            self.index_backfill_skips.lock().unwrap().paths.insert(path);
+            cleaned += 1;
+        }
+        if cleaned > 0 {
+            tracing::info!(
+                namespace = %self.name,
+                segments = cleaned,
+                "removed disabled segment index artifacts"
+            );
+        }
+        cleaned
+    }
+
     fn layout_is_current(&self, path: &str) -> bool {
         if self.current_layouts.lock().unwrap().contains(path) {
             return true;
@@ -1826,6 +1869,69 @@ impl Namespace {
             .unwrap()
             .insert(path.to_string());
         true
+    }
+
+    fn advance_physical_layout_migration(&self) -> Result<bool, StatsError> {
+        let migration_slot = match self.physical_layout_migration_slot.try_lock() {
+            Ok(slot) => slot,
+            Err(TryLockError::WouldBlock) => return Ok(self.physical_layout_migration_is_pending()),
+            Err(TryLockError::Poisoned(_)) => {
+                return Err(StatsError::Internal(
+                    "physical layout migration permit is poisoned".to_string(),
+                ));
+            }
+        };
+        let started = Instant::now();
+        let mut migrated = 0;
+        while !self.stopped.load(Ordering::SeqCst)
+            && started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
+        {
+            let rebuilt = self.physical_layout_migration_l0_wave()?;
+            if rebuilt > 0 {
+                migrated += rebuilt;
+                continue;
+            }
+            if self.physical_layout_migration_non_l0_step()? {
+                migrated += 1;
+                continue;
+            }
+            break;
+        }
+        drop(migration_slot);
+        let pending = self.physical_layout_migration_pending();
+        if migrated > 0 {
+            tracing::info!(
+                namespace = %self.name,
+                jobs = migrated,
+                remaining_migration_l0 = pending.migration_l0,
+                remaining_stale_partition = pending.stale_partitions,
+                remaining_misplaced = pending.misplaced_local,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "physical layout migration advanced"
+            );
+        }
+        Ok(pending.any())
+    }
+
+    async fn advance_remote_layout_migration(&self) -> Result<(), StatsError> {
+        let started = Instant::now();
+        let mut migrated = 0;
+        while !self.stopped.load(Ordering::SeqCst)
+            && started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
+            && self.remote_layout_migration_step().await?
+        {
+            migrated += 1;
+        }
+        if migrated > 0 {
+            tracing::info!(
+                namespace = %self.name,
+                segments = migrated,
+                remaining = self.remote_layout_migration_remaining_count()?,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "remote physical layout migration advanced"
+            );
+        }
+        Ok(())
     }
 
     // ----- maintenance orchestration ------------------------------------
@@ -1853,47 +1959,7 @@ impl Namespace {
         let ns = Arc::clone(self);
         tokio::task::spawn_blocking(move || -> Result<(), StatsError> {
             ns.flush_once()?;
-            let migration_slot = match ns.physical_layout_migration_slot.try_lock() {
-                Ok(slot) => Some(slot),
-                Err(TryLockError::WouldBlock) => None,
-                Err(TryLockError::Poisoned(_)) => {
-                    return Err(StatsError::Internal(
-                        "physical layout migration permit is poisoned".to_string(),
-                    ));
-                }
-            };
-            let migration_started = Instant::now();
-            let mut migrated = 0;
-            if migration_slot.is_some() {
-                while !ns.stopped.load(Ordering::SeqCst)
-                    && migration_started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
-                {
-                    let rebuilt = ns.physical_layout_migration_l0_wave()?;
-                    if rebuilt > 0 {
-                        migrated += rebuilt;
-                        continue;
-                    }
-                    if ns.physical_layout_migration_non_l0_step()? {
-                        migrated += 1;
-                        continue;
-                    }
-                    break;
-                }
-            }
-            let migration_pending = ns.physical_layout_migration_is_pending();
-            if migrated > 0 {
-                let pending = ns.physical_layout_migration_pending();
-                tracing::info!(
-                    namespace = %ns.name,
-                    jobs = migrated,
-                    remaining_migration_l0 = pending.migration_l0,
-                    remaining_stale_partition = pending.stale_partitions,
-                    remaining_misplaced = pending.misplaced_local,
-                    elapsed_ms = migration_started.elapsed().as_millis() as u64,
-                    "physical layout migration advanced"
-                );
-            }
-            drop(migration_slot);
+            let migration_pending = ns.advance_physical_layout_migration()?;
             // An optional forced L0->L1 merge, then the planner-drain loop runs so
             // a forced compaction that leaves >= 32 L1 segments still promotes
             // L1->L2 in the same maintenance call. The drain checks the stop latch
@@ -1930,23 +1996,7 @@ impl Namespace {
         // Relocate evicted objects after local outputs are durable. Each copy is
         // server-side and crash-safe; the time budget prevents a cold archive
         // backlog from monopolizing the maintenance cycle.
-        let remote_migration_started = Instant::now();
-        let mut remote_migrated = 0;
-        while !self.stopped.load(Ordering::SeqCst)
-            && remote_migration_started.elapsed() < PHYSICAL_LAYOUT_MIGRATION_BUDGET
-            && self.remote_layout_migration_step().await?
-        {
-            remote_migrated += 1;
-        }
-        if remote_migrated > 0 {
-            tracing::info!(
-                namespace = %self.name,
-                segments = remote_migrated,
-                remaining = self.remote_layout_migration_remaining_count()?,
-                elapsed_ms = remote_migration_started.elapsed().as_millis() as u64,
-                "remote physical layout migration advanced"
-            );
-        }
+        self.advance_remote_layout_migration().await?;
 
         // Evict (blocking; evict_segment takes blocking_write per segment).
         let ns = Arc::clone(self);
@@ -1954,12 +2004,16 @@ impl Namespace {
             .await
             .map_err(|e| StatsError::Internal(format!("maintenance evict task panicked: {e}")))??;
 
-        // Backfill (blocking parquet reads + index build). Last + bounded so it is
-        // the lowest-priority work: older/terminal segments compaction never
-        // indexed get their bundles rebuilt a few per tick.
+        // Maintain derived indexes last and in bounded batches. Namespaces with
+        // an active policy backfill missing bundles; namespaces whose managed
+        // policy disables indexes remove stale bundles left by older binaries.
         let ns = Arc::clone(self);
         tokio::task::spawn_blocking(move || {
-            ns.backfill_missing_index_bundles(BACKFILL_INDEX_BUNDLES_PER_TICK)
+            if segment_indexes_enabled_for(&ns.name) {
+                ns.backfill_missing_index_bundles(INDEX_BUNDLES_PER_TICK)
+            } else {
+                ns.cleanup_disabled_index_bundles(INDEX_BUNDLES_PER_TICK)
+            }
         })
         .await
         .map_err(|e| StatsError::Internal(format!("maintenance backfill task panicked: {e}")))?;
@@ -2277,48 +2331,16 @@ fn segment_to_row(namespace: &str, seg: &LocalSegment) -> SegmentRow {
 /// the final path, and `discover_segments` ignores the extension, so a survivor
 /// is disk the namespace's own byte accounting cannot see.
 fn discard_staging_files(dir: &std::path::Path, namespace: &str) {
-    let mut pending = vec![dir.to_path_buf()];
-    while let Some(directory) = pending.pop() {
-        let entries = match std::fs::read_dir(&directory) {
-            Ok(entries) => entries,
-            Err(error) => {
-                tracing::warn!(namespace = %namespace, path = %directory.display(), %error,
-                    "could not inspect namespace for abandoned staging files");
-                continue;
-            }
-        };
-        for entry in entries {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(error) => {
-                    tracing::warn!(namespace = %namespace, path = %directory.display(), %error,
-                        "could not inspect namespace directory entry");
-                    continue;
-                }
-            };
-            let file_type = match entry.file_type() {
-                Ok(file_type) => file_type,
-                Err(error) => {
-                    tracing::warn!(namespace = %namespace, path = %entry.path().display(), %error,
-                        "could not inspect namespace file type");
-                    continue;
-                }
-            };
-            let path = entry.path();
-            if file_type.is_dir() {
-                pending.push(path);
-                continue;
-            }
-            if path.extension().and_then(|extension| extension.to_str()) != Some("tmp") {
-                continue;
-            }
-            match std::fs::remove_file(&path) {
-                Ok(()) => tracing::info!(namespace = %namespace, file = %path.display(),
-                    "discarded an abandoned staging file"),
-                Err(e) => {
-                    tracing::warn!(namespace = %namespace, file = %path.display(), error = %e,
-                    "could not discard an abandoned staging file")
-                }
+    for path in discover_files(dir) {
+        if path.extension().and_then(|extension| extension.to_str()) != Some("tmp") {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => tracing::info!(namespace = %namespace, file = %path.display(),
+                "discarded an abandoned staging file"),
+            Err(e) => {
+                tracing::warn!(namespace = %namespace, file = %path.display(), error = %e,
+                "could not discard an abandoned staging file")
             }
         }
     }
@@ -2856,6 +2878,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn levanter_index_cleanup_converges_across_restart() {
+        let dir = tempdir();
+        let ns_dir = dir.join("levanter.metrics");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            catalog,
+        );
+        ns.append_aligned_batch(&metrics_aligned(&["run-a", "run-b"]));
+        ns.flush_once().unwrap();
+        ns.run_maintenance(true).await.unwrap();
+
+        let segments = discover_segments(&ns_dir);
+        assert_eq!(segments.len(), 2);
+        for segment in &segments {
+            std::fs::write(crate::store::index_bundle::bundle_path(segment), b"stale").unwrap();
+        }
+        let legacy = legacy_artifact_paths(&segments[0])[0].clone();
+        std::fs::write(&legacy, b"stale").unwrap();
+        let projection = crate::store::exact::named_projection_path(&segments[0], "legacy");
+        std::fs::write(&projection, b"stale").unwrap();
+        ns.shutdown(Duration::from_secs(10)).await;
+
+        let cleanup = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            Arc::new(Catalog::open(Some(&dir)).unwrap()),
+        );
+        assert_eq!(cleanup.cleanup_disabled_index_bundles(1), 1);
+        assert_eq!(
+            segments
+                .iter()
+                .filter(|segment| crate::store::index_bundle::bundle_path(segment).exists())
+                .count(),
+            1
+        );
+        cleanup.shutdown(Duration::from_secs(10)).await;
+
+        let reopened = open_ns(
+            "levanter.metrics",
+            stored_form(levanter_metrics_schema()),
+            Some(ns_dir.clone()),
+            Arc::new(Catalog::open(Some(&dir)).unwrap()),
+        );
+        reopened.run_maintenance(false).await.unwrap();
+        for segment in &segments {
+            assert!(!crate::store::index_bundle::bundle_path(segment).exists());
+        }
+        assert!(!legacy.exists());
+        assert!(!projection.exists());
+        assert_eq!(reopened.stats().row_count, 2);
+        reopened.shutdown(Duration::from_secs(10)).await;
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
     async fn levanter_runtime_layout_migration_repairs_legacy_l0_and_flat_l1() {
         let dir = tempdir();
         let ns_dir = dir.join("levanter.metrics");
@@ -2888,13 +2970,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let migration_ns = Arc::clone(&ns);
-        assert!(
-            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
-                .await
-                .unwrap()
-                .unwrap()
-        );
+        ns.run_maintenance(false).await.unwrap();
 
         let second = ns.inner.lock().unwrap().local_segments[1].clone();
         let flat_l1_path = ns_dir.join(seg_filename(1, second.min_seq));
@@ -2914,20 +2990,8 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(flat_l1_path.parent(), Some(ns_dir.as_path()));
-        let migration_ns = Arc::clone(&ns);
-        assert!(
-            tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
-                .await
-                .unwrap()
-                .unwrap()
-        );
-        let migration_ns = Arc::clone(&ns);
-        assert!(
-            !tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_step())
-                .await
-                .unwrap()
-                .unwrap()
-        );
+        ns.run_maintenance(false).await.unwrap();
+        assert!(!ns.physical_layout_migration_is_pending());
 
         let segments = ns.inner.lock().unwrap().local_segments.clone();
         assert_eq!(segments.len(), 2);

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -24,7 +24,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::array::{Array, Int64Array, RecordBatch};
@@ -170,16 +170,6 @@ const PHYSICAL_LAYOUT_MIGRATION_CONCURRENCY: usize = 2;
 const PHYSICAL_LAYOUT_MIGRATION_WORKER_COMPRESSED_BYTES: i64 = 32 * 1024 * 1024;
 const PHYSICAL_LAYOUT_MIGRATION_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Process-wide permit for physical-layout migration waves.
-///
-/// Maintenance is per namespace. Without a global permit, every namespace with
-/// a legacy backlog starts several workers at once; the production hub then ran
-/// Levanter, RPC, node-agent, and vLLM waves concurrently and exhausted its
-/// 30 GiB cgroup. One permit retains two-way streaming inside the active
-/// namespace while bounding the whole process to one wave and leaving half of
-/// the four-core hub available for queries.
-static PHYSICAL_LAYOUT_MIGRATION_SLOT: Mutex<()> = Mutex::new(());
-
 /// Process-wide permit for the layout rewrite, so only one namespace re-encodes
 /// at a time.
 ///
@@ -289,6 +279,9 @@ pub struct Namespace {
     /// Shared by every namespace in this store so historical projection builds
     /// cannot saturate the process with concurrent scans and compression.
     index_backfill_slot: Arc<Mutex<()>>,
+    /// Shared by every namespace in this store so only one two-worker physical
+    /// migration wave runs at a time.
+    physical_layout_migration_slot: Arc<Mutex<()>>,
 }
 
 /// Segments the index backfill cannot bring up to date, and the indexed set
@@ -326,6 +319,50 @@ struct BackfillCandidate {
     expected_rows: i64,
 }
 
+#[derive(Clone, Copy, Default)]
+struct PhysicalLayoutMigrationPending {
+    migration_l0: usize,
+    stale_partitions: usize,
+    misplaced_local: usize,
+}
+
+impl PhysicalLayoutMigrationPending {
+    fn any(self) -> bool {
+        self.migration_l0 > 0 || self.stale_partitions > 0 || self.misplaced_local > 0
+    }
+}
+
+fn migration_l0_needs_rebuild(segment: &LocalSegment) -> bool {
+    segment.level == 0 && (segment.min_seq < 0 || segment.partition.is_some())
+}
+
+fn partition_is_stale(
+    segment: &LocalSegment,
+    policy: &dyn crate::partition_policy::PhysicalPartitionPolicy,
+) -> bool {
+    segment.level >= 1
+        && segment
+            .partition
+            .as_ref()
+            .is_none_or(|partition| !policy.is_current_partition(partition))
+}
+
+fn current_layout_destination(
+    dir: &Path,
+    path: &str,
+    level: i32,
+    partition: Option<&SegmentPartition>,
+    policy: &dyn crate::partition_policy::PhysicalPartitionPolicy,
+) -> Option<PathBuf> {
+    let partition = partition?;
+    if level < 1 || !policy.is_current_partition(partition) {
+        return None;
+    }
+    let filename = Path::new(path).file_name()?.to_str()?;
+    let destination = segment_path(dir, filename, level, Some(partition), Some(policy));
+    (Path::new(path) != destination).then_some(destination)
+}
+
 /// A namespace's sealed local segments as one consistent observation: the files a
 /// scan may read, their known key bounds, and the lowest `seq` any of them holds.
 pub struct SegmentSnapshot {
@@ -360,6 +397,7 @@ impl Namespace {
         query_visibility: Arc<RwLock<()>>,
         index_cache: Arc<IndexCache>,
         index_backfill_slot: Arc<Mutex<()>>,
+        physical_layout_migration_slot: Arc<Mutex<()>>,
         remote_log_dir: &str,
         storage_policy: StoragePolicy,
     ) -> Result<Arc<Namespace>, StatsError> {
@@ -449,6 +487,7 @@ impl Namespace {
             current_layouts: Mutex::new(HashSet::new()),
             index_cache,
             index_backfill_slot,
+            physical_layout_migration_slot,
         });
 
         // Refresh the catalog from the adopted deque so the segments table
@@ -883,14 +922,7 @@ impl Namespace {
         Ok(true)
     }
 
-    /// Select independent legacy L0 rebuild jobs up to one parallel wave.
-    ///
-    /// Each worker coalesces about 32 MiB of compressed inputs. Two workers
-    /// partition in parallel while leaving half of the production hub's CPUs
-    /// available for queries, and each publishes its input span atomically.
-    /// Coalescing matters because a migration source file contains many runs:
-    /// one output set per source would replace a 12K-file backlog with hundreds
-    /// of thousands of tiny L1s.
+    /// Select up to `limit` independent legacy L0 rebuild jobs.
     fn physical_layout_migration_l0_jobs(&self, limit: usize) -> Vec<CompactionJob> {
         if physical_partition_policy_for(&self.name).is_none() {
             return Vec::new();
@@ -899,9 +931,14 @@ impl Namespace {
         let mut jobs = Vec::new();
         let mut inputs = Vec::new();
         let mut compressed_bytes: i64 = 0;
-        for segment in inner.local_segments.iter().filter(|segment| {
-            segment.level == 0 && (segment.min_seq < 0 || segment.partition.is_some())
-        }) {
+        // Coalesce compressed inputs before repartitioning. One output set per
+        // migration source would turn the existing backlog into hundreds of
+        // thousands of tiny L1s.
+        for segment in inner
+            .local_segments
+            .iter()
+            .filter(|segment| migration_l0_needs_rebuild(segment))
+        {
             if !inputs.is_empty()
                 && compressed_bytes.saturating_add(segment.size_bytes)
                     > PHYSICAL_LAYOUT_MIGRATION_WORKER_COMPRESSED_BYTES
@@ -971,13 +1008,7 @@ impl Namespace {
         Ok(completed)
     }
 
-    /// Converge one non-L0 legacy placement operation online.
-    ///
-    /// The order encodes the storage contract:
-    /// 1. migration L0 (negative synthetic seq or legacy partition stamp) is
-    ///    rewritten into sorted/partitioned L1;
-    /// 2. stale or absent L1+ partition metadata is rebuilt in place;
-    /// 3. correctly partitioned L1+ is relocated into its bounded directory.
+    /// Rebuild or relocate one legacy L1+ segment.
     fn physical_layout_migration_non_l0_step(&self) -> Result<bool, StatsError> {
         let Some(dir) = self.data_dir.as_deref() else {
             return Ok(false);
@@ -991,13 +1022,7 @@ impl Namespace {
             inner
                 .local_segments
                 .iter()
-                .find(|segment| {
-                    segment.level >= 1
-                        && segment
-                            .partition
-                            .as_ref()
-                            .is_none_or(|partition| !policy.is_current_partition(partition))
-                })
+                .find(|segment| partition_is_stale(segment, policy))
                 .map(|segment| {
                     let mut row = segment_to_row(&self.name, segment);
                     row.partition = None;
@@ -1021,14 +1046,14 @@ impl Namespace {
         let relocation = {
             let inner = self.inner.lock().unwrap();
             inner.local_segments.iter().find_map(|segment| {
-                let partition = segment.partition.as_ref()?;
-                if segment.level < 1 || !policy.is_current_partition(partition) {
-                    return None;
-                }
-                let filename = Path::new(&segment.path).file_name()?.to_str()?;
-                let destination =
-                    segment_path(dir, filename, segment.level, Some(partition), Some(policy));
-                (Path::new(&segment.path) != destination).then(|| (segment.clone(), destination))
+                current_layout_destination(
+                    dir,
+                    &segment.path,
+                    segment.level,
+                    segment.partition.as_ref(),
+                    policy,
+                )
+                .map(|destination| (segment.clone(), destination))
             })
         };
         let Some((segment, destination)) = relocation else {
@@ -1050,8 +1075,7 @@ impl Namespace {
         Ok(true)
     }
 
-    /// Converge one legacy operation. Tests use this serial form; production
-    /// runs L0 inputs through [`Self::physical_layout_migration_l0_wave`].
+    /// Advance one legacy layout operation.
     #[cfg(test)]
     fn physical_layout_migration_step(&self) -> Result<bool, StatsError> {
         if let Some(job) = self.physical_layout_migration_l0_jobs(1).pop() {
@@ -1065,56 +1089,46 @@ impl Namespace {
         self.physical_layout_migration_non_l0_step()
     }
 
-    fn physical_layout_migration_pending(&self) -> (usize, usize, usize) {
+    fn physical_layout_migration_pending(&self) -> PhysicalLayoutMigrationPending {
         let Some(dir) = self.data_dir.as_deref() else {
-            return (0, 0, 0);
+            return PhysicalLayoutMigrationPending::default();
         };
         let Some(policy) = physical_partition_policy_for(&self.name) else {
-            return (0, 0, 0);
+            return PhysicalLayoutMigrationPending::default();
         };
         let inner = self.inner.lock().unwrap();
-        let mut migration_l0 = 0;
-        let mut stale_partition = 0;
-        let mut misplaced = 0;
+        let mut pending = PhysicalLayoutMigrationPending::default();
         for segment in &inner.local_segments {
+            if migration_l0_needs_rebuild(segment) {
+                pending.migration_l0 += 1;
+                continue;
+            }
             if segment.level == 0 {
-                migration_l0 += usize::from(segment.min_seq < 0 || segment.partition.is_some());
-                continue;
-            }
-            let Some(partition) = segment.partition.as_ref() else {
-                stale_partition += 1;
                 continue;
             };
-            if !policy.is_current_partition(partition) {
-                stale_partition += 1;
+            if partition_is_stale(segment, policy) {
+                pending.stale_partitions += 1;
                 continue;
             }
-            let Some(filename) = Path::new(&segment.path)
-                .file_name()
-                .and_then(|filename| filename.to_str())
-            else {
-                misplaced += 1;
-                continue;
-            };
-            let destination =
-                segment_path(dir, filename, segment.level, Some(partition), Some(policy));
-            misplaced += usize::from(Path::new(&segment.path) != destination);
+            pending.misplaced_local += usize::from(
+                current_layout_destination(
+                    dir,
+                    &segment.path,
+                    segment.level,
+                    segment.partition.as_ref(),
+                    policy,
+                )
+                .is_some(),
+            );
         }
-        (migration_l0, stale_partition, misplaced)
+        pending
     }
 
     fn physical_layout_migration_is_pending(&self) -> bool {
-        let pending = self.physical_layout_migration_pending();
-        pending.0 > 0 || pending.1 > 0 || pending.2 > 0
+        self.physical_layout_migration_pending().any()
     }
 
-    /// Relocate one evicted segment to its current object key without routing
-    /// the bytes through this process.
-    ///
-    /// The copy is published before the catalog pointer changes. The old key is
-    /// deleted only after that atomic swap, so queries always have a durable
-    /// source. Boot reconciliation resolves a crash in either gap by retaining
-    /// the key named by the catalog and deleting the other copy.
+    /// Relocate one archived segment to its current physical path.
     async fn remote_layout_migration_step(&self) -> Result<bool, StatsError> {
         let (Some(dir), Some(remote), Some(policy)) = (
             self.data_dir.as_deref(),
@@ -1130,14 +1144,14 @@ impl Namespace {
             .into_iter()
             .filter(|row| row.location == SegmentLocation::Remote)
             .find_map(|row| {
-                let partition = row.partition.as_ref()?;
-                if !policy.is_current_partition(partition) {
-                    return None;
-                }
-                let filename = Path::new(&row.path).file_name()?.to_str()?;
-                let destination =
-                    segment_path(dir, filename, row.level, Some(partition), Some(policy));
-                (Path::new(&row.path) != destination).then_some((row, destination))
+                current_layout_destination(
+                    dir,
+                    &row.path,
+                    row.level,
+                    row.partition.as_ref(),
+                    policy,
+                )
+                .map(|destination| (row, destination))
             });
         let Some((row, destination)) = candidate else {
             return Ok(false);
@@ -1177,7 +1191,7 @@ impl Namespace {
         Ok(true)
     }
 
-    fn remote_layout_migration_pending(&self) -> Result<usize, StatsError> {
+    fn remote_layout_migration_remaining_count(&self) -> Result<usize, StatsError> {
         let (Some(dir), Some(policy)) = (
             self.data_dir.as_deref(),
             physical_partition_policy_for(&self.name),
@@ -1190,20 +1204,14 @@ impl Namespace {
             .into_iter()
             .filter(|row| row.location == SegmentLocation::Remote)
             .filter(|row| {
-                let Some(partition) = row.partition.as_ref() else {
-                    return false;
-                };
-                if !policy.is_current_partition(partition) {
-                    return false;
-                }
-                let Some(filename) = Path::new(&row.path)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                else {
-                    return false;
-                };
-                Path::new(&row.path)
-                    != segment_path(dir, filename, row.level, Some(partition), Some(policy))
+                current_layout_destination(
+                    dir,
+                    &row.path,
+                    row.level,
+                    row.partition.as_ref(),
+                    policy,
+                )
+                .is_some()
             })
             .count())
     }
@@ -1845,7 +1853,15 @@ impl Namespace {
         let ns = Arc::clone(self);
         tokio::task::spawn_blocking(move || -> Result<(), StatsError> {
             ns.flush_once()?;
-            let migration_slot = PHYSICAL_LAYOUT_MIGRATION_SLOT.try_lock().ok();
+            let migration_slot = match ns.physical_layout_migration_slot.try_lock() {
+                Ok(slot) => Some(slot),
+                Err(TryLockError::WouldBlock) => None,
+                Err(TryLockError::Poisoned(_)) => {
+                    return Err(StatsError::Internal(
+                        "physical layout migration permit is poisoned".to_string(),
+                    ));
+                }
+            };
             let migration_started = Instant::now();
             let mut migrated = 0;
             if migration_slot.is_some() {
@@ -1866,14 +1882,13 @@ impl Namespace {
             }
             let migration_pending = ns.physical_layout_migration_is_pending();
             if migrated > 0 {
-                let (migration_l0, stale_partition, misplaced) =
-                    ns.physical_layout_migration_pending();
+                let pending = ns.physical_layout_migration_pending();
                 tracing::info!(
                     namespace = %ns.name,
                     jobs = migrated,
-                    remaining_migration_l0 = migration_l0,
-                    remaining_stale_partition = stale_partition,
-                    remaining_misplaced = misplaced,
+                    remaining_migration_l0 = pending.migration_l0,
+                    remaining_stale_partition = pending.stale_partitions,
+                    remaining_misplaced = pending.misplaced_local,
                     elapsed_ms = migration_started.elapsed().as_millis() as u64,
                     "physical layout migration advanced"
                 );
@@ -1927,7 +1942,7 @@ impl Namespace {
             tracing::info!(
                 namespace = %self.name,
                 segments = remote_migrated,
-                remaining = self.remote_layout_migration_pending()?,
+                remaining = self.remote_layout_migration_remaining_count()?,
                 elapsed_ms = remote_migration_started.elapsed().as_millis() as u64,
                 "remote physical layout migration advanced"
             );
@@ -2264,12 +2279,30 @@ fn segment_to_row(namespace: &str, seg: &LocalSegment) -> SegmentRow {
 fn discard_staging_files(dir: &std::path::Path, namespace: &str) {
     let mut pending = vec![dir.to_path_buf()];
     while let Some(directory) = pending.pop() {
-        let Ok(entries) = std::fs::read_dir(directory) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(file_type) = entry.file_type() else {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(namespace = %namespace, path = %directory.display(), %error,
+                    "could not inspect namespace for abandoned staging files");
                 continue;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::warn!(namespace = %namespace, path = %directory.display(), %error,
+                        "could not inspect namespace directory entry");
+                    continue;
+                }
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) => {
+                    tracing::warn!(namespace = %namespace, path = %entry.path().display(), %error,
+                        "could not inspect namespace file type");
+                    continue;
+                }
             };
             let path = entry.path();
             if file_type.is_dir() {
@@ -2674,6 +2707,7 @@ mod tests {
             Arc::new(RwLock::new(())),
             crate::query::index_cache::test_index_cache(),
             Arc::new(Mutex::new(())),
+            Arc::new(Mutex::new(())),
             "",
             StoragePolicy::default(),
         )
@@ -2696,6 +2730,7 @@ mod tests {
             catalog,
             Arc::new(RwLock::new(())),
             crate::query::index_cache::test_index_cache(),
+            Arc::new(Mutex::new(())),
             Arc::new(Mutex::new(())),
             remote_log_dir,
             policy,
@@ -2937,7 +2972,7 @@ mod tests {
             Some(ns_dir.clone()),
             Arc::new(Catalog::open(Some(&dir)).unwrap()),
         );
-        assert_eq!(ns.physical_layout_migration_pending().0, 6);
+        assert_eq!(ns.physical_layout_migration_pending().migration_l0, 6);
 
         let migration_ns = Arc::clone(&ns);
         let rebuilt =
@@ -2946,7 +2981,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
         assert_eq!(rebuilt, 1);
-        assert_eq!(ns.physical_layout_migration_pending().0, 0);
+        assert_eq!(ns.physical_layout_migration_pending().migration_l0, 0);
         assert_eq!(ns.stats().row_count, 12);
 
         for path in discover_segments(&ns_dir) {
@@ -2977,7 +3012,7 @@ mod tests {
             Arc::new(Catalog::open(Some(&dir)).unwrap()),
         );
 
-        assert_eq!(ns.physical_layout_migration_pending(), (0, 0, 0));
+        assert!(!ns.physical_layout_migration_pending().any());
         let migration_ns = Arc::clone(&ns);
         assert_eq!(
             tokio::task::spawn_blocking(move || migration_ns.physical_layout_migration_l0_wave())
@@ -3040,9 +3075,9 @@ mod tests {
             .replace_segments("levanter.metrics", &[old_path], &[legacy.clone()])
             .unwrap();
 
-        assert_eq!(ns.remote_layout_migration_pending().unwrap(), 1);
+        assert_eq!(ns.remote_layout_migration_remaining_count().unwrap(), 1);
         assert!(ns.remote_layout_migration_step().await.unwrap());
-        assert_eq!(ns.remote_layout_migration_pending().unwrap(), 0);
+        assert_eq!(ns.remote_layout_migration_remaining_count().unwrap(), 0);
         assert!(!ns.remote_layout_migration_step().await.unwrap());
 
         let relocated = ns

--- a/lib/finelog/rust/src/store/reconcile.rs
+++ b/lib/finelog/rust/src/store/reconcile.rs
@@ -14,7 +14,7 @@
 //!    delete leaves the input file in the bucket, and adoption would give it a
 //!    permanent REMOTE row.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use futures::StreamExt;
 
@@ -63,10 +63,39 @@ pub async fn reconcile_remote_segments(
 
     // Catalog rows at L>=1 keyed by relative object key (the durable pointers).
     let catalog_rows = catalog.list_segments_min_level(namespace, 1)?;
-    let catalog_by_key: HashMap<String, SegmentRow> = catalog_rows
+    let mut catalog_by_key: HashMap<String, SegmentRow> = catalog_rows
         .into_iter()
         .filter_map(|row| segment_relative_key(local_dir, &row.path).map(|key| (key, row)))
         .collect();
+
+    // A REMOTE row is only a pointer into this object listing. If its object is
+    // absent after a successful strongly-consistent list, the row is already
+    // unreadable and must not poison later maintenance. This also repairs a
+    // layout move that crashed after deleting the old key: the destination is
+    // adopted below instead of being discarded as a duplicate of a phantom.
+    let object_keys: HashSet<&str> = objects.iter().map(|(key, _)| key.as_str()).collect();
+    let missing_remote: Vec<(String, String)> = catalog_by_key
+        .iter()
+        .filter(|(key, row)| {
+            row.location == SegmentLocation::Remote && !object_keys.contains(key.as_str())
+        })
+        .map(|(key, row)| (key.clone(), row.path.clone()))
+        .collect();
+    let missing_remote_paths: Vec<String> = missing_remote
+        .iter()
+        .map(|(_key, path)| path.clone())
+        .collect();
+    catalog.remove_segments(namespace, &missing_remote_paths)?;
+    for (key, _path) in &missing_remote {
+        catalog_by_key.remove(key);
+    }
+    if !missing_remote.is_empty() {
+        tracing::warn!(
+            namespace,
+            segments = missing_remote.len(),
+            "removed catalog pointers to missing remote segments"
+        );
+    }
 
     // Footer-fetch every remote parquet not already known to the catalog.
     struct Footer {
@@ -225,6 +254,7 @@ pub async fn reconcile_remote_segments(
         namespace,
         remote_objects = objects.len(),
         catalog_segments = catalog_by_key.len(),
+        removed_missing = missing_remote.len(),
         footer_reads = footers.len(),
         adopted,
         dropped_redundant = dropped,

--- a/lib/finelog/rust/src/store/reconcile.rs
+++ b/lib/finelog/rust/src/store/reconcile.rs
@@ -22,7 +22,7 @@ use crate::errors::StatsError;
 use crate::partition_policy::SegmentPartition;
 use crate::store::catalog::Catalog;
 use crate::store::remote::RemoteStore;
-use crate::store::types::{basename, parse_seg_filename, SegmentLocation, SegmentRow};
+use crate::store::types::{parse_seg_filename, segment_relative_key, SegmentLocation, SegmentRow};
 
 /// Bounded concurrency for the boot reconcile's remote footer reads. High enough
 /// to hide cross-region round-trip latency (a sequential await chain costs O(N)
@@ -40,7 +40,7 @@ fn now_ms() -> i64 {
 /// Reconcile the remote bucket for `namespace` against the catalog at boot.
 ///
 /// `local_dir` is the namespace's on-disk directory (adopted REMOTE rows point
-/// their `path` at `{local_dir}/{basename}` so a later download lands the file
+/// their `path` at `{local_dir}/{relative key}` so a later download lands the file
 /// in place). `key_column` is the namespace's ordering key for footer key-bound
 /// recovery.
 pub async fn reconcile_remote_segments(
@@ -61,16 +61,16 @@ pub async fn reconcile_remote_segments(
     };
     let list_ms = list_started.elapsed().as_millis() as u64;
 
-    // Catalog rows at L>=1 keyed by basename (the durable-archive pointers).
+    // Catalog rows at L>=1 keyed by relative object key (the durable pointers).
     let catalog_rows = catalog.list_segments_min_level(namespace, 1)?;
-    let catalog_by_basename: HashMap<String, SegmentRow> = catalog_rows
+    let catalog_by_key: HashMap<String, SegmentRow> = catalog_rows
         .into_iter()
-        .map(|r| (basename(&r.path), r))
+        .filter_map(|row| segment_relative_key(local_dir, &row.path).map(|key| (key, row)))
         .collect();
 
     // Footer-fetch every remote parquet not already known to the catalog.
     struct Footer {
-        basename: String,
+        relative_key: String,
         level: i32,
         min_seq: i64,
         max_seq: i64,
@@ -82,8 +82,11 @@ pub async fn reconcile_remote_segments(
     }
     let pending: Vec<(String, u64)> = objects
         .iter()
-        .filter(|(name, _)| !catalog_by_basename.contains_key(name))
-        .filter_map(|(name, size)| parse_seg_filename(name).map(|_| (name.clone(), *size)))
+        .filter(|(key, _)| !catalog_by_key.contains_key(key))
+        .filter_map(|(key, size)| {
+            let filename = std::path::Path::new(key).file_name()?.to_str()?;
+            parse_seg_filename(filename).map(|_| (key.clone(), *size))
+        })
         .collect();
     // Fetch footers CONCURRENTLY: these are latency-bound cross-region round
     // trips, so a sequential await would cost O(N) RTTs. `buffer_unordered`
@@ -102,7 +105,7 @@ pub async fn reconcile_remote_segments(
                 return None;
             };
             Some(Footer {
-                basename: name,
+                relative_key: name,
                 level: metadata.level,
                 min_seq: metadata.min_seq,
                 max_seq: metadata.max_seq,
@@ -121,7 +124,7 @@ pub async fn reconcile_remote_segments(
     // a strictly-higher level as redundant (transitivity makes a single pass
     // sufficient — Z covers Y, Y covers X => Z covers X).
     let mut all_known: HashMap<String, (i32, i64, i64, Option<SegmentPartition>)> = HashMap::new();
-    for (name, row) in &catalog_by_basename {
+    for (name, row) in &catalog_by_key {
         all_known.insert(
             name.clone(),
             (row.level, row.min_seq, row.max_seq, row.partition.clone()),
@@ -129,7 +132,7 @@ pub async fn reconcile_remote_segments(
     }
     for f in &footers {
         all_known.insert(
-            f.basename.clone(),
+            f.relative_key.clone(),
             (f.level, f.min_seq, f.max_seq, f.partition.clone()),
         );
     }
@@ -142,6 +145,22 @@ pub async fn reconcile_remote_segments(
     }
     let mut redundant: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (name, (level, min_seq, max_seq, partition)) in &all_known {
+        // A path-only layout migration changes the object key without changing
+        // the segment identity represented by its level/seq/partition tuple.
+        // If the process crashes after uploading the new key but before deleting
+        // the old one, retain the catalog-owned key and discard the duplicate
+        // instead of adopting a permanent REMOTE row for it.
+        if !catalog_by_key.contains_key(name)
+            && catalog_by_key.values().any(|row| {
+                row.level == *level
+                    && row.min_seq == *min_seq
+                    && row.max_seq == *max_seq
+                    && row.partition == *partition
+            })
+        {
+            redundant.insert(name.clone());
+            continue;
+        }
         for (higher_level, ranges) in &by_level {
             if *higher_level <= *level {
                 continue;
@@ -159,7 +178,7 @@ pub async fn reconcile_remote_segments(
     let catalog_update_started = std::time::Instant::now();
     let removed_paths: Vec<String> = redundant
         .iter()
-        .filter_map(|name| catalog_by_basename.get(name).map(|row| row.path.clone()))
+        .filter_map(|name| catalog_by_key.get(name).map(|row| row.path.clone()))
         .collect();
     catalog.remove_segments(namespace, &removed_paths)?;
     let catalog_remove_ms = catalog_update_started.elapsed().as_millis() as u64;
@@ -176,10 +195,10 @@ pub async fn reconcile_remote_segments(
     let now = now_ms();
     let mut adopted_rows = Vec::new();
     for f in &footers {
-        if redundant.contains(&f.basename) {
+        if redundant.contains(&f.relative_key) {
             continue;
         }
-        let local_path = local_dir.join(&f.basename);
+        let local_path = local_dir.join(&f.relative_key);
         // Record the footer's actual num_rows, not a seq-span recomputation, so
         // an edge-case empty footer adopts row_count=0 rather than 1.
         adopted_rows.push(SegmentRow {
@@ -205,7 +224,7 @@ pub async fn reconcile_remote_segments(
     tracing::info!(
         namespace,
         remote_objects = objects.len(),
-        catalog_segments = catalog_by_basename.len(),
+        catalog_segments = catalog_by_key.len(),
         footer_reads = footers.len(),
         adopted,
         dropped_redundant = dropped,

--- a/lib/finelog/rust/src/store/reconcile.rs
+++ b/lib/finelog/rust/src/store/reconcile.rs
@@ -63,10 +63,18 @@ pub async fn reconcile_remote_segments(
 
     // Catalog rows at L>=1 keyed by relative object key (the durable pointers).
     let catalog_rows = catalog.list_segments_min_level(namespace, 1)?;
-    let mut catalog_by_key: HashMap<String, SegmentRow> = catalog_rows
-        .into_iter()
-        .filter_map(|row| segment_relative_key(local_dir, &row.path).map(|key| (key, row)))
-        .collect();
+    let mut catalog_by_key: HashMap<String, SegmentRow> = HashMap::new();
+    for row in catalog_rows {
+        let Some(key) = segment_relative_key(local_dir, &row.path) else {
+            tracing::warn!(
+                namespace,
+                path = %row.path,
+                "remote catalog segment is outside its namespace directory"
+            );
+            continue;
+        };
+        catalog_by_key.insert(key, row);
+    }
 
     // A REMOTE row is only a pointer into this object listing. If its object is
     // absent after a successful strongly-consistent list, the row is already

--- a/lib/finelog/rust/src/store/remote.rs
+++ b/lib/finelog/rust/src/store/remote.rs
@@ -151,9 +151,7 @@ impl RemoteStore {
         }
     }
 
-    /// Copy one object within a namespace without downloading it through the
-    /// Finelog process. Layout migration uses this to publish a new key before
-    /// atomically changing the catalog pointer to it.
+    /// Copy an object between two keys in the same namespace.
     pub async fn copy(&self, namespace: &str, from_key: &str, to_key: &str) -> bool {
         let from = self.object_path(namespace, from_key);
         let to = self.object_path(namespace, to_key);

--- a/lib/finelog/rust/src/store/remote.rs
+++ b/lib/finelog/rust/src/store/remote.rs
@@ -7,7 +7,7 @@
 //! non-empty value -> `LocalFileSystem` rooted at that directory (tests pass a
 //! plain tmp path). An empty `remote_log_dir` disables sync (returns `None`).
 //!
-//! The on-disk layout is `{remote_log_dir}/{namespace}/{basename}`; the
+//! The on-disk layout is `{remote_log_dir}/{namespace}/{relative segment key}`; the
 //! `RemoteStore` carries an optional bucket-relative `prefix` (the `gs://`
 //! path component) and every per-namespace op composes `{prefix}/{namespace}`.
 //! object_store 0.13 moved `put`/`get`/`head`/`delete` onto the `ObjectStoreExt`
@@ -51,7 +51,7 @@ pub fn is_object_store(remote_log_dir: &str) -> bool {
 /// iris owns the addressing-style decision (path-style for R2, virtual-hosted
 /// for CoreWeave Object Storage) and this server stays endpoint-agnostic.
 /// Any other value -> a `LocalFileSystem` rooted at that (created) directory,
-/// with an empty prefix, writing into `{remote_log_dir}/{namespace}/{basename}`.
+/// with an empty prefix, writing into `{remote_log_dir}/{namespace}/{relative segment key}`.
 pub fn build_remote_store(remote_log_dir: &str) -> Result<Option<RemoteStore>, StatsError> {
     let dir = remote_log_dir.trim_end_matches('/');
     if dir.is_empty() {
@@ -86,7 +86,7 @@ pub fn build_remote_store(remote_log_dir: &str) -> Result<Option<RemoteStore>, S
         }));
     }
     // Local filesystem remote (tests). Root the store at the remote dir so
-    // object paths are `{namespace}/{basename}`.
+    // object paths are `{namespace}/{relative segment key}`.
     std::fs::create_dir_all(dir)
         .map_err(|e| StatsError::Internal(format!("create remote dir {dir}: {e}")))?;
     let store = LocalFileSystem::new_with_prefix(dir)
@@ -105,9 +105,13 @@ impl RemoteStore {
         self.prefix.split('/').filter(|s| !s.is_empty())
     }
 
-    /// The object path for `{prefix}/{namespace}/{basename}`.
-    fn object_path(&self, namespace: &str, basename: &str) -> OsPath {
-        let parts: Vec<&str> = self.prefix_parts().chain([namespace, basename]).collect();
+    /// The object path for `{prefix}/{namespace}/{relative segment key}`.
+    fn object_path(&self, namespace: &str, relative_key: &str) -> OsPath {
+        let parts: Vec<&str> = self
+            .prefix_parts()
+            .chain([namespace])
+            .chain(relative_key.split('/').filter(|part| !part.is_empty()))
+            .collect();
         OsPath::from_iter(parts)
     }
 
@@ -117,13 +121,15 @@ impl RemoteStore {
         OsPath::from_iter(parts)
     }
 
-    /// Upload `local_path` to `{namespace}/{basename}`. Returns `true` on
+    /// Upload `local_path` to `{namespace}/{relative_key}`. Returns `true` on
     /// success; the next sync retries on failure. The byte read + put run as
     /// async object_store calls (no spawn_blocking).
-    pub async fn upload(&self, namespace: &str, local_path: &std::path::Path) -> bool {
-        let Some(basename) = local_path.file_name().and_then(|n| n.to_str()) else {
-            return false;
-        };
+    pub async fn upload(
+        &self,
+        namespace: &str,
+        relative_key: &str,
+        local_path: &std::path::Path,
+    ) -> bool {
         let bytes = match tokio::fs::read(local_path).await {
             Ok(b) => b,
             Err(e) => {
@@ -131,7 +137,7 @@ impl RemoteStore {
                 return false;
             }
         };
-        let remote = self.object_path(namespace, basename);
+        let remote = self.object_path(namespace, relative_key);
         match self
             .store
             .put(&remote, bytes::Bytes::from(bytes).into())
@@ -145,23 +151,43 @@ impl RemoteStore {
         }
     }
 
-    /// List the basenames of every parquet object under `{namespace}/`.
-    pub async fn list_basenames(&self, namespace: &str) -> Result<Vec<String>, StatsError> {
+    /// Copy one object within a namespace without downloading it through the
+    /// Finelog process. Layout migration uses this to publish a new key before
+    /// atomically changing the catalog pointer to it.
+    pub async fn copy(&self, namespace: &str, from_key: &str, to_key: &str) -> bool {
+        let from = self.object_path(namespace, from_key);
+        let to = self.object_path(namespace, to_key);
+        match self.store.copy(&from, &to).await {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(from = %from, to = %to, %error, "remote copy failed");
+                false
+            }
+        }
+    }
+
+    /// List the relative keys of every object under `{namespace}/`.
+    pub async fn list_keys(&self, namespace: &str) -> Result<Vec<String>, StatsError> {
         let prefix = self.namespace_prefix(namespace);
         let mut stream = self.store.list(Some(&prefix));
         let mut out = Vec::new();
         while let Some(item) = stream.next().await {
             let meta =
                 item.map_err(|e| StatsError::Internal(format!("remote list {namespace:?}: {e}")))?;
-            if let Some(name) = meta.location.filename() {
-                out.push(name.to_string());
-            }
+            if let Some(parts) = meta.location.prefix_match(&prefix) {
+                out.push(
+                    parts
+                        .map(|part| part.as_ref().to_string())
+                        .collect::<Vec<_>>()
+                        .join("/"),
+                );
+            };
         }
         Ok(out)
     }
 
-    /// List `(basename, byte_size)` for every parquet object under
-    /// `{namespace}/` whose basename parses as a segment filename. Used by boot
+    /// List `(relative_key, byte_size)` for every parquet object under
+    /// `{namespace}/` whose filename parses as a segment filename. Used by boot
     /// reconcile to enumerate adoption candidates.
     pub async fn list_segment_objects(
         &self,
@@ -173,23 +199,33 @@ impl RemoteStore {
         while let Some(item) = stream.next().await {
             let meta =
                 item.map_err(|e| StatsError::Internal(format!("remote list {namespace:?}: {e}")))?;
-            if let Some(name) = meta.location.filename() {
-                out.push((name.to_string(), meta.size));
+            let Some(filename) = meta.location.filename() else {
+                continue;
+            };
+            if crate::store::types::parse_seg_filename(filename).is_none() {
+                continue;
             }
+            if let Some(parts) = meta.location.prefix_match(&prefix) {
+                let key = parts
+                    .map(|part| part.as_ref().to_string())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                out.push((key, meta.size));
+            };
         }
         Ok(out)
     }
 
-    /// Delete `{namespace}/{basename}` from the remote store. Best-effort; logs
+    /// Delete `{namespace}/{relative_key}` from the remote store. Best-effort; logs
     /// and swallows on error (warn-and-continue).
-    pub async fn delete(&self, namespace: &str, basename: &str) {
-        let remote = self.object_path(namespace, basename);
+    pub async fn delete(&self, namespace: &str, relative_key: &str) {
+        let remote = self.object_path(namespace, relative_key);
         if let Err(e) = self.store.delete(&remote).await {
             tracing::warn!(remote = %remote, error = %e, "remote delete failed");
         }
     }
 
-    /// Async footer read of `{namespace}/{basename}`, including actual seq
+    /// Async footer read of `{namespace}/{relative_key}`, including actual seq
     /// bounds and hidden partition metadata.
     /// Returns `None` on an unreadable footer.
     ///
@@ -199,16 +235,17 @@ impl RemoteStore {
     pub async fn read_footer(
         &self,
         namespace: &str,
-        basename: &str,
+        relative_key: &str,
         file_size: u64,
         key_column: Option<&str>,
     ) -> Option<crate::store::segment::SegmentMetadata> {
         use parquet::arrow::async_reader::ParquetObjectReader;
         use parquet::file::metadata::ParquetMetaDataReader;
 
-        let (level, filename_min_seq) = crate::store::types::parse_seg_filename(basename)?;
+        let filename = std::path::Path::new(relative_key).file_name()?.to_str()?;
+        let (level, filename_min_seq) = crate::store::types::parse_seg_filename(filename)?;
 
-        let remote = self.object_path(namespace, basename);
+        let remote = self.object_path(namespace, relative_key);
         let mut reader =
             ParquetObjectReader::new(Arc::clone(&self.store), remote).with_file_size(file_size);
         let md = ParquetMetaDataReader::new()
@@ -284,23 +321,56 @@ mod tests {
 
         let local_file = local_dir.join("seg_L1_0000000000000000001.parquet");
         std::fs::write(&local_file, b"hello-parquet").unwrap();
-        assert!(store.upload("ns.a", &local_file).await);
+        assert!(
+            store
+                .upload(
+                    "ns.a",
+                    "run_id/07/seg_L1_0000000000000000001.parquet",
+                    &local_file
+                )
+                .await
+        );
 
         let on_disk = remote_dir
             .join("ns.a")
+            .join("run_id/07")
             .join(local_file.file_name().unwrap());
         assert!(on_disk.exists());
-        let names = store.list_basenames("ns.a").await.unwrap();
+
+        assert!(
+            store
+                .copy(
+                    "ns.a",
+                    "run_id/07/seg_L1_0000000000000000001.parquet",
+                    "run_id/08/seg_L1_0000000000000000001.parquet",
+                )
+                .await
+        );
+        let copied = remote_dir
+            .join("ns.a")
+            .join("run_id/08")
+            .join(local_file.file_name().unwrap());
+        assert_eq!(std::fs::read(&copied).unwrap(), b"hello-parquet");
+
+        let mut names = store.list_keys("ns.a").await.unwrap();
+        names.sort();
         assert_eq!(
             names,
-            vec!["seg_L1_0000000000000000001.parquet".to_string()]
+            vec![
+                "run_id/07/seg_L1_0000000000000000001.parquet".to_string(),
+                "run_id/08/seg_L1_0000000000000000001.parquet".to_string(),
+            ]
         );
 
         store
-            .delete("ns.a", "seg_L1_0000000000000000001.parquet")
+            .delete("ns.a", "run_id/07/seg_L1_0000000000000000001.parquet")
             .await;
         assert!(!on_disk.exists());
-        assert!(store.list_basenames("ns.a").await.unwrap().is_empty());
+        store
+            .delete("ns.a", "run_id/08/seg_L1_0000000000000000001.parquet")
+            .await;
+        assert!(!copied.exists());
+        assert!(store.list_keys("ns.a").await.unwrap().is_empty());
 
         std::fs::remove_dir_all(&remote_dir).ok();
         std::fs::remove_dir_all(&local_dir).ok();

--- a/lib/finelog/rust/src/store/remote.rs
+++ b/lib/finelog/rust/src/store/remote.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use object_store::local::LocalFileSystem;
 use object_store::path::Path as OsPath;
-use object_store::{ObjectStore, ObjectStoreExt};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 
 use crate::errors::StatsError;
 
@@ -152,36 +152,47 @@ impl RemoteStore {
     }
 
     /// Copy an object between two keys in the same namespace.
-    pub async fn copy(&self, namespace: &str, from_key: &str, to_key: &str) -> bool {
+    pub async fn copy(
+        &self,
+        namespace: &str,
+        from_key: &str,
+        to_key: &str,
+    ) -> Result<(), StatsError> {
         let from = self.object_path(namespace, from_key);
         let to = self.object_path(namespace, to_key);
-        match self.store.copy(&from, &to).await {
-            Ok(()) => true,
-            Err(error) => {
-                tracing::warn!(from = %from, to = %to, %error, "remote copy failed");
-                false
-            }
+        self.store.copy(&from, &to).await.map_err(|error| {
+            StatsError::Internal(format!("remote copy {from} -> {to} failed: {error}"))
+        })
+    }
+
+    async fn list_objects(&self, namespace: &str) -> Result<Vec<(String, ObjectMeta)>, StatsError> {
+        let prefix = self.namespace_prefix(namespace);
+        let mut stream = self.store.list(Some(&prefix));
+        let mut objects = Vec::new();
+        while let Some(item) = stream.next().await {
+            let meta = item.map_err(|error| {
+                StatsError::Internal(format!("remote list {namespace:?}: {error}"))
+            })?;
+            let Some(parts) = meta.location.prefix_match(&prefix) else {
+                continue;
+            };
+            let key = parts
+                .map(|part| part.as_ref().to_string())
+                .collect::<Vec<_>>()
+                .join("/");
+            objects.push((key, meta));
         }
+        Ok(objects)
     }
 
     /// List the relative keys of every object under `{namespace}/`.
     pub async fn list_keys(&self, namespace: &str) -> Result<Vec<String>, StatsError> {
-        let prefix = self.namespace_prefix(namespace);
-        let mut stream = self.store.list(Some(&prefix));
-        let mut out = Vec::new();
-        while let Some(item) = stream.next().await {
-            let meta =
-                item.map_err(|e| StatsError::Internal(format!("remote list {namespace:?}: {e}")))?;
-            if let Some(parts) = meta.location.prefix_match(&prefix) {
-                out.push(
-                    parts
-                        .map(|part| part.as_ref().to_string())
-                        .collect::<Vec<_>>()
-                        .join("/"),
-                );
-            };
-        }
-        Ok(out)
+        Ok(self
+            .list_objects(namespace)
+            .await?
+            .into_iter()
+            .map(|(key, _meta)| key)
+            .collect())
     }
 
     /// List `(relative_key, byte_size)` for every parquet object under
@@ -191,27 +202,16 @@ impl RemoteStore {
         &self,
         namespace: &str,
     ) -> Result<Vec<(String, u64)>, StatsError> {
-        let prefix = self.namespace_prefix(namespace);
-        let mut stream = self.store.list(Some(&prefix));
-        let mut out = Vec::new();
-        while let Some(item) = stream.next().await {
-            let meta =
-                item.map_err(|e| StatsError::Internal(format!("remote list {namespace:?}: {e}")))?;
-            let Some(filename) = meta.location.filename() else {
-                continue;
-            };
-            if crate::store::types::parse_seg_filename(filename).is_none() {
-                continue;
-            }
-            if let Some(parts) = meta.location.prefix_match(&prefix) {
-                let key = parts
-                    .map(|part| part.as_ref().to_string())
-                    .collect::<Vec<_>>()
-                    .join("/");
-                out.push((key, meta.size));
-            };
-        }
-        Ok(out)
+        Ok(self
+            .list_objects(namespace)
+            .await?
+            .into_iter()
+            .filter_map(|(key, meta)| {
+                let filename = meta.location.filename()?;
+                crate::store::types::parse_seg_filename(filename)?;
+                Some((key, meta.size))
+            })
+            .collect())
     }
 
     /// Delete `{namespace}/{relative_key}` from the remote store. Best-effort; logs
@@ -335,15 +335,14 @@ mod tests {
             .join(local_file.file_name().unwrap());
         assert!(on_disk.exists());
 
-        assert!(
-            store
-                .copy(
-                    "ns.a",
-                    "run_id/07/seg_L1_0000000000000000001.parquet",
-                    "run_id/08/seg_L1_0000000000000000001.parquet",
-                )
-                .await
-        );
+        store
+            .copy(
+                "ns.a",
+                "run_id/07/seg_L1_0000000000000000001.parquet",
+                "run_id/08/seg_L1_0000000000000000001.parquet",
+            )
+            .await
+            .unwrap();
         let copied = remote_dir
             .join("ns.a")
             .join("run_id/08")

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -1083,6 +1083,26 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
     Ok(merged_schema)
 }
 
+/// Merge a server-owned schema while treating its derived layout as authoritative.
+///
+/// Columns still evolve additively so historical Parquets remain readable, but
+/// secondary indexes, projections, and grouped extrema are owned by the server
+/// policy rather than monotonically accumulated from older registrations. This
+/// lets a rollout disable a broken derived index without rewriting source data.
+pub fn merge_managed_schema(registered: &Schema, requested: &Schema) -> Result<Schema, StatsError> {
+    let mut merged = merge_schemas(registered, requested)?;
+    for column in &mut merged.columns {
+        column.index = requested
+            .column(&column.name)
+            .map(|requested_column| requested_column.index.clone())
+            .unwrap_or_default();
+    }
+    merged.projections = requested.projections.clone();
+    merged.grouped_extrema = requested.grouped_extrema.clone();
+    validate_index_policies(&merged)?;
+    Ok(merged)
+}
+
 /// Validate a forwarded schema without evolving the receiving schema.
 ///
 /// Unknown nullable columns are returned as ignored. Shared columns must retain their

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -623,27 +623,28 @@ pub(crate) fn discover_files(dir: &Path) -> Vec<PathBuf> {
     while let Some(directory) = pending.pop() {
         let entries = match std::fs::read_dir(&directory) {
             Ok(entries) => entries,
-            Err(error) => {
-                if error.kind() != std::io::ErrorKind::NotFound {
-                    tracing::warn!(path = %directory.display(), %error, "file discovery could not read directory");
-                }
-                continue;
-            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => panic!(
+                "file discovery could not read directory {}: {error}",
+                directory.display()
+            ),
         };
         for entry in entries {
             let entry = match entry {
                 Ok(entry) => entry,
-                Err(error) => {
-                    tracing::warn!(path = %directory.display(), %error, "file discovery could not read directory entry");
-                    continue;
-                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => panic!(
+                    "file discovery could not read an entry in {}: {error}",
+                    directory.display()
+                ),
             };
             let file_type = match entry.file_type() {
                 Ok(file_type) => file_type,
-                Err(error) => {
-                    tracing::warn!(path = %entry.path().display(), %error, "file discovery could not read file type");
-                    continue;
-                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => panic!(
+                    "file discovery could not read the type of {}: {error}",
+                    entry.path().display()
+                ),
             };
             let path = entry.path();
             if file_type.is_dir() {

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -617,18 +617,34 @@ fn cached_segment_identity_and_row_group_rows(path: &Path) -> Option<(Uuid, Arc<
     Some((segment_identity, rows))
 }
 
-/// All `seg_L*_*.parquet` files in `dir`, sorted by filename (== by min_seq for
-/// a fixed level width). Returns an empty list if the dir does not exist.
+/// All `seg_L*_*.parquet` files under `dir`, sorted by path.
+///
+/// L0 lives directly in the namespace directory. Physical policies may place
+/// L1+ segments in bounded subdirectories, so discovery is recursive. Symlinked
+/// directories are not followed. Returns an empty list if `dir` does not exist.
 pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let p = entry.path();
-        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
-            if parse_seg_filename(name).is_some() {
-                out.push(p);
+    let mut pending = vec![dir.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if file_type.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if file_type.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| parse_seg_filename(name).is_some())
+            {
+                out.push(path);
             }
         }
     }
@@ -923,5 +939,24 @@ mod tests {
         let name = seg_filename(0, 42);
         assert_eq!(name, "seg_L0_0000000000000000042.parquet");
         assert_eq!(parse_seg_filename(&name), Some((0, 42)));
+    }
+
+    #[test]
+    fn discover_segments_includes_nested_physical_directories() {
+        let dir = tempdir();
+        let nested = dir.join("run_id/07");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(dir.join(seg_filename(0, 1)), b"l0").unwrap();
+        std::fs::write(nested.join(seg_filename(1, 2)), b"l1").unwrap();
+        std::fs::write(nested.join("ignored.parquet.tmp"), b"tmp").unwrap();
+
+        let discovered = discover_segments(&dir);
+        assert_eq!(discovered.len(), 2);
+        assert!(discovered.iter().any(|path| path.parent() == Some(&dir)));
+        assert!(discovered
+            .iter()
+            .any(|path| path.parent() == Some(nested.as_path())));
+
+        std::fs::remove_dir_all(dir).ok();
     }
 }

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -617,12 +617,7 @@ fn cached_segment_identity_and_row_group_rows(path: &Path) -> Option<(Uuid, Arc<
     Some((segment_identity, rows))
 }
 
-/// All `seg_L*_*.parquet` files under `dir`, sorted by path.
-///
-/// L0 lives directly in the namespace directory. Physical policies may place
-/// L1+ segments in bounded subdirectories, so discovery is recursive. Symlinked
-/// directories are not followed. Returns an empty list if `dir` does not exist.
-pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
+pub(crate) fn discover_files(dir: &Path) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = Vec::new();
     let mut pending = vec![dir.to_path_buf()];
     while let Some(directory) = pending.pop() {
@@ -630,7 +625,7 @@ pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
             Ok(entries) => entries,
             Err(error) => {
                 if error.kind() != std::io::ErrorKind::NotFound {
-                    tracing::warn!(path = %directory.display(), %error, "segment discovery could not read directory");
+                    tracing::warn!(path = %directory.display(), %error, "file discovery could not read directory");
                 }
                 continue;
             }
@@ -639,14 +634,14 @@ pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(error) => {
-                    tracing::warn!(path = %directory.display(), %error, "segment discovery could not read directory entry");
+                    tracing::warn!(path = %directory.display(), %error, "file discovery could not read directory entry");
                     continue;
                 }
             };
             let file_type = match entry.file_type() {
                 Ok(file_type) => file_type,
                 Err(error) => {
-                    tracing::warn!(path = %entry.path().display(), %error, "segment discovery could not read file type");
+                    tracing::warn!(path = %entry.path().display(), %error, "file discovery could not read file type");
                     continue;
                 }
             };
@@ -655,18 +650,29 @@ pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
                 pending.push(path);
                 continue;
             }
-            if file_type.is_file()
-                && path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| parse_seg_filename(name).is_some())
-            {
+            if file_type.is_file() {
                 out.push(path);
             }
         }
     }
     out.sort();
     out
+}
+
+/// All `seg_L*_*.parquet` files under `dir`, sorted by path.
+///
+/// L0 lives directly in the namespace directory. Physical policies may place
+/// L1+ segments in bounded subdirectories, so discovery is recursive. Symlinked
+/// directories are not followed. Returns an empty list if `dir` does not exist.
+pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
+    discover_files(dir)
+        .into_iter()
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| parse_seg_filename(name).is_some())
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -626,12 +626,29 @@ pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = Vec::new();
     let mut pending = vec![dir.to_path_buf()];
     while let Some(directory) = pending.pop() {
-        let Ok(entries) = std::fs::read_dir(directory) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(file_type) = entry.file_type() else {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(path = %directory.display(), %error, "segment discovery could not read directory");
+                }
                 continue;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::warn!(path = %directory.display(), %error, "segment discovery could not read directory entry");
+                    continue;
+                }
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) => {
+                    tracing::warn!(path = %entry.path().display(), %error, "segment discovery could not read file type");
+                    continue;
+                }
             };
             let path = entry.path();
             if file_type.is_dir() {

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -169,6 +169,7 @@ pub struct Store {
     query_visibility: Arc<tokio::sync::RwLock<()>>,
     index_cache: Arc<IndexCache>,
     index_backfill_slot: Arc<Mutex<()>>,
+    physical_layout_migration_slot: Arc<Mutex<()>>,
     policies: PolicyRegistry,
     _store_lock: Option<File>,
 }
@@ -276,6 +277,7 @@ impl Store {
             query_visibility: Arc::new(tokio::sync::RwLock::new(())),
             index_cache: Arc::new(IndexCache::new(index_cache_mb)),
             index_backfill_slot: Arc::new(Mutex::new(())),
+            physical_layout_migration_slot: Arc::new(Mutex::new(())),
             policies: PolicyRegistry::new(telemetry_root_write_mode),
             _store_lock: store_lock,
         };
@@ -406,6 +408,7 @@ impl Store {
             Arc::clone(&self.query_visibility),
             Arc::clone(&self.index_cache),
             Arc::clone(&self.index_backfill_slot),
+            Arc::clone(&self.physical_layout_migration_slot),
             &self.remote_log_dir,
             policy,
         )?;

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -23,7 +23,7 @@ use clap::ValueEnum;
 
 use crate::errors::StatsError;
 use crate::ingestion_policy::IngestionBatchSource;
-use crate::policies::{physical_partition_policy_for, PolicyRegistry};
+use crate::policies::{physical_partition_policy_for, segment_indexes_enabled_for, PolicyRegistry};
 use crate::proto::finelog::stats::ColumnType;
 use crate::query::index_cache::IndexCache;
 use crate::query::provider::NamespaceProvider;
@@ -34,9 +34,9 @@ use crate::store::namespace::Namespace;
 use crate::store::namespace_name::validate_namespace_name;
 use crate::store::policy::StoragePolicy;
 use crate::store::schema::{
-    merge_schemas, resolve_key_column, stamp_cluster_column, stored_form, validate_and_align_batch,
-    validate_and_align_forwarded_batch, validate_index_policies, AlignedBatch, Column, Schema,
-    MAX_WRITE_ROWS_BYTES, MAX_WRITE_ROWS_ROWS,
+    merge_managed_schema, merge_schemas, resolve_key_column, stamp_cluster_column, stored_form,
+    validate_and_align_batch, validate_and_align_forwarded_batch, validate_index_policies,
+    AlignedBatch, Column, Schema, MAX_WRITE_ROWS_BYTES, MAX_WRITE_ROWS_ROWS,
 };
 use crate::store::types::NamespaceStats;
 use crate::telemetry_policy::{TelemetryRootWriteMode, TELEMETRY_NAMESPACE};
@@ -59,6 +59,12 @@ pub struct ForwardedWrite {
     pub rows_written: i64,
     pub persisted_targets: Vec<(String, i64)>,
     pub ignored_columns: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum SchemaRegistration {
+    Additive,
+    Managed,
 }
 
 #[derive(Clone, Copy)]
@@ -496,6 +502,30 @@ impl Store {
         schema: Schema,
         policy: StoragePolicy,
     ) -> Result<Schema, StatsError> {
+        self.register_table_with(name, schema, policy, SchemaRegistration::Additive)
+    }
+
+    /// Register a server-owned schema whose derived layout is authoritative.
+    ///
+    /// Column evolution remains additive, but index and projection policy may
+    /// be withdrawn by a rollout. Callers must supply the canonical server
+    /// schema rather than a client declaration.
+    pub fn register_managed_table(
+        &self,
+        name: &str,
+        schema: Schema,
+        policy: StoragePolicy,
+    ) -> Result<Schema, StatsError> {
+        self.register_table_with(name, schema, policy, SchemaRegistration::Managed)
+    }
+
+    fn register_table_with(
+        &self,
+        name: &str,
+        schema: Schema,
+        policy: StoragePolicy,
+        registration: SchemaRegistration,
+    ) -> Result<Schema, StatsError> {
         // Validate the name (and fence the `log` dir special-case) first.
         self.namespace_dir(name)?;
         validate_index_policies(&schema)?;
@@ -509,9 +539,19 @@ impl Store {
         let had_engine = self.engines.lock().unwrap().contains_key(name);
         let (effective_schema, effective_policy) =
             self.catalog
-                .register_or_evolve(name, stored, policy, move |existing_schema| {
-                    merge_schemas(existing_schema, &stored_for_merge)
-                })?;
+                .register_or_evolve(
+                    name,
+                    stored,
+                    policy,
+                    move |existing_schema| match registration {
+                        SchemaRegistration::Additive => {
+                            merge_schemas(existing_schema, &stored_for_merge)
+                        }
+                        SchemaRegistration::Managed => {
+                            merge_managed_schema(existing_schema, &stored_for_merge)
+                        }
+                    },
+                )?;
         // (Re)build the engine on fresh registration or when the effective schema
         // evolved. The engine re-opens on the same dir, adopting existing
         // segments and recovering next_seq, so an additive evolution keeps the
@@ -735,6 +775,7 @@ impl Store {
                 Arc::clone(&self.index_cache),
             )
             .map_err(|e| StatsError::Internal(format!("build provider {:?}: {e}", ns.name)))?
+            .with_segment_indexes_enabled(segment_indexes_enabled_for(&ns.name))
             .with_exact_postings_policy(exact_postings_policy)
             .with_segment_key_bounds(key_column, segments.key_bounds)
             .with_segment_partitions(physical_partition_policy_for(&ns.name), segments.partitions);
@@ -958,6 +999,7 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::levanter_metrics_policy::levanter_metrics_schema;
     use crate::store::schema::{with_implicit_cluster, with_implicit_seq, CoveringProjection};
 
     fn worker_schema() -> Schema {
@@ -999,6 +1041,48 @@ mod tests {
             .column("cluster")
             .expect("implicit cluster column");
         assert!(cluster.nullable);
+    }
+
+    #[test]
+    fn managed_levanter_registration_can_disable_stale_index_policy() {
+        let store = mem_store();
+        let mut stale = levanter_metrics_schema();
+        stale
+            .columns
+            .iter_mut()
+            .find(|column| column.name == "name")
+            .unwrap()
+            .index
+            .trigram = true;
+        stale
+            .columns
+            .iter_mut()
+            .find(|column| column.name == "kind")
+            .unwrap()
+            .index
+            .value_counts = true;
+        store
+            .catalog
+            .register_or_evolve(
+                "levanter.metrics",
+                stored_form(stale),
+                StoragePolicy::default(),
+                |_| unreachable!("fresh catalog registration does not merge"),
+            )
+            .unwrap();
+
+        let effective = store
+            .register_managed_table(
+                "levanter.metrics",
+                levanter_metrics_schema(),
+                StoragePolicy::default(),
+            )
+            .unwrap();
+        assert!(effective.columns.iter().all(|column| {
+            !column.index.trigram
+                && !column.index.value_counts
+                && column.index.exact_values.is_empty()
+        }));
     }
 
     #[test]

--- a/lib/finelog/rust/src/store/types.rs
+++ b/lib/finelog/rust/src/store/types.rs
@@ -124,6 +124,21 @@ pub fn basename(path: &str) -> String {
         .to_string()
 }
 
+/// Object-store key for a catalog segment path relative to its namespace dir.
+pub fn segment_relative_key(namespace_dir: &std::path::Path, path: &str) -> Option<String> {
+    let relative = std::path::Path::new(path)
+        .strip_prefix(namespace_dir)
+        .ok()?;
+    let parts = relative
+        .components()
+        .map(|component| match component {
+            std::path::Component::Normal(part) => part.to_str(),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
 /// Filename for a segment at `level` whose smallest seq is `min_seq`.
 pub fn seg_filename(level: i32, min_seq: i64) -> String {
     format!("seg_L{level}_{min_seq:019}.parquet")

--- a/lib/finelog/rust/src/store/types.rs
+++ b/lib/finelog/rust/src/store/types.rs
@@ -113,9 +113,8 @@ pub struct MemorySummary {
 
 /// The filename part of `path`, or `path` itself when it has none.
 ///
-/// Segments are identified by basename nearly everywhere outside the catalog —
-/// logs, the remote archive's object keys, the debug and introspection routes —
-/// because the directory is a property of the store, not of the segment.
+/// Segments are identified by basename in logs and introspection routes. Remote
+/// archive keys use [`segment_relative_key`] so physical partitions survive.
 pub fn basename(path: &str) -> String {
     std::path::Path::new(path)
         .file_name()


### PR DESCRIPTION
Partition `levanter.metrics` by exact `run_id` metadata while keeping L0 flat. Exact run predicates prune current partitions; legacy and transition files remain visible during online migration. Compacted files use the bounded directory layout `levanter.metrics/run_id/00..31/` without weakening the full run-id partition recorded in segment metadata.

Converge existing local and archived segments without stopping ingestion. A store-wide two-worker permit bounds rebuild memory, and namespaces without a physical partition policy stay on ordinary compaction. `levanter.metrics` intentionally uses no secondary indexes: managed registration withdraws the inherited telemetry declarations, readers ignore old bundles, and bounded maintenance removes local derived files online.

Carry the current execution identity from Hero phase enrollment into health aggregation and scan `levanter.metrics` once with exact run and execution predicates. The training run selector now uses a fixed 12-hour discovery window rather than inheriting the graph window. The former seven-day selector scanned 1.068 billion rows across 17,411 segments and exceeded the server's 10-second deadline; production probes of the bounded selector completed in 2.10–3.58 seconds. Explicitly selected historical runs remain queryable.

The production migration routed 1,723,699,039 of 2,173,077,173 legacy rows into semantic telemetry and typed Levanter tables. After Grafana switched to semantic queries, Finelog returned to normal single-write mode, accepted a semantic-only canary exactly once, and retired the compatibility root. Removing the rollback tree and retired local root files reclaimed about 92 GB; the GCS compatibility archive remains intact.

The complete Finelog suite passes with 458 tests and one pre-existing ignored test. The Grafana suite passes all 252 tests. Rust checks, clippy, repository lint, and required CI checks pass.

Incident records: https://echo.oa.dev/wiki/254 and https://echo.oa.dev/wiki/256
