### PR TITLE
[iris] Scrape node metrics from the local kubelet

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -550,12 +550,15 @@ Namespaces:
 - `iris.task` — per-attempt task resource snapshots, keyed by `ts`. Worker
   daemons write their process readings directly. On Kubernetes, each
   `iris-node-agent` samples the task containers on its node from kubelet
-  `/metrics/resource` every 30 seconds. CPU is derived from consecutive
-  cumulative counter samples, so the first row after an agent start reports
-  zero CPU. Memory uses the working-set gauge and an agent-local peak; an agent
-  restart resets that peak. Kubelet resource metrics do not expose container
-  filesystem usage, so Kubernetes rows report zero disk usage. The node-agent
-  service account requires `get` on `nodes/proxy`.
+  `/metrics/resource` every 60 seconds. The agent runs on the host network and
+  reads its own kubelet over loopback; the request does not go through the
+  apiserver, so node telemetry stays off the cluster's Konnectivity tunnel. CPU
+  is derived from consecutive cumulative counter samples, so the first row after
+  an agent start reports zero CPU. Memory uses the working-set gauge and an
+  agent-local peak; an agent restart resets that peak. Kubelet resource metrics
+  do not expose container filesystem usage, so Kubernetes rows report zero disk
+  usage. The node-agent service account requires `get` on `nodes/metrics`, which
+  is the subresource the kubelet authorizes that endpoint against.
 - `iris.task_event` — up to 30 days of deduplicated backend verdicts and
   state-changing controller actions per task attempt. Query all attempts with
   `iris task events /user/job/0`, or directly:

--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import http.client
 import logging
 import math
+import ssl
 import threading
 import time
 import urllib.request
@@ -45,8 +47,13 @@ from iris.rpc import job_pb2
 logger = logging.getLogger(__name__)
 
 DEFAULT_COLLECTION_INTERVAL = 60.0
-K8S_API_TIMEOUT = 2.0
+# Generous enough that ordinary apiserver latency, including a control plane under
+# load, does not fail a collection cycle; collection runs once per interval, so a
+# slow call delays one sample rather than overlapping the next.
+K8S_API_TIMEOUT = 15.0
 NODE_EXPORTER_ADDRESS = "127.0.0.1"
+KUBELET_RESOURCE_METRICS_URL = "https://127.0.0.1:10250/metrics/resource"
+SERVICE_ACCOUNT_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 _K8S_GPU_MODEL_LABELS = ("nvidia.com/gpu.product", "gpu.nvidia.com/model")
 
 # CoreWeave runs both exporters as DaemonSets in this namespace. node-exporter
@@ -108,6 +115,41 @@ def _http_get(url: str, timeout: float = _SCRAPE_TIMEOUT) -> str | None:
     except Exception as e:
         logger.debug("node-metrics scrape failed for %s: %s", url, e)
         return None
+
+
+# The kubelet's serving certificate is issued by the node rather than the cluster
+# CA, so it does not verify against the service-account CA bundle. The connection
+# is to loopback on the agent's own node and carries no off-host exposure.
+_KUBELET_TLS_CONTEXT = ssl.create_default_context()
+_KUBELET_TLS_CONTEXT.check_hostname = False
+_KUBELET_TLS_CONTEXT.verify_mode = ssl.CERT_NONE
+
+
+class KubeletScrapeError(RuntimeError):
+    """The local kubelet did not return resource metrics."""
+
+
+def kubelet_resource_metrics(timeout: float = _SCRAPE_TIMEOUT) -> str:
+    """Return the local kubelet's ``metrics/resource`` text.
+
+    The node agent runs on the host network and reads its own kubelet directly.
+    Routing the same request through the apiserver's ``nodes/proxy`` subresource
+    sends every sample across the cluster's Konnectivity tunnel, behind the same
+    control-plane path that carries ``exec``, ``port-forward``, and ``logs``.
+
+    Authorization uses the pod's service-account token, which the kubelet checks
+    against the ``nodes/metrics`` subresource.
+    """
+    token = SERVICE_ACCOUNT_TOKEN_PATH.read_text().strip()
+    request = urllib.request.Request(KUBELET_RESOURCE_METRICS_URL, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout, context=_KUBELET_TLS_CONTEXT) as resp:
+            body = resp.read(_MAX_SCRAPE_BYTES + 1)
+    except (OSError, http.client.HTTPException) as error:
+        raise KubeletScrapeError(f"kubelet resource-metrics scrape failed: {error}") from error
+    if len(body) > _MAX_SCRAPE_BYTES:
+        raise KubeletScrapeError(f"kubelet resource metrics exceeded {_MAX_SCRAPE_BYTES} bytes")
+    return body.decode("utf-8", errors="replace")
 
 
 def _parse_labels(body: str) -> dict[str, str]:
@@ -224,11 +266,13 @@ class TaskStatsCollector:
         table: Table,
         *,
         clock: Callable[[], float] = time.monotonic,
+        read_kubelet_metrics: Callable[[], str] = kubelet_resource_metrics,
     ) -> None:
         self._kubectl = kubectl
         self._node_name = node_name
         self._table = table
         self._clock = clock
+        self._read_kubelet_metrics = read_kubelet_metrics
         self._previous_cpu: dict[str, tuple[float, float]] = {}
         self._memory_peak: dict[str, int] = {}
 
@@ -241,8 +285,8 @@ class TaskStatsCollector:
                 labels=labels,
                 field_selector=f"spec.nodeName={self._node_name}",
             )
-            resources = parse_kubelet_resource_metrics(self._kubectl.node_resource_metrics(self._node_name))
-        except KubectlError as error:
+            resources = parse_kubelet_resource_metrics(self._read_kubelet_metrics())
+        except (KubectlError, KubeletScrapeError) as error:
             logger.warning("task-resource collection failed for node %s: %s", self._node_name, error)
             return
 

--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -132,13 +132,9 @@ class KubeletScrapeError(RuntimeError):
 def kubelet_resource_metrics(timeout: float = _SCRAPE_TIMEOUT) -> str:
     """Return the local kubelet's ``metrics/resource`` text.
 
-    The node agent runs on the host network and reads its own kubelet directly.
-    Routing the same request through the apiserver's ``nodes/proxy`` subresource
-    sends every sample across the cluster's Konnectivity tunnel, behind the same
-    control-plane path that carries ``exec``, ``port-forward``, and ``logs``.
-
-    Authorization uses the pod's service-account token, which the kubelet checks
-    against the ``nodes/metrics`` subresource.
+    Reads the kubelet on the agent's own node over loopback, which the host
+    network makes reachable. Authorization uses the pod's service-account token,
+    which the kubelet checks against the ``nodes/metrics`` subresource.
     """
     token = SERVICE_ACCOUNT_TOKEN_PATH.read_text().strip()
     request = urllib.request.Request(KUBELET_RESOURCE_METRICS_URL, headers={"Authorization": f"Bearer {token}"})

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -265,7 +265,6 @@ class InMemoryK8sService:
         self._exec_responses: dict[str, list[ExecResult]] = {}
         self._file_contents: dict[tuple[str, str], bytes] = {}  # (pod_name, path) -> data
         self._rm_files_calls: list[tuple[str, list[str]]] = []
-        self._node_resource_metrics: dict[str, str] = {}
         self._log_watermarks: dict[str, int] = {}  # pod_name -> bytes consumed
 
         # Pods living outside the service's own namespace, keyed by
@@ -539,9 +538,6 @@ class InMemoryK8sService:
         """Pre-populate file content readable via read_file."""
         self._file_contents[(pod_name, path)] = data
 
-    def set_node_resource_metrics(self, node_name: str, text: str) -> None:
-        self._node_resource_metrics[node_name] = text
-
     def seed_resource(self, resource: K8sResource, name: str, manifest: dict) -> None:
         """Directly insert a resource into the in-memory store for test setup.
 
@@ -795,10 +791,6 @@ class InMemoryK8sService:
             if _matches_field_selector(event, field_selector):
                 results.append(event)
         return results
-
-    def node_resource_metrics(self, node_name: str) -> str:
-        self._check_failure("node_resource_metrics")
-        return self._node_resource_metrics.get(node_name, "")
 
     def read_file(
         self,

--- a/lib/iris/src/iris/cluster/platforms/k8s/rbac_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/rbac_manifests.py
@@ -18,7 +18,9 @@ CLUSTER_ROLE_RULES = [
         "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
     },
     {"apiGroups": [""], "resources": ["nodes"], "verbs": ["get", "list", "watch"]},
-    {"apiGroups": [""], "resources": ["nodes/proxy"], "verbs": ["get"]},
+    # The node agent reads its own kubelet's metrics/resource endpoint directly;
+    # the kubelet authorizes that read against the nodes/metrics subresource.
+    {"apiGroups": [""], "resources": ["nodes/metrics"], "verbs": ["get"]},
     {
         "apiGroups": [""],
         "resources": ["configmaps"],

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -58,6 +58,24 @@ DEFAULT_TIMEOUT: float = 60.0
 # Threshold for slow-operation warnings (milliseconds)
 _SLOW_THRESHOLD_MS: int = 2000
 
+
+@contextmanager
+def _k8s_call(operation: str) -> Iterator[None]:
+    """Time one kubernetes API call and convert its transport failures.
+
+    ``operation`` names the call in both the slow-call warning and the raised
+    error. Callers add their own ``except ApiException`` where a status code
+    selects different handling; everything reaching here is a transport failure
+    the client raises as a urllib3 error, which callers expect as
+    ``KubectlError``.
+    """
+    with slow_log(logger, operation, threshold_ms=_SLOW_THRESHOLD_MS):
+        try:
+            yield
+        except TransportError as error:
+            raise KubectlError(f"{operation} failed: {error}") from error
+
+
 # Items requested per LIST page. An unpaginated list of a large collection
 # streams one chunked response body that no timeout bounds — the client arms a
 # per-recv socket timeout, which every arriving chunk resets — so a slow list
@@ -301,7 +319,7 @@ class CloudK8sService:
         ns = manifest["metadata"].get("namespace", self.namespace) if res.is_namespaced else None
 
         logger.info("k8s: apply %s/%s", kind, name)
-        with slow_log(logger, f"apply {kind}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"apply {kind}/{name}"):
             try:
                 if res is K8sResource.PODS:
                     self._apply_pod(res, ns, manifest)
@@ -319,8 +337,6 @@ class CloudK8sService:
                 raise KubectlError(
                     f"apply {kind}/{name} failed ({e.status}): {e.reason} {(e.body or '')[:_ERROR_BODY_MAX_LEN]}"
                 ) from e
-            except TransportError as e:
-                raise KubectlError(f"apply {kind}/{name} failed: {e}") from e
 
     def _apply_pod(self, res: K8sResource, ns: str | None, manifest: dict) -> None:
         """Create the Pod if it is not already present (create-if-absent).
@@ -338,23 +354,22 @@ class CloudK8sService:
         api = self._resource_api(res)
         ns_kw = {"namespace": ns} if ns else {}
         timeout_kw = self._request_timeout_kwargs()
-        try:
-            api.create(body=manifest, **timeout_kw, **ns_kw)
-        except ApiException as e:
-            if e.status == 409:
-                # Pod already present (or a prior generation still terminating);
-                # leave it. A later reconcile re-applies once any deletion lands.
-                return
-            raise
-        except TransportError as e:
-            raise KubectlError(f"create {res.plural} failed: {e}") from e
+        with _k8s_call(f"create {res.plural}"):
+            try:
+                api.create(body=manifest, **timeout_kw, **ns_kw)
+            except ApiException as e:
+                if e.status == 409:
+                    # Pod already present (or a prior generation still terminating);
+                    # leave it. A later reconcile re-applies once any deletion lands.
+                    return
+                raise
 
     # -- get -----------------------------------------------------------------
 
     def get_json(self, resource: K8sResource, name: str) -> dict | None:
         """Get a Kubernetes resource as a parsed dict. Returns None if not found."""
         logger.info("k8s: GET %s/%s", resource.plural, name)
-        with slow_log(logger, f"get {resource.plural}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"get {resource.plural}/{name}"):
             try:
                 result = self._resource_api(resource).get(
                     name=name,
@@ -366,8 +381,6 @@ class CloudK8sService:
                 return None
             except ApiException as e:
                 raise KubectlError(f"get {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"get {resource.plural}/{name} failed: {e}") from e
 
     # -- list ----------------------------------------------------------------
 
@@ -399,7 +412,7 @@ class CloudK8sService:
         kwargs.update(self._request_timeout_kwargs())
         api = self._resource_api(resource)
         continue_token = ""
-        with slow_log(logger, f"list {resource.plural}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"list {resource.plural}"):
             while True:
                 page_kwargs = dict(kwargs, limit=_LIST_PAGE_LIMIT)
                 if continue_token:
@@ -408,8 +421,6 @@ class CloudK8sService:
                     result = api.get(**page_kwargs)
                 except ApiException as e:
                     raise KubectlError(f"list {resource.plural} failed ({e.status}): {e.reason}") from e
-                except TransportError as e:
-                    raise KubectlError(f"list {resource.plural} failed: {e}") from e
                 for item in result.items:
                     yield item.to_dict()
                 meta = result.metadata
@@ -439,15 +450,13 @@ class CloudK8sService:
             body["gracePeriodSeconds"] = 0
         if not wait:
             body["propagationPolicy"] = "Background"
-        with slow_log(logger, f"delete {resource.plural}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"delete {resource.plural}/{name}"):
             try:
                 self._resource_api(resource).delete(name=name, body=body, **kwargs)
             except NotFoundError:
                 return
             except ApiException as e:
                 raise KubectlError(f"delete {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"delete {resource.plural}/{name} failed: {e}") from e
 
     def delete_many(self, resource: K8sResource, names: list[str], *, force: bool = False, wait: bool = False) -> None:
         """Delete multiple resources by name."""
@@ -491,7 +500,7 @@ class CloudK8sService:
     def delete_pod_in_namespace(self, namespace: str, name: str) -> None:
         """Delete a pod in an explicit namespace, ignoring NotFound."""
         logger.info("k8s: DELETE pod %s/%s", namespace, name)
-        with slow_log(logger, f"delete pod {namespace}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"delete pod {namespace}/{name}"):
             try:
                 self._resource_api(K8sResource.PODS).delete(
                     name=name,
@@ -503,8 +512,6 @@ class CloudK8sService:
                 return
             except ApiException as e:
                 raise KubectlError(f"delete pod {namespace}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"delete pod {namespace}/{name} failed: {e}") from e
 
     # -- remove_finalizer ----------------------------------------------------
 
@@ -524,7 +531,7 @@ class CloudK8sService:
             return
         remaining = [f for f in finalizers if f != finalizer]
         logger.info("k8s: PATCH remove finalizer %s from %s/%s", finalizer, resource.plural, name)
-        with slow_log(logger, f"remove_finalizer {resource.plural}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"remove_finalizer {resource.plural}/{name}"):
             try:
                 self._resource_api(resource).patch(
                     body={"metadata": {"finalizers": remaining}},
@@ -537,8 +544,6 @@ class CloudK8sService:
                 return
             except ApiException as e:
                 raise KubectlError(f"remove_finalizer {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"remove_finalizer {resource.plural}/{name} failed: {e}") from e
 
     # -- set_image -----------------------------------------------------------
 
@@ -554,7 +559,7 @@ class CloudK8sService:
             }
         }
         logger.info("k8s: PATCH set_image %s/%s container=%s image=%s", resource.plural, name, container, image)
-        with slow_log(logger, f"set_image {resource.plural}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"set_image {resource.plural}/{name}"):
             try:
                 self._resource_api(resource).patch(
                     body=patch_body,
@@ -565,8 +570,6 @@ class CloudK8sService:
                 )
             except ApiException as e:
                 raise KubectlError(f"set_image {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"set_image {resource.plural}/{name} failed: {e}") from e
 
     # -- rollout_restart -----------------------------------------------------
 
@@ -585,7 +588,7 @@ class CloudK8sService:
             }
         }
         logger.info("k8s: PATCH rollout_restart %s/%s", resource.plural, name)
-        with slow_log(logger, f"rollout_restart {resource.plural}/{name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"rollout_restart {resource.plural}/{name}"):
             try:
                 self._resource_api(resource).patch(
                     body=patch_body,
@@ -596,8 +599,6 @@ class CloudK8sService:
                 )
             except ApiException as e:
                 raise KubectlError(f"rollout_restart {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
-            except TransportError as e:
-                raise KubectlError(f"rollout_restart {resource.plural}/{name} failed: {e}") from e
 
     # -- rollout_status ------------------------------------------------------
 
@@ -635,7 +636,7 @@ class CloudK8sService:
     def get_events(self, field_selector: str | None = None) -> list[dict]:
         """Get Kubernetes events, optionally filtered by field selector."""
         logger.info("k8s: list events field_selector=%s", field_selector)
-        with slow_log(logger, "get_events", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call("get_events"):
             try:
                 kwargs: dict = {"namespace": self.namespace, "_request_timeout": self.timeout}
                 if field_selector:
@@ -646,15 +647,13 @@ class CloudK8sService:
                 if e.status == 404:
                     return []
                 raise
-            except TransportError as e:
-                raise KubectlError(f"list events failed: {e}") from e
 
     # -- logs ----------------------------------------------------------------
 
     def logs(self, pod_name: str, *, container: str | None = None, tail: int = 50, previous: bool = False) -> str:
         """Fetch logs from a Pod container."""
         logger.info("k8s: logs %s container=%s tail=%d previous=%s", pod_name, container, tail, previous)
-        with slow_log(logger, f"logs {pod_name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"logs {pod_name}"):
             try:
                 kwargs: dict = {
                     "name": pod_name,
@@ -670,8 +669,6 @@ class CloudK8sService:
                 if e.status == 404:
                     return ""
                 raise
-            except TransportError as e:
-                raise KubectlError(f"logs {pod_name} failed: {e}") from e
 
     # -- stream_logs ---------------------------------------------------------
 
@@ -690,7 +687,7 @@ class CloudK8sService:
         before parsing.
         """
         logger.info("k8s: stream_logs %s since=%s limit_bytes=%s", pod_name, since_time, limit_bytes)
-        with slow_log(logger, f"stream_logs {pod_name}", threshold_ms=_SLOW_THRESHOLD_MS):
+        with _k8s_call(f"stream_logs {pod_name}"):
             try:
                 kwargs: dict = {
                     "name": pod_name,
@@ -712,8 +709,6 @@ class CloudK8sService:
                 if e.status == 404:
                     return KubectlLogResult(lines=[], last_timestamp=since_time)
                 raise
-            except TransportError as e:
-                raise KubectlError(f"stream_logs {pod_name} failed: {e}") from e
 
         # When limit_bytes is active the response may be truncated mid-line.
         # Drop the trailing partial line by trimming to the last newline.

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -24,11 +24,17 @@ try:
     from kubernetes.client.exceptions import ApiException
     from kubernetes.dynamic import DynamicClient
     from kubernetes.dynamic.exceptions import NotFoundError
+
+    # The kubernetes client reports transport failures — connect and read timeouts,
+    # connection resets, retry exhaustion — as urllib3 errors rather than
+    # ApiException, so they need the same conversion to KubectlError.
+    from urllib3.exceptions import HTTPError as TransportError
 except ImportError:
     kubernetes = None  # type: ignore[assignment]
     ApiException = Exception  # type: ignore[assignment,misc]
     NotFoundError = Exception  # type: ignore[assignment,misc]
     DynamicClient = None  # type: ignore[assignment,misc]
+    TransportError = Exception  # type: ignore[assignment,misc]
 
 
 from rigging.log_setup import slow_log
@@ -156,8 +162,6 @@ class K8sService(Protocol):
         self,
         field_selector: str | None = None,
     ) -> list[dict]: ...
-
-    def node_resource_metrics(self, node_name: str) -> str: ...
 
     def read_file(
         self,
@@ -315,6 +319,8 @@ class CloudK8sService:
                 raise KubectlError(
                     f"apply {kind}/{name} failed ({e.status}): {e.reason} {(e.body or '')[:_ERROR_BODY_MAX_LEN]}"
                 ) from e
+            except TransportError as e:
+                raise KubectlError(f"apply {kind}/{name} failed: {e}") from e
 
     def _apply_pod(self, res: K8sResource, ns: str | None, manifest: dict) -> None:
         """Create the Pod if it is not already present (create-if-absent).
@@ -340,6 +346,8 @@ class CloudK8sService:
                 # leave it. A later reconcile re-applies once any deletion lands.
                 return
             raise
+        except TransportError as e:
+            raise KubectlError(f"create {res.plural} failed: {e}") from e
 
     # -- get -----------------------------------------------------------------
 
@@ -358,6 +366,8 @@ class CloudK8sService:
                 return None
             except ApiException as e:
                 raise KubectlError(f"get {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"get {resource.plural}/{name} failed: {e}") from e
 
     # -- list ----------------------------------------------------------------
 
@@ -398,6 +408,8 @@ class CloudK8sService:
                     result = api.get(**page_kwargs)
                 except ApiException as e:
                     raise KubectlError(f"list {resource.plural} failed ({e.status}): {e.reason}") from e
+                except TransportError as e:
+                    raise KubectlError(f"list {resource.plural} failed: {e}") from e
                 for item in result.items:
                     yield item.to_dict()
                 meta = result.metadata
@@ -434,6 +446,8 @@ class CloudK8sService:
                 return
             except ApiException as e:
                 raise KubectlError(f"delete {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"delete {resource.plural}/{name} failed: {e}") from e
 
     def delete_many(self, resource: K8sResource, names: list[str], *, force: bool = False, wait: bool = False) -> None:
         """Delete multiple resources by name."""
@@ -489,6 +503,8 @@ class CloudK8sService:
                 return
             except ApiException as e:
                 raise KubectlError(f"delete pod {namespace}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"delete pod {namespace}/{name} failed: {e}") from e
 
     # -- remove_finalizer ----------------------------------------------------
 
@@ -521,6 +537,8 @@ class CloudK8sService:
                 return
             except ApiException as e:
                 raise KubectlError(f"remove_finalizer {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"remove_finalizer {resource.plural}/{name} failed: {e}") from e
 
     # -- set_image -----------------------------------------------------------
 
@@ -547,6 +565,8 @@ class CloudK8sService:
                 )
             except ApiException as e:
                 raise KubectlError(f"set_image {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"set_image {resource.plural}/{name} failed: {e}") from e
 
     # -- rollout_restart -----------------------------------------------------
 
@@ -576,6 +596,8 @@ class CloudK8sService:
                 )
             except ApiException as e:
                 raise KubectlError(f"rollout_restart {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
+            except TransportError as e:
+                raise KubectlError(f"rollout_restart {resource.plural}/{name} failed: {e}") from e
 
     # -- rollout_status ------------------------------------------------------
 
@@ -624,6 +646,8 @@ class CloudK8sService:
                 if e.status == 404:
                     return []
                 raise
+            except TransportError as e:
+                raise KubectlError(f"list events failed: {e}") from e
 
     # -- logs ----------------------------------------------------------------
 
@@ -646,6 +670,8 @@ class CloudK8sService:
                 if e.status == 404:
                     return ""
                 raise
+            except TransportError as e:
+                raise KubectlError(f"logs {pod_name} failed: {e}") from e
 
     # -- stream_logs ---------------------------------------------------------
 
@@ -686,6 +712,8 @@ class CloudK8sService:
                 if e.status == 404:
                     return KubectlLogResult(lines=[], last_timestamp=since_time)
                 raise
+            except TransportError as e:
+                raise KubectlError(f"stream_logs {pod_name} failed: {e}") from e
 
         # When limit_bytes is active the response may be truncated mid-line.
         # Drop the trailing partial line by trimming to the last newline.
@@ -753,7 +781,7 @@ class CloudK8sService:
                         return ExecResult(returncode=resp.returncode, stdout=stdout, stderr=stderr)
                     finally:
                         resp.close()
-            except ApiException as e:
+            except (ApiException, TransportError) as e:
                 return ExecResult(returncode=1, stdout="", stderr=str(e))
 
     # -- read_file / rm_files ------------------------------------------------
@@ -768,25 +796,6 @@ class CloudK8sService:
     def rm_files(self, pod_name: str, paths: list[str], *, container: str | None = None) -> None:
         """Remove files inside a Pod container. Ignores missing files."""
         self.exec(pod_name, ["rm", "-f", *paths], container=container, timeout=10)
-
-    # -- node metrics ---------------------------------------------------------
-
-    def node_resource_metrics(self, node_name: str) -> str:
-        """Return kubelet ``metrics/resource`` text for one node."""
-        logger.debug("k8s: node resource metrics node=%s", node_name)
-        with slow_log(logger, "node_resource_metrics", threshold_ms=_SLOW_THRESHOLD_MS):
-            try:
-                response = self._core_v1.connect_get_node_proxy_with_path(
-                    name=node_name,
-                    path="metrics/resource",
-                    _preload_content=False,
-                    **self._request_timeout_kwargs(),
-                )
-                return response.data.decode("utf-8")
-            except ApiException as error:
-                raise KubectlError(
-                    f"get nodes/{node_name}/proxy/metrics/resource failed ({error.status}): {error.reason}"
-                ) from error
 
     # -- port_forward (subprocess-based) -------------------------------------
 

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -7,9 +7,10 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
+import urllib3
 from iris.cluster.platforms.k8s import service as k8s_service
 from iris.cluster.platforms.k8s.service import CloudK8sService
-from iris.cluster.platforms.k8s.types import K8sResource
+from iris.cluster.platforms.k8s.types import K8sResource, KubectlError
 
 
 class _FakeExecStream:
@@ -100,23 +101,6 @@ def test_crud_client_requires_kubernetes(monkeypatch, client_attr: str):
         getattr(svc, client_attr)
 
 
-def test_node_resource_metrics_decodes_raw_response():
-    metrics = b"# HELP container_cpu_usage_seconds_total CPU usage.\ncontainer_cpu_usage_seconds_total 1.5\n"
-    request: dict = {}
-
-    def get_metrics(**kwargs):
-        request.update(kwargs)
-        return SimpleNamespace(data=metrics)
-
-    svc = CloudK8sService(namespace="iris")
-    svc.__dict__["_core_v1"] = SimpleNamespace(connect_get_node_proxy_with_path=get_metrics)
-
-    assert svc.node_resource_metrics("worker-0") == metrics.decode()
-    assert request["name"] == "worker-0"
-    assert request["path"] == "metrics/resource"
-    assert request["_preload_content"] is False
-
-
 class _FakeApiServer:
     """Paginating stand-in for one DynamicClient resource handle.
 
@@ -172,6 +156,25 @@ def test_list_json_walks_all_pages():
     assert names == ["a", "b", "c", "d", "e"]
     # Every request carries a page limit: an unpaginated one is the wedge itself.
     assert [req.get("limit") for req in api.requests] == [k8s_service._LIST_PAGE_LIMIT] * 3
+
+
+def test_list_json_converts_transport_timeout_to_kubectl_error():
+    """A urllib3 timeout must surface as KubectlError, not escape the client boundary.
+
+    The node agent's collection loop catches KubectlError and skips the cycle; an
+    escaping transport error propagates out of its run loop and kills the agent.
+    """
+    svc = CloudK8sService(namespace="iris")
+
+    def timing_out(**kwargs):
+        raise urllib3.exceptions.ReadTimeoutError(None, "/api/v1/pods", "Read timed out. (read timeout=15.0)")
+
+    svc.__dict__["_dyn"] = SimpleNamespace(
+        resources=SimpleNamespace(get=lambda **kwargs: SimpleNamespace(get=timing_out))
+    )
+
+    with pytest.raises(KubectlError, match="list pods failed"):
+        svc.list_json(K8sResource.PODS)
 
 
 def test_iter_json_stops_fetching_when_abandoned():

--- a/lib/iris/tests/cluster/node_agent/test_kubernetes.py
+++ b/lib/iris/tests/cluster/node_agent/test_kubernetes.py
@@ -11,8 +11,10 @@ network, and DCGM's ``hostname``/``gpu``/``modelName`` labels).
 
 import pytest
 from iris.cluster.node_agent.kubernetes import (
+    KubeletScrapeError,
     NodeStatsScraper,
     TaskStatsCollector,
+    kubelet_resource_metrics,
     parse_dcgm,
     parse_kubelet_resource_metrics,
     parse_node_exporter,
@@ -122,11 +124,16 @@ def test_task_stats_collector_writes_cpu_memory_and_peak():
     )
     table = FakeStatsTable()
     sampled_at = iter((100.0, 110.0))
-    collector = TaskStatsCollector(k8s, "node-a", table, clock=lambda: next(sampled_at))
-    k8s.set_node_resource_metrics(
-        "node-a",
+    kubelet_text = [
         'container_cpu_usage_seconds_total{container="task",pod="pod-a"} 10\n'
-        'container_memory_working_set_bytes{container="task",pod="pod-a"} 1073741824\n',
+        'container_memory_working_set_bytes{container="task",pod="pod-a"} 1073741824\n'
+    ]
+    collector = TaskStatsCollector(
+        k8s,
+        "node-a",
+        table,
+        clock=lambda: next(sampled_at),
+        read_kubelet_metrics=lambda: kubelet_text[0],
     )
 
     collector.collect_once()
@@ -137,16 +144,49 @@ def test_task_stats_collector_writes_cpu_memory_and_peak():
     assert first.memory_mb == 1024
     assert first.memory_peak_mb == 1024
 
-    k8s.set_node_resource_metrics(
-        "node-a",
+    kubelet_text[0] = (
         'container_cpu_usage_seconds_total{container="task",pod="pod-a"} 12\n'
-        'container_memory_working_set_bytes{container="task",pod="pod-a"} 536870912\n',
+        'container_memory_working_set_bytes{container="task",pod="pod-a"} 536870912\n'
     )
     collector.collect_once()
     second = table.writes[-1][0]
     assert second.cpu_millicores == 200
     assert second.memory_mb == 512
     assert second.memory_peak_mb == 1024
+
+
+def test_kubelet_resource_metrics_converts_transport_failure(monkeypatch):
+    """A socket timeout must become KubeletScrapeError, which the collector handles."""
+
+    def timing_out(*args, **kwargs):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(
+        "iris.cluster.node_agent.kubernetes.SERVICE_ACCOUNT_TOKEN_PATH",
+        _FakeTokenPath(),
+    )
+    monkeypatch.setattr("urllib.request.urlopen", timing_out)
+
+    with pytest.raises(KubeletScrapeError, match="scrape failed"):
+        kubelet_resource_metrics()
+
+
+class _FakeTokenPath:
+    def read_text(self) -> str:
+        return "token\n"
+
+
+def test_task_stats_collector_skips_cycle_when_kubelet_scrape_fails():
+    k8s = InMemoryK8sService(namespace="iris")
+    table = FakeStatsTable()
+
+    def unavailable() -> str:
+        raise KubeletScrapeError("connection refused")
+
+    collector = TaskStatsCollector(k8s, "node-a", table, read_kubelet_metrics=unavailable)
+    collector.collect_once()
+
+    assert table.writes == []
 
 
 def test_parse_node_exporter_extracts_host_readings():


### PR DESCRIPTION
The Kubernetes node agent reads its own kubelet's metrics/resource endpoint over
loopback instead of routing the request through the apiserver's nodes/proxy
subresource. Every sample previously crossed the cluster's Konnectivity tunnel,
the control-plane path that also carries exec, port-forward, and logs. On
cw-rno2a that was 65 agents at roughly 2.2 requests per second and about 33 KiB
per response, and while the control plane was congested a third of those
requests were failing with 503. After the rollout the cluster's nodes/proxy rate
measures 0.00/s on a replica-pinned 60-second window, against 776,931 cumulative
requests before it, and task stats keep landing in finelog.

The agent already runs on the host network, so the kubelet is reachable at
127.0.0.1:10250. The kubelet authorizes that endpoint against the nodes/metrics
subresource rather than nodes/proxy, so the controller ClusterRole grants
nodes/metrics; IaC owns that role and renders it from these shared manifest
builders, so the stacks must be applied before the agents roll or the new agents
403. The kubelet's serving certificate is issued by the node and does not verify
against the service-account CA bundle, so the loopback connection does not
verify it.

The kubernetes client reports transport failures as urllib3 errors rather than
ApiException, so a read timeout escaped every call site in the k8s service
wrapper. In the node agent that exception propagated out of the collection loop
and terminated the process, and the kubelet restarted it straight back into the
same scrape; agents on cw-rno2a had accumulated 11 to 24 restarts each, two of
them above 50. A _k8s_call context manager now wraps the existing slow_log
timing and converts those errors to KubectlError once, naming the operation for
both the slow-call warning and the raised error. Call sites that select handling
from a status code keep their own except ApiException; exec keeps a combined
clause because it reports failure as an ExecResult, and delete_many and
delete_by_labels issue no direct API calls.

The node agent's apiserver timeout moves from 2 to 15 seconds. The 2-second
value was tripping whenever apiserver latency rose, which is what turned
congestion into a restart loop.

Deployed to cw-rno2a, cw-us-east-02a, cw-us-east-08a, and cw-us-west-04a, each
with a smoke job and, except for CI, a five-minute verify against a pre-restart
baseline. All four report healthy controllers with node counts unchanged. The
deployed trees predate the error-translation consolidation, which is
behavior-preserving.
