### PR TITLE
[iris] Scope node-agent dcgm discovery to its own node

### DIFF
--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -366,6 +366,16 @@ class HostSample:
 
 
 @dataclass(frozen=True)
+class _DcgmExporter:
+    """One dcgm-exporter pod's scrape address and the identity of what it reports."""
+
+    name: str
+    url: str
+    uid: str
+    node_name: str
+
+
+@dataclass(frozen=True)
 class _DcgmMetricSpec:
     name: str
     unit: str = ""
@@ -656,10 +666,10 @@ class NodeStatsScraper:
         self._fetch = fetch
         self._max_workers = max_workers
         self._prev_cpu: dict[str, tuple[float, float]] = {}
-        # node name -> its dcgm-exporter pods. The exporter is a DaemonSet pod whose
-        # address only moves when it restarts, so discovery is cached until a scrape
-        # of that node's exporter fails.
-        self._dcgm_pods_by_node: dict[str, list[dict]] = {}
+        # node name -> its dcgm exporters. The exporter is a DaemonSet pod whose address
+        # moves only when it restarts, so discovery is cached until a pass reads nothing
+        # from that node.
+        self._dcgm_exporters_by_node: dict[str, list[_DcgmExporter]] = {}
 
     def scrape(self, targets: list[NodeTarget]) -> dict[str, NodeMetrics]:
         """Return per-node metrics for ``targets`` (best-effort; missing nodes omitted)."""
@@ -716,24 +726,19 @@ class NodeStatsScraper:
     def _prune_prev(self, live: set[str]) -> None:
         for stale in self._prev_cpu.keys() - live:
             del self._prev_cpu[stale]
-        for stale in self._dcgm_pods_by_node.keys() - live:
-            del self._dcgm_pods_by_node[stale]
+        for stale in self._dcgm_exporters_by_node.keys() - live:
+            del self._dcgm_exporters_by_node[stale]
 
     def _scrape_hosts(self, targets: list[NodeTarget]) -> dict[str, HostSample]:
         urls = {t.name: f"http://{t.internal_ip}:{self._node_port}/metrics" for t in targets if t.internal_ip}
         texts = self._fetch_all(urls)
         return {name: parse_node_exporter(text) for name, text in texts.items()}
 
-    def _dcgm_pods(self, node_name: str) -> list[dict]:
-        """Return the addressable dcgm-exporter pods running on ``node_name``.
+    def _dcgm_exporters(self, node_name: str) -> list[_DcgmExporter]:
+        """Return the scrapeable dcgm exporters on ``node_name``.
 
-        Both selectors are applied server-side. The exporters namespace holds one
-        pod per exporter per node, so an unfiltered list would ship every node's
-        exporters to every agent on every collection pass.
-
-        Pods without a ``podIP`` are dropped rather than returned: a replacement
-        exporter that is scheduled but not yet running has no address to scrape, so
-        caching it would strand the node until the agent restarts.
+        Both selectors are applied server-side. Pods with no ``podIP`` are omitted
+        because they have no address to scrape.
         """
         try:
             pods = list(
@@ -747,46 +752,57 @@ class NodeStatsScraper:
         except Exception as e:
             logger.debug("node-metrics: listing dcgm exporters in %s failed: %s", self._ns, e)
             return []
-        return [pod for pod in pods if pod.get("status", {}).get("podIP")]
+        exporters = []
+        for pod in pods:
+            metadata = pod.get("metadata", {})
+            name = metadata.get("name", "")
+            pod_ip = pod.get("status", {}).get("podIP")
+            if not name or not pod_ip:
+                continue
+            exporters.append(
+                _DcgmExporter(
+                    name=name,
+                    url=f"http://{pod_ip}:{self._dcgm_port}/metrics",
+                    uid=metadata.get("uid", ""),
+                    node_name=pod.get("spec", {}).get("nodeName", node_name),
+                )
+            )
+        return exporters
 
-    def _discover_dcgm_pods(self, node_name: str) -> list[dict]:
-        """Return ``node_name``'s cached dcgm-exporter pods, discovering them if needed.
+    def _discover_dcgm_exporters(self, node_name: str) -> list[_DcgmExporter]:
+        """Return ``node_name``'s cached exporters, discovering them when the cache is cold.
 
-        An empty result is not cached, so a node whose exporter has not started yet
-        is retried on the next pass.
+        An empty result is not cached, so a node whose exporter has not started yet is
+        retried on the next pass.
         """
-        cached = self._dcgm_pods_by_node.get(node_name)
+        cached = self._dcgm_exporters_by_node.get(node_name)
         if cached:
             return cached
-        pods = self._dcgm_pods(node_name)
-        if pods:
-            self._dcgm_pods_by_node[node_name] = pods
-        return pods
+        exporters = self._dcgm_exporters(node_name)
+        if exporters:
+            self._dcgm_exporters_by_node[node_name] = exporters
+        return exporters
 
     def _scrape_gpus(self, node_names: set[str]) -> dict[str, GpuSample]:
-        dcgm_pods = [pod for node_name in sorted(node_names) for pod in self._discover_dcgm_pods(node_name)]
-        exporters: dict[str, tuple[str, str, str]] = {}
-        for pod in dcgm_pods:
-            pod_ip = pod.get("status", {}).get("podIP")
-            name = pod.get("metadata", {}).get("name", "")
-            uid = pod.get("metadata", {}).get("uid", "")
-            node_name = pod.get("spec", {}).get("nodeName", "")
-            if pod_ip and name:
-                exporters[name] = (f"http://{pod_ip}:{self._dcgm_port}/metrics", uid, node_name)
+        exporters = {
+            exporter.name: exporter
+            for node_name in sorted(node_names)
+            for exporter in self._discover_dcgm_exporters(node_name)
+        }
         merged: dict[str, GpuSample] = {}
-        urls = {name: endpoint[0] for name, endpoint in exporters.items()}
-        for name, text in self._fetch_all(urls).items():
-            _, uid, node_name = exporters[name]
+        texts = self._fetch_all({exporter.name: exporter.url for exporter in exporters.values()})
+        for name, text in texts.items():
+            exporter = exporters[name]
             try:
-                merged.update(parse_dcgm(text, exporter_uid=uid, node_name=node_name))
+                merged.update(parse_dcgm(text, exporter_uid=exporter.uid, node_name=exporter.node_name))
             except ValueError as error:
                 logger.warning("could not parse dcgm exporter %s: %s", name, error)
         # Drop the cached address of every node this pass could not read: the exporter
         # stopped answering, moved, or a recycled pod IP is serving another node's
         # metrics under its own hostname. Those nodes rediscover on the next pass.
-        for _, _, node_name in exporters.values():
-            if node_name not in merged:
-                self._dcgm_pods_by_node.pop(node_name, None)
+        for exporter in exporters.values():
+            if exporter.node_name not in merged:
+                self._dcgm_exporters_by_node.pop(exporter.node_name, None)
         return merged
 
     def _fetch_all(self, urls: dict[str, str]) -> dict[str, str]:

--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -95,7 +95,6 @@ _MAX_SCRAPE_WORKERS = 16
 _MAX_SCRAPE_BYTES = 16 << 20
 _MAX_DCGM_SAMPLES = 32_768
 _MAX_DCGM_DEVICES = 256
-_MAX_DCGM_EXPORTERS = 512
 
 # One injectable seam so tests exercise the parsing/aggregation without a network.
 Fetch = Callable[[str], str | None]
@@ -657,6 +656,10 @@ class NodeStatsScraper:
         self._fetch = fetch
         self._max_workers = max_workers
         self._prev_cpu: dict[str, tuple[float, float]] = {}
+        # node name -> its dcgm-exporter pods. The exporter is a DaemonSet pod whose
+        # address only moves when it restarts, so discovery is cached until a scrape
+        # of that node's exporter fails.
+        self._dcgm_pods_by_node: dict[str, list[dict]] = {}
 
     def scrape(self, targets: list[NodeTarget]) -> dict[str, NodeMetrics]:
         """Return per-node metrics for ``targets`` (best-effort; missing nodes omitted)."""
@@ -713,28 +716,57 @@ class NodeStatsScraper:
     def _prune_prev(self, live: set[str]) -> None:
         for stale in self._prev_cpu.keys() - live:
             del self._prev_cpu[stale]
+        for stale in self._dcgm_pods_by_node.keys() - live:
+            del self._dcgm_pods_by_node[stale]
 
     def _scrape_hosts(self, targets: list[NodeTarget]) -> dict[str, HostSample]:
         urls = {t.name: f"http://{t.internal_ip}:{self._node_port}/metrics" for t in targets if t.internal_ip}
         texts = self._fetch_all(urls)
         return {name: parse_node_exporter(text) for name, text in texts.items()}
 
-    def _scrape_gpus(self, node_names: set[str]) -> dict[str, GpuSample]:
+    def _dcgm_pods(self, node_name: str) -> list[dict]:
+        """Return the addressable dcgm-exporter pods running on ``node_name``.
+
+        Both selectors are applied server-side. The exporters namespace holds one
+        pod per exporter per node, so an unfiltered list would ship every node's
+        exporters to every agent on every collection pass.
+
+        Pods without a ``podIP`` are dropped rather than returned: a replacement
+        exporter that is scheduled but not yet running has no address to scrape, so
+        caching it would strand the node until the agent restarts.
+        """
         try:
-            pods = self._kubectl.list_pods_in_namespace(self._ns)
+            pods = list(
+                self._kubectl.iter_json(
+                    K8sResource.PODS,
+                    namespace=self._ns,
+                    labels={_DCGM_NAME_LABEL: _DCGM_NAME_VALUE},
+                    field_selector=f"spec.nodeName={node_name}",
+                )
+            )
         except Exception as e:
             logger.debug("node-metrics: listing dcgm exporters in %s failed: %s", self._ns, e)
-            return {}
-        dcgm_pods = [
-            pod
-            for pod in pods
-            if pod.get("metadata", {}).get("labels", {}).get(_DCGM_NAME_LABEL) == _DCGM_NAME_VALUE
-            and pod.get("spec", {}).get("nodeName", "") in node_names
-        ]
-        if len(dcgm_pods) > _MAX_DCGM_EXPORTERS:
-            logger.warning("dcgm exporter count exceeded %d", _MAX_DCGM_EXPORTERS)
+            return []
+        return [pod for pod in pods if pod.get("status", {}).get("podIP")]
+
+    def _discover_dcgm_pods(self, node_name: str) -> list[dict]:
+        """Return ``node_name``'s cached dcgm-exporter pods, discovering them if needed.
+
+        An empty result is not cached, so a node whose exporter has not started yet
+        is retried on the next pass.
+        """
+        cached = self._dcgm_pods_by_node.get(node_name)
+        if cached:
+            return cached
+        pods = self._dcgm_pods(node_name)
+        if pods:
+            self._dcgm_pods_by_node[node_name] = pods
+        return pods
+
+    def _scrape_gpus(self, node_names: set[str]) -> dict[str, GpuSample]:
+        dcgm_pods = [pod for node_name in sorted(node_names) for pod in self._discover_dcgm_pods(node_name)]
         exporters: dict[str, tuple[str, str, str]] = {}
-        for pod in dcgm_pods[:_MAX_DCGM_EXPORTERS]:
+        for pod in dcgm_pods:
             pod_ip = pod.get("status", {}).get("podIP")
             name = pod.get("metadata", {}).get("name", "")
             uid = pod.get("metadata", {}).get("uid", "")
@@ -749,6 +781,12 @@ class NodeStatsScraper:
                 merged.update(parse_dcgm(text, exporter_uid=uid, node_name=node_name))
             except ValueError as error:
                 logger.warning("could not parse dcgm exporter %s: %s", name, error)
+        # Drop the cached address of every node this pass could not read: the exporter
+        # stopped answering, moved, or a recycled pod IP is serving another node's
+        # metrics under its own hostname. Those nodes rediscover on the next pass.
+        for _, _, node_name in exporters.values():
+            if node_name not in merged:
+                self._dcgm_pods_by_node.pop(node_name, None)
         return merged
 
     def _fetch_all(self, urls: dict[str, str]) -> dict[str, str]:

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -274,6 +274,9 @@ class InMemoryK8sService:
         # Every explicit-namespace pod call as (operation, namespace), so
         # tests can assert the eviction feature stays silent when disabled.
         self.namespaced_pod_calls: list[tuple[str, str]] = []
+        # Every explicit-namespace pod list as (namespace, labels, field_selector), so
+        # tests can assert a caller filters server-side instead of listing everything.
+        self.namespaced_pod_list_selectors: list[tuple[str, dict[str, str] | None, str | None]] = []
 
         # Node model
         self._nodes: dict[str, FakeNode] = {}
@@ -590,9 +593,26 @@ class InMemoryK8sService:
         field_selector: str | None = None,
         namespace: str | None = None,
     ) -> Iterator[dict]:
-        # The fake holds one namespace, so an override resolves to the same store; it
-        # is accepted so the fake still stands in for cross-namespace reads.
-        yield from self.list_json(resource, labels=labels, field_selector=field_selector)
+        self._check_failure("iter_json")
+        if namespace is None or namespace == self._namespace:
+            yield from self.list_json(resource, labels=labels, field_selector=field_selector)
+            return
+        if resource is not K8sResource.PODS:
+            raise NotImplementedError(f"the fake stores no foreign-namespace {resource.plural}")
+        # A foreign namespace reads the store seeded by seed_namespaced_pod. The selectors
+        # are applied here because the real service applies them server-side; the recorded
+        # pair lets tests pin that they were pushed down rather than filtered by the caller.
+        self.namespaced_pod_calls.append(("list", namespace))
+        self.namespaced_pod_list_selectors.append((namespace, labels, field_selector))
+        for (pod_namespace, _), manifest in self._namespaced_pods.items():
+            if pod_namespace != namespace:
+                continue
+            pod_labels = manifest.get("metadata", {}).get("labels", {})
+            if labels and not all(pod_labels.get(key) == value for key, value in labels.items()):
+                continue
+            if field_selector and not _matches_field_selector(manifest, field_selector):
+                continue
+            yield manifest
 
     def list_json(
         self,

--- a/lib/iris/tests/cluster/node_agent/test_kubernetes.py
+++ b/lib/iris/tests/cluster/node_agent/test_kubernetes.py
@@ -277,6 +277,111 @@ def test_scraper_discovers_dcgm_pods_and_merges_gpu_readings():
     assert metrics.mem_total_bytes == 2162529861632
 
 
+def test_scraper_only_scrapes_the_exporter_on_its_own_node():
+    k8s = InMemoryK8sService(namespace="iris")
+    for pod_name, node, pod_ip in [
+        ("dcgm-exporter-own", "g83d142", "10.9.9.9"),
+        ("dcgm-exporter-other", "g99", "10.7.7.7"),
+    ]:
+        k8s.seed_namespaced_pod(
+            "cw-exporters",
+            pod_name,
+            {
+                "metadata": {"name": pod_name, "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
+                "spec": {"nodeName": node},
+                "status": {"podIP": pod_ip},
+            },
+        )
+    fetched: list[str] = []
+
+    def record(url: str) -> str | None:
+        fetched.append(url)
+        return {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT, "http://10.9.9.9:9400/metrics": DCGM_TEXT}.get(url)
+
+    scraper = NodeStatsScraper(k8s, fetch=record)
+    metrics = scraper.scrape([NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")])["g83d142"]
+
+    assert metrics.gpu_count == 2
+    assert "http://10.7.7.7:9400/metrics" not in fetched
+    # The node filter must reach the apiserver: listing the namespace and discarding
+    # the other nodes' exporters locally is what overloaded the control plane.
+    assert k8s.namespaced_pod_list_selectors == [
+        ("cw-exporters", {"app.kubernetes.io/name": "dcgm-exporter"}, "spec.nodeName=g83d142")
+    ]
+
+
+def _dcgm_pod(name: str, node: str, pod_ip: str | None) -> dict:
+    status = {"podIP": pod_ip} if pod_ip else {}
+    return {
+        "metadata": {"name": name, "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
+        "spec": {"nodeName": node},
+        "status": status,
+    }
+
+
+def test_scraper_rediscovers_an_exporter_that_had_no_address_yet():
+    """A scheduled-but-not-running exporter must not be cached; nothing would evict it."""
+    k8s = InMemoryK8sService(namespace="iris")
+    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", None))
+    answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT}
+    scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
+    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
+
+    assert scraper.scrape(targets)["g83d142"].dcgm_available is False
+
+    # The pod gets its address; the next pass must pick it up rather than serve a
+    # cached, unscrapeable manifest forever.
+    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", "10.9.9.9"))
+    answers["http://10.9.9.9:9400/metrics"] = DCGM_TEXT
+
+    assert scraper.scrape(targets)["g83d142"].gpu_count == 2
+
+
+def test_scraper_rediscovers_when_the_cached_address_stops_serving_this_node():
+    """A recycled pod IP answers 200 without this node's readings; the entry must not stick."""
+    k8s = InMemoryK8sService(namespace="iris")
+    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", "10.9.9.9"))
+    answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT, "http://10.9.9.9:9400/metrics": DCGM_TEXT}
+    scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
+    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
+
+    scraper.scrape(targets)
+    listed = k8s.namespaced_pod_calls.count(("list", "cw-exporters"))
+
+    answers["http://10.9.9.9:9400/metrics"] = 'DCGM_FI_DEV_FB_USED{gpu="0"} not-a-number\n'
+    scraper.scrape(targets)
+    scraper.scrape(targets)
+
+    assert k8s.namespaced_pod_calls.count(("list", "cw-exporters")) > listed
+
+
+def test_scraper_caches_dcgm_discovery_until_a_scrape_fails():
+    k8s = InMemoryK8sService(namespace="iris")
+    k8s.seed_namespaced_pod(
+        "cw-exporters",
+        "dcgm-exporter-abc",
+        {
+            "metadata": {"name": "dcgm-exporter-abc", "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
+            "spec": {"nodeName": "g83d142"},
+            "status": {"podIP": "10.9.9.9"},
+        },
+    )
+    answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT, "http://10.9.9.9:9400/metrics": DCGM_TEXT}
+    scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
+    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
+
+    scraper.scrape(targets)
+    scraper.scrape(targets)
+    assert k8s.namespaced_pod_calls.count(("list", "cw-exporters")) == 1
+
+    # The exporter stops answering at its cached address: that pass drops the entry,
+    # and the next one rediscovers.
+    del answers["http://10.9.9.9:9400/metrics"]
+    scraper.scrape(targets)
+    scraper.scrape(targets)
+    assert k8s.namespaced_pod_calls.count(("list", "cw-exporters")) == 2
+
+
 def test_scraper_missing_exporter_yields_empty_metrics():
     k8s = InMemoryK8sService(namespace="iris")
     scraper = NodeStatsScraper(k8s, fetch=_fetch_from({}))  # nothing answers

--- a/lib/iris/tests/cluster/node_agent/test_kubernetes.py
+++ b/lib/iris/tests/cluster/node_agent/test_kubernetes.py
@@ -277,21 +277,26 @@ def test_scraper_discovers_dcgm_pods_and_merges_gpu_readings():
     assert metrics.mem_total_bytes == 2162529861632
 
 
+def _seed_dcgm_pod(k8s: InMemoryK8sService, name: str, node: str, pod_ip: str | None) -> None:
+    """Seed one dcgm-exporter pod, optionally still waiting on its address."""
+    k8s.seed_namespaced_pod(
+        "cw-exporters",
+        name,
+        {
+            "metadata": {"name": name, "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
+            "spec": {"nodeName": node},
+            "status": {"podIP": pod_ip} if pod_ip else {},
+        },
+    )
+
+
+_TARGETS = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
+
+
 def test_scraper_only_scrapes_the_exporter_on_its_own_node():
     k8s = InMemoryK8sService(namespace="iris")
-    for pod_name, node, pod_ip in [
-        ("dcgm-exporter-own", "g83d142", "10.9.9.9"),
-        ("dcgm-exporter-other", "g99", "10.7.7.7"),
-    ]:
-        k8s.seed_namespaced_pod(
-            "cw-exporters",
-            pod_name,
-            {
-                "metadata": {"name": pod_name, "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
-                "spec": {"nodeName": node},
-                "status": {"podIP": pod_ip},
-            },
-        )
+    _seed_dcgm_pod(k8s, "dcgm-exporter-own", "g83d142", "10.9.9.9")
+    _seed_dcgm_pod(k8s, "dcgm-exporter-other", "g99", "10.7.7.7")
     fetched: list[str] = []
 
     def record(url: str) -> str | None:
@@ -310,69 +315,46 @@ def test_scraper_only_scrapes_the_exporter_on_its_own_node():
     ]
 
 
-def _dcgm_pod(name: str, node: str, pod_ip: str | None) -> dict:
-    status = {"podIP": pod_ip} if pod_ip else {}
-    return {
-        "metadata": {"name": name, "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
-        "spec": {"nodeName": node},
-        "status": status,
-    }
-
-
 def test_scraper_rediscovers_an_exporter_that_had_no_address_yet():
     """A scheduled-but-not-running exporter must not be cached; nothing would evict it."""
     k8s = InMemoryK8sService(namespace="iris")
-    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", None))
+    _seed_dcgm_pod(k8s, "dcgm-exporter-abc", "g83d142", None)
     answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT}
     scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
-    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
 
-    assert scraper.scrape(targets)["g83d142"].dcgm_available is False
+    assert scraper.scrape(_TARGETS)["g83d142"].dcgm_available is False
 
-    # The pod gets its address; the next pass must pick it up rather than serve a
-    # cached, unscrapeable manifest forever.
-    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", "10.9.9.9"))
+    _seed_dcgm_pod(k8s, "dcgm-exporter-abc", "g83d142", "10.9.9.9")
     answers["http://10.9.9.9:9400/metrics"] = DCGM_TEXT
 
-    assert scraper.scrape(targets)["g83d142"].gpu_count == 2
+    assert scraper.scrape(_TARGETS)["g83d142"].gpu_count == 2
 
 
 def test_scraper_rediscovers_when_the_cached_address_stops_serving_this_node():
-    """A recycled pod IP answers 200 without this node's readings; the entry must not stick."""
+    """An address that answers without this node's readings must not stay cached."""
     k8s = InMemoryK8sService(namespace="iris")
-    k8s.seed_namespaced_pod("cw-exporters", "dcgm-exporter-abc", _dcgm_pod("dcgm-exporter-abc", "g83d142", "10.9.9.9"))
+    _seed_dcgm_pod(k8s, "dcgm-exporter-abc", "g83d142", "10.9.9.9")
     answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT, "http://10.9.9.9:9400/metrics": DCGM_TEXT}
     scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
-    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
 
-    scraper.scrape(targets)
-    listed = k8s.namespaced_pod_calls.count(("list", "cw-exporters"))
+    assert scraper.scrape(_TARGETS)["g83d142"].gpu_count == 2
 
+    # The exporter restarts at a new address and something else now answers on the old
+    # one. The stale entry can only be evicted by noticing the readings stopped.
     answers["http://10.9.9.9:9400/metrics"] = 'DCGM_FI_DEV_FB_USED{gpu="0"} not-a-number\n'
-    scraper.scrape(targets)
-    scraper.scrape(targets)
+    _seed_dcgm_pod(k8s, "dcgm-exporter-abc", "g83d142", "10.9.9.10")
+    answers["http://10.9.9.10:9400/metrics"] = DCGM_TEXT
 
-    assert k8s.namespaced_pod_calls.count(("list", "cw-exporters")) > listed
+    scraper.scrape(_TARGETS)
+    assert scraper.scrape(_TARGETS)["g83d142"].gpu_count == 2
 
 
 def test_scraper_caches_dcgm_discovery_until_a_scrape_fails():
     k8s = InMemoryK8sService(namespace="iris")
-    k8s.seed_namespaced_pod(
-        "cw-exporters",
-        "dcgm-exporter-abc",
-        {
-            "metadata": {"name": "dcgm-exporter-abc", "labels": {"app.kubernetes.io/name": "dcgm-exporter"}},
-            "spec": {"nodeName": "g83d142"},
-            "status": {"podIP": "10.9.9.9"},
-        },
-    )
+    _seed_dcgm_pod(k8s, "dcgm-exporter-abc", "g83d142", "10.9.9.9")
     answers = {"http://g83d142:9100/metrics": NODE_EXPORTER_TEXT, "http://10.9.9.9:9400/metrics": DCGM_TEXT}
     scraper = NodeStatsScraper(k8s, fetch=lambda url: answers.get(url))
-    targets = [NodeTarget(name="g83d142", node_uid="node-uid-1", internal_ip="g83d142")]
-
-    scraper.scrape(targets)
-    scraper.scrape(targets)
-    assert k8s.namespaced_pod_calls.count(("list", "cw-exporters")) == 1
+    targets = _TARGETS
 
     # The exporter stops answering at its cached address: that pass drops the entry,
     # and the next one rediscovers.


### PR DESCRIPTION
Every node agent listed the whole `cw-exporters` namespace on each collection
pass to find the one dcgm-exporter pod on its own node, then filtered
client-side. That namespace holds 386 pods on cw-rno2a and 1018 on
cw-us-east-08a, so a single list returns 3.9 MB and 5.0 MB against 65 and 206
agents.

Discovery now sends the exporter label and `spec.nodeName` as server-side
selectors, and caches the result per node because the exporter is a DaemonSet
pod whose address moves only when it restarts. A node's entry is dropped
whenever a pass yields no readings for it, which covers an exporter that stopped
answering, one that moved, and a recycled pod IP serving another node's metrics
under its own hostname. Pods with no podIP are never cached, so an exporter that
is scheduled but not yet running is retried rather than stranding the node until
the agent process restarts.

Measured on one apiserver replica per cluster, before and after deploying to all
four CoreWeave clusters:

| cluster | pod-list response bytes | namespaced pods LIST |
| --- | --- | --- |
| cw-rno2a (65 agents) | 3.80 -> 0.91 MB/s | 1.45 -> 0.52 req/s |
| cw-us-east-08a (206 agents) | 19.13 -> 0.45 MB/s | 5.78 -> 1.28 req/s |

The rno2a pair is same-replica verified. The 08a pair selects samples by
counter monotonicity across a 122s window, because that cluster's replicas can
share `process_start_time_seconds` to within 10ms, so treat its absolute rates
as approximate.

This is apiserver load rather than Konnectivity tunnel bytes, so it does not by
itself explain the 27x tunnel spike on 2026-08-26; it removes a large measured
load source from the same control plane that services the tunnel's dials.

The exporter-count cap is gone: the only caller scrapes a single node, so it
could not trip.

The in-memory Kubernetes fake ignored the namespace override on `iter_json` and
answered from its own namespace's store. Foreign-namespace pod reads now go
through the store seeded by `seed_namespaced_pod` with the selectors applied, and
record them so a test can assert the filtering happens server-side rather than in
the caller.
