### PR TITLE
[echo] Serve dashboard in one response

### DIFF
--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -114,8 +114,10 @@ case-insensitive literal substring scan over activity, newest first.
 
 The API runs four ONNX inference threads on each 4-vCPU Cloud Run instance. Request-based
 billing retains one warm instance, admits one request per instance, and scales concurrent
-searches out to at most four instances. Startup CPU boost reduces model initialization time
-for burst instances without allocating CPU to idle instances continuously.
+searches out to at most four instances. The production dashboard bundles its JavaScript,
+styles, and fonts into the HTML response so an uncached page load does not consume that
+single-request capacity with parallel static assets. Startup CPU boost reduces model
+initialization time for burst instances without allocating CPU to idle instances continuously.
 
 CLI search prints one result block with an execution-specific grading key, title,
 source ID, and one primary source excerpt of at most 240 characters. File results use

--- a/infra/echo/api/Dockerfile
+++ b/infra/echo/api/Dockerfile
@@ -5,6 +5,9 @@ COPY dashboard/package.json dashboard/package-lock.json ./
 RUN npm ci
 COPY dashboard/ ./
 RUN npm run build
+# Echo admits one request per Cloud Run instance. Keep first paint in the HTML response
+# so an uncached dashboard load does not start model-serving instances for static assets.
+RUN test "$(find dist -type f | wc -l)" -eq 1
 
 FROM python:3.12-slim AS runtime
 

--- a/infra/echo/dashboard/rsbuild.config.ts
+++ b/infra/echo/dashboard/rsbuild.config.ts
@@ -13,8 +13,18 @@ export default defineConfig({
   output: {
     distPath: { root: 'dist' },
     assetPrefix: 'auto',
+    dataUriLimit: { font: 40_000 },
+    inlineScripts: true,
+    inlineStyles: true,
+    legalComments: 'inline',
+  },
+  // Cloud Run admits one request per Echo instance so CPU-bound searches scale out.
+  // Keep the dashboard in one response instead of scaling out for its initial assets.
+  performance: {
+    chunkSplit: { strategy: 'all-in-one' },
   },
   html: {
+    inject: 'body',
     template: './src/template.html',
     templateParameters: { title: 'Echo · Marin' },
   },

--- a/infra/echo/dashboard/src/styles.css
+++ b/infra/echo/dashboard/src/styles.css
@@ -1,7 +1,22 @@
-@import '@fontsource-variable/noto-sans';
-@import '@fontsource-variable/noto-sans-mono';
 @import 'tailwindcss';
 @config '../tailwind.config.ts';
+
+@font-face {
+  font-family: 'Noto Sans Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('@fontsource-variable/noto-sans/files/noto-sans-latin-wght-normal.woff2') format('woff2-variations');
+}
+
+@font-face {
+  font-family: 'Noto Sans Mono Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('@fontsource-variable/noto-sans-mono/files/noto-sans-mono-latin-wght-normal.woff2')
+    format('woff2-variations');
+}
 
 :root {
   --color-cream: #f8f6ef;


### PR DESCRIPTION
Bundle the production dashboard's JavaScript, CSS, and Latin font subsets into
its HTML response. On an uncached `/wiki/226` load, the page HTML completed in
11 milliseconds while five parallel asset requests started three model-serving
instances. The entry JavaScript reached the container about 24 seconds after
navigation; `/api/wiki/226` was not called until refresh and completed in 22
milliseconds.

The production build now emits one 292 KB file (138 KB gzip) and rejects
additional files. Echo retains one warm request-based instance, scales to four
for burst searches, and admits one request per instance.

Incident: https://echo.oa.dev/wiki/262
