### PR TITLE
[canary] Fail when TPU capacity is exhausted

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -23,6 +23,8 @@ jobs:
   canary-ferry:
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    outputs:
+      resource_exhausted: ${{ steps.wait.outputs.resource_exhausted }}
     concurrency:
       group: canary-ferry
       cancel-in-progress: true
@@ -223,12 +225,18 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      - name: Mark resource exhaustion as failure
+        if: steps.wait.outputs.resource_exhausted == 'true'
+        run: |
+          echo "The TPU canary did not run because Iris could not admit TPU capacity." >&2
+          exit 1
+
   # Separate job so Slack always fires, even if the main job is force-killed
   # after its grace window. `needs.canary-ferry.result` reflects the main job
   # outcome; failure()/cancelled() context functions only see this job's steps.
   notify-slack:
     needs: canary-ferry
-    if: always() && (needs.canary-ferry.result == 'failure' || needs.canary-ferry.result == 'cancelled') && github.event_name == 'schedule'
+    if: always() && (needs.canary-ferry.result == 'failure' || needs.canary-ferry.result == 'cancelled') && needs.canary-ferry.outputs.resource_exhausted != 'true' && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Make the TPU canary fail when Iris cannot admit the requested TPU capacity.
Iris still cancels the waiting job cleanly; a final workflow step then exits
nonzero, so GitHub and Grafana no longer record a no-training success.

Scheduled capacity outcomes skip Slack. Other failures retain diagnostics and
Slack notification. Successful runs still require metrics validation.

[Run 33423728535](https://github.com/marin-community/marin/actions/runs/33423728535)
tested exact head `590e8d190c0aef95eba54ac282e16f1246a0b07a` on a real v6e-4 in
`us-east5-b`. It completed 237 steps with final loss 5.7976 against limits of
200 steps and 8.0, and left both Iris jobs terminal. All eight focused Iris
monitor tests pass. The optional profile summary could not find
`trainer.log_dir`; it is non-blocking and did not affect the gates.

That run covers the normal path. [Scheduled run
32939622815](https://github.com/marin-community/marin/actions/runs/32939622815)
produced the real `RESOURCE_EXHAUSTED` signal under the old workflow. Focused
tests cover that output and cleanup. A natural stockout has not exercised the
new final GitHub failure step end to end.
