### PR TITLE
Fix Megablox tiling across ragged-dot gradients

### DIFF
--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -85,17 +85,21 @@ def _megablox_tile_size() -> tuple[int, int, int]:
     return _MEGABLOX_TILE_DEFAULT
 
 
+def _megablox_tiling(m: int, k: int, n: int) -> tuple[int, int, int]:
+    """Choose a Megablox tile for the shape of each forward or VJP GMM."""
+    tile_size = _megablox_tile_size()
+    return min(m, tile_size[0]), min(k, tile_size[1]), min(n, tile_size[2])
+
+
 def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
     if _gmm_megablox is None:
         raise NotImplementedError("megablox GMM is not available (TPU-only)")
-    tile_size = _megablox_tile_size()
-    m, k, n = lhs.shape[0], lhs.shape[1], rhs.shape[2]
     return _gmm_megablox(
         lhs,
         rhs,
         group_sizes,
         preferred_element_type=lhs.dtype,
-        tiling=(min(m, tile_size[0]), min(k, tile_size[1]), min(n, tile_size[2])),
+        tiling=_megablox_tiling,
         interpret=jax.default_backend() == "cpu",
     )
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1078,17 +1078,25 @@ def test_expert_granular_a2a_params_chunked_masking_composes():
 
 
 @pytest.mark.parametrize("implementation", ["ring", "ragged_all_to_all"])
-def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(implementation: MoeImplementation):
+def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(
+    implementation: MoeImplementation,
+    monkeypatch: pytest.MonkeyPatch,
+):
     mesh = _make_ep_mesh_or_none()
     if mesh is None:
         pytest.skip("requires an even number of >=2 devices")
-    if jax.devices()[0].platform == "cpu":
+
+    platform = jax.devices()[0].platform
+    if platform == "cpu":
         pytest.skip("ragged_all_to_all is not implemented on XLA:CPU")
+    if platform == "tpu":
+        monkeypatch.setenv("RAGGED_DOT_IMPL", "megablox")
 
     tokens = len(jax.devices()) * 8
-    gpu_runtime = jax.devices()[0].platform == "gpu"
+    gpu_runtime = platform == "gpu"
     hidden_dim = 16 if gpu_runtime else 128
-    intermediate_dim = 24 if gpu_runtime else 128
+    # Keep the TPU GMM rectangular so its VJP must swap the K and N dimensions.
+    intermediate_dim = 24 if gpu_runtime else 16
     num_experts = 4
     topk = 2
     x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
@@ -1099,7 +1107,7 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(impl
         num_experts=num_experts,
         topk=topk,
     )
-    dtype = jnp.bfloat16 if gpu_runtime else jnp.float32
+    dtype = jnp.bfloat16 if platform in {"gpu", "tpu"} else jnp.float32
     relative_tolerance = _BF16_MOE_RELATIVE_TOLERANCE if dtype == jnp.bfloat16 else _FP32_MOE_RELATIVE_TOLERANCE
     x = x.astype(dtype)
     combine_weights = combine_weights.astype(dtype)

--- a/lib/levanter/tests/kernels/test_pallas_mamba3.py
+++ b/lib/levanter/tests/kernels/test_pallas_mamba3.py
@@ -8,6 +8,7 @@ import math
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from levanter.kernels.pallas.mamba3 import (
     HybridModeConfig,
@@ -42,9 +43,14 @@ from levanter.kernels.pallas.mamba3.xla import mamba3_mimo_chunked_forward_ranke
 from levanter.kernels.pallas.ssd import intra_chunk_log_alpha_cumsum, local_log_alpha
 from levanter.testing.helpers import skip_if_no_torch
 
+
 # The parity tolerances below assume float32 matmuls. TPU defaults to lower-precision
 # passes for float32 inputs, which pushes the XLA-vs-reference gap past `1e-5`.
-jax.config.update("jax_default_matmul_precision", "float32")
+@pytest.fixture(scope="module", autouse=True)
+def _use_float32_matmul_precision():
+    with jax.default_matmul_precision("float32"):
+        yield
+
 
 MAMBA3_MIMO_RANKED_PARITY_ATOL = 1e-4
 MAMBA3_MIMO_RANKED_PARITY_RTOL = 1e-4

--- a/lib/levanter/tests/test_gdn_kernels.py
+++ b/lib/levanter/tests/test_gdn_kernels.py
@@ -11,7 +11,11 @@ from haliax import Axis
 from levanter.layers.gated_deltanet import chunk_gated_delta_rule, recurrent_gated_delta_rule
 from levanter.testing.helpers import skip_if_no_torch
 
-jax.config.update("jax_default_matmul_precision", "float32")
+
+@pytest.fixture(scope="module", autouse=True)
+def _use_float32_matmul_precision():
+    with jax.default_matmul_precision("float32"):
+        yield
 
 
 def _to_np(x):

--- a/lib/levanter/tests/test_gdn_layer.py
+++ b/lib/levanter/tests/test_gdn_layer.py
@@ -16,7 +16,11 @@ from levanter.layers.gated_deltanet import (
 )
 from levanter.testing.helpers import skip_if_no_torch
 
-jax.config.update("jax_default_matmul_precision", "float32")
+
+@pytest.fixture(scope="module", autouse=True)
+def _use_float32_matmul_precision():
+    with jax.default_matmul_precision("float32"):
+        yield
 
 
 def _np(x):

--- a/lib/levanter/tests/test_moe.py
+++ b/lib/levanter/tests/test_moe.py
@@ -72,7 +72,7 @@ def test_dense_router_delta_gradient_matches_naive_dense():
 
         return jax.grad(scalar)(logits)
 
-    with use_test_mesh():
+    with jax.default_matmul_precision("float32"), use_test_mesh():
         g_helper = jax.jit(helper_grad)(logits)
         g_naive = jax.jit(naive_grad)(logits)
 


### PR DESCRIPTION
The production failure and the later v5e CI failure had different causes.

Haliax now passes Megablox a tiling policy instead of freezing the forward GMM tile. JAX evaluates the policy for each transformed GMM, so forward and VJP calls each clamp their real `(m, k, n)` dimensions. The existing accelerator MoE regression forces Megablox on TPU and checks BF16 values, input gradients, weight gradients, finiteness, and overflow behavior for both `ring` and `ragged_a2a` expert parallelism.

The full v5e lane then exposed an unrelated pytest collection leak. Three test modules changed process-wide JAX matmul precision at import time. Collecting one of them was enough to turn the later BF16 Megablox lowering into FP32 and trigger Mosaic's `Bad lhs type`. Precision changes are now scoped to module fixtures, and the one strict downstream oracle requests FP32 inside its own test. No v5-only tile, workflow diagnostic, selector change, or VMEM workaround remains.

The squashed head `7339f798597a748ab090a20d2d106c24a7392a35` has Git tree `7c2b8ce49c7213930cc2ef02c37f84753602fbfb`, identical to qualified head `3dfe45750805f484fa378e952b7924a6f51d9f3b`; `git diff` between the two heads is empty. At that qualified tree:

- The [authoritative v5e workflow](https://github.com/marin-community/marin/actions/runs/33293007271) and [TPU job](https://github.com/marin-community/marin/actions/runs/33293007271/job/99207863146) passed both target variants and the full fixed lane: `1074 passed, 30 skipped, 171 deselected`.
- The one exact blank-input [canary ferry](https://github.com/marin-community/marin/actions/runs/33294173253) succeeded on production-priority preemptible v6e-4. Its [Iris child](https://iris.oa.dev/#/job/%2Frunner%2Firis-run-job-20260830-051314%2Fgrug-train-canary-tpu-33294173253-1) completed 238/238 steps with zero preemptions; the unchanged validator passed 237 recorded steps and final loss `5.7976 <= 8.0`.
- The canary preserved its [W&B run](https://wandb.ai/marin-community/marin/runs/canary-tpu-33294173253-1) and [direct XProf trace](https://iris.oa.dev/proxy/xprof/open?uri=gs%3A%2F%2Fmarin-eu-west4%2Ftmp%2Fttl%3D30d%2Fxprof%2Fcanary-tpu-33294173253-1&tool=trace_viewer).
- Changed-file checks, focused local regressions, and two independent High-reasoning reviews passed with no material findings.

The resolved CI collection incident and response are preserved in [Echo wiki #291](https://echo.oa.dev/wiki/291).

Fixes #8731.
Unblocks #8718.
