### PR TITLE
[rl] Validate SkyRL role plan group/batch consistency

### DIFF
--- a/lib/marin/src/marin/rl/skyrl.py
+++ b/lib/marin/src/marin/rl/skyrl.py
@@ -62,6 +62,19 @@ class SkyRLRolePlan:
     micro_train_batch_size_per_gpu: int
     n_samples_per_prompt: int
 
+    def __post_init__(self) -> None:
+        if self.n_samples_per_prompt < 2:
+            raise ValueError(
+                f"n_samples_per_prompt must be at least 2 so each rollout group has "
+                f"within-group variance for the GRPO advantage; got {self.n_samples_per_prompt}"
+            )
+        if self.train_batch_size % self.n_samples_per_prompt != 0:
+            raise ValueError(
+                f"train_batch_size ({self.train_batch_size}) must be divisible by "
+                f"n_samples_per_prompt ({self.n_samples_per_prompt}) so rollout groups "
+                f"are not split across batch boundaries"
+            )
+
 
 @dataclass(frozen=True)
 class SkyRLTopology:

--- a/tests/rl/test_skyrl.py
+++ b/tests/rl/test_skyrl.py
@@ -143,6 +143,21 @@ def test_skyrl_retention_allows_explicit_rollback_depth_up_to_five() -> None:
         SkyRLRetentionPolicy(resume_checkpoint_count=6)
 
 
+def test_skyrl_role_plan_requires_within_group_sampling() -> None:
+    """A single sample per prompt leaves every group with zero variance, hence no GRPO advantage."""
+
+    assert _role_plan().n_samples_per_prompt == 4
+    with pytest.raises(ValueError, match="at least 2"):
+        dataclasses.replace(_role_plan(), n_samples_per_prompt=1)
+
+
+def test_skyrl_role_plan_requires_whole_rollout_groups_per_batch() -> None:
+    """A batch boundary slicing through a rollout group corrupts the group-relative advantage."""
+
+    with pytest.raises(ValueError, match="divisible"):
+        dataclasses.replace(_role_plan(), train_batch_size=18)
+
+
 def test_skyrl_step_fingerprint_includes_runtime_identity_and_excludes_placement() -> None:
     spec = _spec()
     base = skyrl_step(spec, _execution())


### PR DESCRIPTION
## [rl] Validate SkyRL role plan group/batch consistency

### Summary

- Add `__post_init__` validation to `SkyRLRolePlan`, following the existing `SkyRLRetentionPolicy` validation pattern.
- Two invariants checked:
  1. `n_samples_per_prompt >= 2` — a group of one has zero within-group variance, so every GRPO advantage is zero and the run silently learns nothing.
  2. `train_batch_size % n_samples_per_prompt == 0` — a batch boundary slicing through a rollout group corrupts the group-relative advantage.

### Why

Both misconfigurations currently fail silently (or surface much later as mysteriously flat rewards / zero-advantage steps), which is hard to diagnose from cluster logs. Catching them at plan-construction time turns a multi-hour debugging session into an immediate, actionable error.

The group-size invariant follows directly from the GRPO objective: the advantage is computed within each rollout group, so a degenerate group (single sample) or a group split across batch boundaries invalidates the estimator rather than crashing the run.

### Testing

- `test_skyrl_role_plan_requires_within_group_sampling` — rejects `n_samples_per_prompt=1`
- `test_skyrl_role_plan_requires_whole_rollout_groups_per_batch` — rejects `train_batch_size=18` with groups of 4
- Verified existing configs unaffected:
  - `iceball_micro` role plan (batch 16 / groups 4) still valid
  - `test_skyrl_step_fingerprint_...`'s `dataclasses.replace(..., train_batch_size=32)` (mini 16 < train 32) still valid — the mini-vs-train relation is intentionally **not** validated, since `mini < train` is legitimate under multi-epoch iteration over a batch
