### PR TITLE
[datakit] Solve complete fuzzy-duplicate clusters

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/cluster_dedup.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/cluster_dedup.py
@@ -1,0 +1,297 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find duplicates inside a materialized fuzzy-duplicate candidate cluster.
+
+The shipped verifier compares each cluster member with at most two
+representatives, so roughly half the removals its own rule authorizes are never
+found. Given the cluster text grouped in one place, the whole cluster can be
+solved instead of sampled.
+
+A document is a duplicate when a *longer* surviving document already holds its
+content. Containment of word n-grams measures that directly, and the direction
+matters: a symmetric score such as Jaccard calls two documents duplicates when
+each holds text the other lacks, and removing either loses information.
+
+Cluster sizes are heavily skewed. Small clusters take an exact all-pairs scan.
+Large ones generate candidate pairs from a rare-n-gram inverted index, which
+needs no extra input and keeps the work near-linear.
+
+The solver is complete only within the cluster group it receives. The
+materializer can partition very large connected components with a MinHash key;
+that bound can separate containment pairs with low Jaccard similarity.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import dupekit
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+_EMPTY = np.empty(0, dtype=np.uint64)
+
+
+class ClusterDedupParams(BaseModel):
+    """Thresholds and work bounds for one cluster."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ngram_size: int = Field(default=3, ge=1)
+    minimum_containment: float = Field(default=0.60, ge=0, le=1)
+    """Share of the member's n-grams the representative must already hold.
+
+    Calibrated against 312 blind-labeled candidate pairs, stratified over five
+    content types. A near-duplicate survives light editing -- a changed word, a
+    curly quote, reflowed markup -- but every such edit destroys the n-grams
+    that span it, so a threshold near 1.0 rejects genuine duplicates. Verified
+    duplicates sit at 0.62 to 0.81, while pairs that connected components merged
+    by transitive closure sit near 0. At 0.60 the rule keeps 87.7% of true
+    duplicates against 11.3% for a 1.0 threshold, and 1.5% of what it accepts is
+    a genuinely different document.
+    """
+
+    exact_scan_maximum: int = Field(default=256, ge=2)
+    """Below this member count a cluster takes an exhaustive ordered-pair scan."""
+
+    probe_ngrams: int = Field(default=32, ge=1)
+    """How many of a member's rarest n-grams probe the inverted index."""
+
+    maximum_posting_length: int = Field(default=512, ge=1)
+    """N-grams held by more documents than this are boilerplate and are skipped."""
+
+    maximum_candidates: int = Field(default=32, ge=1)
+    """Maximum representatives checked for one member in the index path."""
+
+
+@dataclass(frozen=True)
+class ClusterDocument:
+    id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class PreparedDocument:
+    """N-gram hashes and the sizes the rule compares."""
+
+    index: int
+    chars: int
+    ngrams: np.ndarray
+    token_hashes: np.ndarray
+    text: str
+
+
+@dataclass(frozen=True)
+class Removal:
+    """One duplicate decision."""
+
+    member_index: int
+    representative_index: int
+    containment: float
+    jaccard: float
+    novel_tokens: int
+    comparisons: int
+
+
+def ngram_hashes(text: str, ngram_size: int) -> np.ndarray:
+    """Sorted unique 64-bit hashes of the case-folded word n-grams.
+
+    A 64-bit collision is unlikely for the bounded clusters this solver reads,
+    so the hash array stands in for the n-gram set.
+    """
+    tokens = text.casefold().split()
+    if not tokens:
+        return _EMPTY
+    if len(tokens) < ngram_size:
+        shingles = [" ".join(tokens).encode("utf-8", "surrogatepass")]
+    else:
+        shingles = [
+            " ".join(tokens[start : start + ngram_size]).encode("utf-8", "surrogatepass")
+            for start in range(len(tokens) - ngram_size + 1)
+        ]
+    return np.unique(np.asarray(dupekit.hash_xxh3_64_batch(shingles), dtype=np.uint64))
+
+
+def prepare(documents: Sequence[ClusterDocument], params: ClusterDedupParams) -> list[PreparedDocument]:
+    prepared = []
+    for index, document in enumerate(documents):
+        prepared.append(
+            PreparedDocument(
+                index=index,
+                chars=len(document.text),
+                ngrams=ngram_hashes(document.text, params.ngram_size),
+                token_hashes=ngram_hashes(document.text, 1),
+                text=document.text,
+            )
+        )
+    return prepared
+
+
+def novel_token_count(
+    member: PreparedDocument,
+    representative: PreparedDocument,
+) -> int:
+    """Words of the member that the representative does not hold."""
+    return int(member.token_hashes.size) - _overlap(member.token_hashes, representative.token_hashes)
+
+
+def _overlap(left: np.ndarray, right: np.ndarray) -> int:
+    """Size of the intersection of two sorted unique hash arrays."""
+    if left.size == 0 or right.size == 0:
+        return 0
+    if left.size > right.size:
+        left, right = right, left
+    position = np.searchsorted(right, left)
+    position[position >= right.size] = right.size - 1
+    return int(np.count_nonzero(right[position] == left))
+
+
+@dataclass(frozen=True)
+class _NgramIndex:
+    """Inverted index from n-gram hash to the documents that hold it."""
+
+    values: np.ndarray
+    counts: np.ndarray
+    starts: np.ndarray
+    owners: np.ndarray
+
+
+def _build_index(prepared: list[PreparedDocument]) -> _NgramIndex:
+    sizes = np.fromiter((document.ngrams.size for document in prepared), dtype=np.int64, count=len(prepared))
+    values = np.concatenate([document.ngrams for document in prepared]) if sizes.sum() else _EMPTY
+    owners = np.repeat(np.arange(len(prepared), dtype=np.int32), sizes)
+    order = np.argsort(values, kind="stable")
+    values = values[order]
+    owners = owners[order]
+    if values.size == 0:
+        return _NgramIndex(values=values, counts=_EMPTY.astype(np.int64), starts=_EMPTY.astype(np.int64), owners=owners)
+    # ``np.unique`` would sort this array a second time, which dominated the
+    # stage on a cluster holding a hundred million n-grams. The array is
+    # already sorted, so the run boundaries are one comparison per element.
+    boundary = np.empty(values.size, dtype=bool)
+    boundary[0] = True
+    np.not_equal(values[1:], values[:-1], out=boundary[1:])
+    starts = np.flatnonzero(boundary)
+    counts = np.diff(np.append(starts, values.size))
+    return _NgramIndex(values=values[starts], counts=counts, starts=starts, owners=owners)
+
+
+def _index_candidates(
+    member: PreparedDocument,
+    index: _NgramIndex,
+    rank: np.ndarray,
+    params: ClusterDedupParams,
+) -> np.ndarray:
+    """Documents that share the member's rarest n-grams, best first.
+
+    Probing with the rarest n-grams is what keeps this near-linear. A member
+    whose containment clears the threshold shares almost every n-gram it has,
+    so each rare probe finds the representative with high probability, while a
+    common n-gram would return most of the cluster and carry no signal.
+    """
+    if member.ngrams.size == 0:
+        return np.empty(0, dtype=np.int32)
+    position = np.searchsorted(index.values, member.ngrams)
+    position[position >= index.values.size] = index.values.size - 1
+    present = index.values[position] == member.ngrams
+    position = position[present]
+    if position.size == 0:
+        return np.empty(0, dtype=np.int32)
+
+    counts = index.counts[position]
+    usable = counts <= params.maximum_posting_length
+    position, counts = position[usable], counts[usable]
+    if position.size == 0:
+        return np.empty(0, dtype=np.int32)
+    if position.size > params.probe_ngrams:
+        rarest = np.argpartition(counts, params.probe_ngrams)[: params.probe_ngrams]
+        position, counts = position[rarest], counts[rarest]
+
+    total = int(counts.sum())
+    if total == 0:
+        return np.empty(0, dtype=np.int32)
+    offsets = np.repeat(index.starts[position], counts)
+    within = np.arange(total) - np.repeat(np.cumsum(counts) - counts, counts)
+    owners = index.owners[offsets + within]
+
+    # Tally the probed documents only. Counting into an array the size of the
+    # cluster would cost one allocation per member, which is quadratic in the
+    # member count and stalls on a cluster of 100,000.
+    distinct, shared = np.unique(owners, return_counts=True)
+    # Only a document that ranks ahead of the member -- longer, or equal and
+    # earlier -- can be its representative.
+    ahead = rank[distinct] < rank[member.index]
+    distinct, shared = distinct[ahead], shared[ahead]
+    if distinct.size == 0:
+        return np.empty(0, dtype=np.int32)
+    if distinct.size > params.maximum_candidates:
+        strongest = np.lexsort((rank[distinct], -shared))[: params.maximum_candidates]
+        distinct = distinct[strongest]
+    ranked = distinct[np.argsort(rank[distinct])]
+    return ranked.astype(np.int32)
+
+
+def _candidate_pairs(
+    prepared: list[PreparedDocument], order: list[int], params: ClusterDedupParams
+) -> dict[int, list[int]]:
+    """Map each member to the representatives worth an exact comparison.
+
+    A representative must be at least as long as the member, which is the
+    direction the rule accepts, so only earlier-ranked documents ever appear.
+    """
+    if len(prepared) <= params.exact_scan_maximum:
+        rank = {index: position for position, index in enumerate(order)}
+        return {index: [other for other in order if rank[other] < rank[index]] for index in order}
+
+    rank = np.empty(len(prepared), dtype=np.int64)
+    for position, index in enumerate(order):
+        rank[index] = position
+    ngram_index = _build_index(prepared)
+    return {index: _index_candidates(prepared[index], ngram_index, rank, params).tolist() for index in order}
+
+
+def find_duplicates(
+    documents: Sequence[ClusterDocument],
+    params: ClusterDedupParams,
+) -> list[Removal]:
+    """Solve one cluster: every member that a longer survivor already holds.
+
+    Walks members from the longest, so a representative is always decided
+    before the documents it can absorb, and a removed document never becomes
+    the representative of another.
+    """
+    prepared = prepare(documents, params)
+    order = sorted(range(len(prepared)), key=lambda index: (-prepared[index].chars, documents[index].id, index))
+    candidates = _candidate_pairs(prepared, order, params)
+
+    removed: set[int] = set()
+    removals: list[Removal] = []
+    for member in order:
+        comparisons = 0
+        member_prepared = prepared[member]
+        if member_prepared.ngrams.size == 0:
+            continue
+        for representative in candidates[member]:
+            if representative in removed:
+                continue
+            other = prepared[representative]
+            comparisons += 1
+            shared = _overlap(member_prepared.ngrams, other.ngrams)
+            containment = shared / member_prepared.ngrams.size
+            if containment < params.minimum_containment:
+                continue
+            novel_tokens = novel_token_count(member_prepared, other)
+            union = member_prepared.ngrams.size + other.ngrams.size - shared
+            removed.add(member)
+            removals.append(
+                Removal(
+                    member_index=member,
+                    representative_index=representative,
+                    containment=containment,
+                    jaccard=shared / union if union else 1.0,
+                    novel_tokens=novel_tokens,
+                    comparisons=comparisons,
+                )
+            )
+            break
+    return removals

--- a/tests/processing/classification/deduplication/test_cluster_dedup.py
+++ b/tests/processing/classification/deduplication/test_cluster_dedup.py
@@ -1,0 +1,213 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior of the whole-cluster duplicate solver.
+
+Every document here is short enough to read. The counts in the comments come
+from the rule itself: the original holds 31 words, thus 29 distinct word
+3-grams, and one replaced word destroys the 3 n-grams that span it.
+"""
+
+from itertools import permutations
+
+import pytest
+from marin.processing.classification.deduplication.cluster_dedup import (
+    ClusterDedupParams,
+    ClusterDocument,
+    find_duplicates,
+)
+
+ORIGINAL = (
+    "the reference implementation walks every cluster member from the longest "
+    "document and keeps the first representative that already holds the member "
+    "content so a shorter copy never survives a longer original"
+)
+"""31 words, 205 characters, 29 distinct 3-grams."""
+
+SHORTER_COPY = ORIGINAL.replace("already holds", "now holds")
+"""The original with one word replaced: containment 26/29, 201 characters."""
+
+LONGER_COPY = ORIGINAL.replace("already holds", "presently holds")
+"""The same single-word edit, but 207 characters, thus longer than the original."""
+
+EXCERPT = " ".join(ORIGINAL.split()[4:20])
+"""16 consecutive words of the original, thus a strict subset of its n-grams."""
+
+UNRELATED = (
+    "a calibration table maps each humidity reading to the pressure coefficient "
+    "that the sensor firmware applies before it reports a value to the flight recorder bus"
+)
+"""A different document. It shares no 3-gram with the original, and 160 characters put it
+in the middle of the length order, thus the rule does examine it."""
+
+BLANK = " \n\t" * 100
+"""Whitespace only. 300 characters make it the longest member of a cluster, but it holds
+no n-gram."""
+
+
+def _cluster(named_texts: dict[str, str]) -> list[ClusterDocument]:
+    """One cluster whose member ids are the keys, in the given order."""
+    return [ClusterDocument(id=name, text=text) for name, text in named_texts.items()]
+
+
+def _removed_by(documents: list[ClusterDocument], params: ClusterDedupParams | None = None) -> dict[str, str]:
+    """Map the id of each removed document to the id of the survivor that holds it."""
+    removals = find_duplicates(documents, params or ClusterDedupParams())
+    return {documents[removal.member_index].id: documents[removal.representative_index].id for removal in removals}
+
+
+NESTED_EXCERPTS = {
+    "original": ORIGINAL,
+    "first24": " ".join(ORIGINAL.split()[:24]),
+    "first18": " ".join(ORIGINAL.split()[:18]),
+    "first12": " ".join(ORIGINAL.split()[:12]),
+    "first6": " ".join(ORIGINAL.split()[:6]),
+    "unrelated": UNRELATED,
+}
+"""Four excerpts of one original, plus one document that shares nothing with it."""
+
+
+def test_lightly_edited_copy_is_removed_at_the_default_threshold():
+    documents = _cluster({"original": ORIGINAL, "copy": SHORTER_COPY})
+
+    (removal,) = find_duplicates(documents, ClusterDedupParams())
+
+    assert documents[removal.member_index].id == "copy"
+    assert documents[removal.representative_index].id == "original"
+    # The one edit puts the pair between the two thresholds: the copy is a
+    # near-duplicate, not an exact subset of the original.
+    assert ClusterDedupParams().minimum_containment <= removal.containment < 1.0
+    assert removal.novel_tokens == 1
+
+
+def test_lightly_edited_copy_survives_a_full_containment_threshold():
+    documents = _cluster({"original": ORIGINAL, "copy": SHORTER_COPY})
+
+    assert _removed_by(documents, ClusterDedupParams(minimum_containment=1.0)) == {}
+
+
+def test_unrelated_document_in_the_same_cluster_is_never_removed():
+    documents = _cluster({"original": ORIGINAL, "copy": SHORTER_COPY, "excerpt": EXCERPT, "unrelated": UNRELATED})
+
+    # The unrelated document is neither a member that the rule removes nor a
+    # representative that absorbs one, although it is shorter than the original.
+    assert _removed_by(documents) == {"copy": "original", "excerpt": "original"}
+
+
+@pytest.mark.parametrize(
+    ("copy_text", "expected_removals"),
+    [
+        (SHORTER_COPY, {"copy": "original"}),
+        (LONGER_COPY, {"original": "copy"}),
+    ],
+    ids=["copy_is_shorter", "copy_is_longer"],
+)
+def test_near_duplicate_pair_removes_only_the_shorter_document(copy_text, expected_removals):
+    # The two variants hold the same single-word edit, thus containment is
+    # identical (26/29) in each direction and in each case. Only the character
+    # count differs, and it alone decides which document the rule removes.
+    documents = _cluster({"original": ORIGINAL, "copy": copy_text})
+
+    assert _removed_by(documents) == expected_removals
+
+
+def test_longest_document_in_a_cluster_always_survives():
+    # The excerpts come first in the input, thus an order-sensitive rule would
+    # remove the original against one of them.
+    documents = _cluster({name: NESTED_EXCERPTS[name] for name in reversed(list(NESTED_EXCERPTS))})
+
+    removed = _removed_by(documents)
+
+    assert set(removed) == {"first24", "first18", "first12", "first6"}
+    assert set(removed.values()) == {"original"}
+
+
+def test_strict_excerpt_is_removed_with_no_novel_tokens():
+    documents = _cluster({"original": ORIGINAL, "excerpt": EXCERPT})
+
+    (removal,) = find_duplicates(documents, ClusterDedupParams())
+
+    assert documents[removal.member_index].id == "excerpt"
+    assert documents[removal.representative_index].id == "original"
+    assert removal.containment == 1.0
+    assert removal.novel_tokens == 0
+
+
+def test_removals_are_independent_of_input_order():
+    named_texts = {
+        "original": ORIGINAL,
+        "copy": SHORTER_COPY,
+        "excerpt": EXCERPT,
+        "unrelated": UNRELATED,
+        "blank": BLANK,
+    }
+    expected = {"copy": "original", "excerpt": "original"}
+
+    for permutation in permutations(named_texts):
+        documents = _cluster({name: named_texts[name] for name in permutation})
+
+        assert _removed_by(documents) == expected, permutation
+
+
+@pytest.mark.parametrize("exact_scan_maximum", [2, 256], ids=["inverted_index", "exact_scan"])
+def test_the_two_candidate_paths_find_the_same_duplicates(exact_scan_maximum):
+    # The cluster holds 6 members, thus a maximum of 2 selects the banded
+    # inverted index and a maximum of 256 selects the exhaustive scan.
+    documents = _cluster(NESTED_EXCERPTS)
+
+    removed = _removed_by(documents, ClusterDedupParams(exact_scan_maximum=exact_scan_maximum))
+
+    assert removed == {
+        "first24": "original",
+        "first18": "original",
+        "first12": "original",
+        "first6": "original",
+    }
+
+
+@pytest.mark.parametrize("exact_scan_maximum", [2, 256], ids=["inverted_index", "exact_scan"])
+def test_blank_documents_are_neither_removed_nor_representatives(exact_scan_maximum):
+    # The whitespace-only document is the longest member, thus it is the first
+    # candidate representative for every other member. It holds no n-gram, thus
+    # containment against it is 0 and it absorbs nothing.
+    documents = _cluster(
+        {
+            "blank": BLANK,
+            "empty": "",
+            "original": ORIGINAL,
+            "copy": SHORTER_COPY,
+            "excerpt": EXCERPT,
+        }
+    )
+
+    removed = _removed_by(documents, ClusterDedupParams(exact_scan_maximum=exact_scan_maximum))
+
+    assert removed == {"copy": "original", "excerpt": "original"}
+
+
+def test_inverted_index_skips_ngrams_above_the_posting_limit():
+    documents = _cluster({"original": ORIGINAL, "copy": ORIGINAL, "unrelated": UNRELATED})
+    params = ClusterDedupParams(exact_scan_maximum=2, maximum_posting_length=1)
+
+    assert _removed_by(documents, params) == {}
+
+
+@pytest.mark.parametrize("exact_scan_maximum", [2, 256], ids=["inverted_index", "exact_scan"])
+def test_equal_length_ties_use_document_id(exact_scan_maximum):
+    documents = _cluster({"zeta": ORIGINAL, "alpha": ORIGINAL, "unrelated": UNRELATED})
+
+    removed = _removed_by(documents, ClusterDedupParams(exact_scan_maximum=exact_scan_maximum))
+
+    assert removed == {"zeta": "alpha"}
+
+
+@pytest.mark.parametrize("exact_scan_maximum", [2, 256], ids=["inverted_index", "exact_scan"])
+def test_candidate_cap_keeps_the_strongest_match(exact_scan_maximum):
+    weak_longest = "the reference implementation " + (UNRELATED + " ") * 3
+    strong = ORIGINAL + " retained context"
+    documents = _cluster({"weak": weak_longest, "strong": strong, "member": ORIGINAL})
+    params = ClusterDedupParams(exact_scan_maximum=exact_scan_maximum, maximum_candidates=1)
+
+    removed = _removed_by(documents, params)
+
+    assert removed == {"member": "strong"}


### PR DESCRIPTION
- solve each fuzzy-candidate cluster with directional word n-gram containment
- scan small clusters exactly and bound large-cluster work with a rare-n-gram index
- retain longer representatives and keep representative choice stable across both candidate paths
- document that completeness applies within each materialized cluster group