### PR TITLE
[datakit] Materialize fuzzy-duplicate cluster text

### DIFF
--- a/experiments/datakit/scripts/fuzzy_cluster_text.py
+++ b/experiments/datakit/scripts/fuzzy_cluster_text.py
@@ -1,0 +1,415 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Materialize fuzzy-duplicate candidate text grouped by cluster.
+
+The production verifier re-joins candidate attributes to normalized text and
+serves the text through worker memory stores on every run, which makes each
+algorithm change cost a full corpus pass. Paying the shuffle once and storing
+the text already grouped by cluster turns duplicate detection into an
+embarrassingly parallel map over cluster groups.
+
+Every row carries a document ID and a file index. The manifest maps each file
+index to its normalized source and shard name, which is enough to write the
+co-partitioned marker tree.
+
+Connected components are heavily skewed. A cluster above ``--max-cluster-size``
+is split with one MinHash permutation of each document's text. Two documents
+with Jaccard J share their minimum n-gram hash with probability J. This is an
+operational bound, not a full-recall containment partition: a short excerpt can
+meet the containment rule while it has low Jaccard similarity with its source.
+
+    uv run iris --cluster=marin job run --target-cluster cw-us-east-02a \
+        --no-wait --priority batch --cpu 16 --memory 96GB \
+        -- python experiments/datakit/scripts/fuzzy_cluster_text.py \
+            --prefix s3://.../marin --candidates datakit/dedup_709f5997 \
+            --large-clusters s3://.../user/rav/dedup/large_clusters/v1/large_clusters.parquet \
+            --out s3://.../user/rav/dedup/cluster_text/v6 \
+            --output-shards 8192 --shards-per-task 96 --max-workers 96
+"""
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+import dupekit
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from marin.datakit.copartitioned import CopartitionedSource, build_copartitioned_shards
+from marin.execution.artifact import read_record
+from marin.processing.classification.deduplication.cluster_text import (
+    CLUSTER_TEXT_SUBDIRECTORY,
+    MAXIMUM_VERIFICATION_TEXT_CHARS,
+    ClusterTextManifest,
+    ClusterTextShard,
+    resolve_data_path,
+    write_cluster_text_manifest,
+    write_cluster_text_success,
+)
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+from zephyr import counters
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.worker_context import zephyr_worker_ctx
+from zephyr.writers import write_parquet_file
+
+logger = logging.getLogger(__name__)
+
+COUNTER_PREFIX = "fuzzy/cluster_text"
+_SHARED_OVERSIZED_KEY = "fuzzy_cluster_text_oversized"
+SPLIT_NGRAM_SIZE = 5
+DEFAULT_MAX_SHARD_FAILURES = 20
+
+_TEXT_SCHEMA = pa.schema(
+    [
+        pa.field("cluster_key", pa.string(), nullable=False),
+        pa.field("dup_cluster_id", pa.string(), nullable=False),
+        pa.field("id", pa.string(), nullable=False),
+        pa.field("text", pa.large_string(), nullable=False),
+        pa.field("text_truncated", pa.bool_(), nullable=False),
+        pa.field("file_idx", pa.int32(), nullable=False),
+    ]
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class TextShard:
+    """One normalized shard and the candidate attributes beside it."""
+
+    file_idx: int
+    normalized_path: str
+    candidate_path: str
+    source_key: str
+    source_tag: str
+    basename: str
+
+
+def _split_hash(text: str) -> int:
+    """One MinHash permutation over the document's word n-grams.
+
+    Returns the minimum 64-bit hash of the case-folded word n-grams. Two
+    documents with Jaccard J share this value with probability exactly J, which
+    is what makes it a partition key that keeps duplicates together where a
+    split on the document ID would scatter them. Python's own string hash is
+    salted per process and would place the same document differently on
+    different workers, so this uses dupekit's fixed xxh3.
+    """
+    tokens = text.casefold().split()
+    if len(tokens) < SPLIT_NGRAM_SIZE:
+        return dupekit.hash_xxh3_64(" ".join(tokens).encode("utf-8", "surrogatepass"))
+    shingles = [
+        " ".join(tokens[start : start + SPLIT_NGRAM_SIZE]).encode("utf-8", "surrogatepass")
+        for start in range(len(tokens) - SPLIT_NGRAM_SIZE + 1)
+    ]
+    return min(dupekit.hash_xxh3_64_batch(shingles))
+
+
+def _read_table(path: str, columns: list[str]) -> pa.Table | None:
+    """Read selected columns, or None when the file holds no rows.
+
+    A shard with no candidates is written as an empty Parquet file whose schema
+    carries no columns at all, so selecting by name raises there.
+    """
+    with StoragePath(path).open("rb") as handle:
+        parquet = pq.ParquetFile(handle)
+        if parquet.metadata.num_rows == 0:
+            return None
+        return parquet.read(columns=columns)
+
+
+def _join_shard_group(shards: list[TextShard]) -> Iterator[dict[str, Any]]:
+    """Join a group of shards in one task.
+
+    The shuffle reads every map output once per reduce partition, so its cost
+    scales with the product of the two counts. Grouping input shards cuts the
+    map side of that product without changing the result.
+    """
+    oversized: dict[str, int] = zephyr_worker_ctx().get_shared(_SHARED_OVERSIZED_KEY)
+    for shard in shards:
+        yield from _join_shard(shard, oversized)
+
+
+def _join_shard(shard: TextShard, oversized: Mapping[str, int]) -> Iterator[dict[str, Any]]:
+    """Join one shard's candidate rows to their normalized text.
+
+    Only a fifth of a normalized shard is a candidate in a typical source, so
+    the row selection happens in Arrow and only the selected text crosses into
+    Python. Converting every row first was the dominant cost of this stage.
+    """
+    if not StoragePath(shard.candidate_path).exists():
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/candidate_shards_missing", 1)
+        return
+    candidates = _read_table(shard.candidate_path, ["id", "dup_cluster_id"])
+    if candidates is None:
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/candidate_shards_empty", 1)
+        return
+    attributes = {
+        candidate_id: str(cluster_id)
+        for candidate_id, cluster_id in zip(
+            candidates.column("id").to_pylist(),
+            candidates.column("dup_cluster_id").to_pylist(),
+            strict=True,
+        )
+    }
+    if len(attributes) != candidates.num_rows:
+        raise ValueError(f"{shard.candidate_path} contains duplicate candidate IDs")
+    wanted = candidates.column("id").combine_chunks()
+
+    emitted = 0
+    previous_id: str | None = None
+    previous_text: str | None = None
+    with StoragePath(shard.normalized_path).open("rb") as handle:
+        parquet = pq.ParquetFile(handle)
+        for batch in parquet.iter_batches(columns=["id", "text"]):
+            mask = pc.is_in(batch.column("id"), value_set=wanted)
+            selected = batch.filter(mask)
+            if selected.num_rows:
+                ids = selected.column("id").to_pylist()
+                texts = selected.column("text").to_pylist()
+                for record_id, text in zip(ids, texts, strict=True):
+                    raw_text = text or ""
+                    cluster_id = attributes.pop(record_id, None)
+                    if cluster_id is None:
+                        if record_id != previous_id or raw_text != previous_text:
+                            raise ValueError(f"Repeated normalized ID {record_id!r} has inconsistent text")
+                        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/repeated_normalized_ids", 1)
+                        continue
+                    previous_id = record_id
+                    previous_text = raw_text
+                    text = raw_text
+                    text_truncated = len(text) > MAXIMUM_VERIFICATION_TEXT_CHARS
+                    if text_truncated:
+                        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/oversized_documents", 1)
+                        text = ""
+                    splits = oversized.get(cluster_id, 1)
+                    cluster_key = cluster_id
+                    if splits > 1:
+                        split_index = _split_hash(text) % splits
+                        cluster_key = f"{cluster_id}:{split_index:04d}"
+                        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/split_members", 1)
+                    yield {
+                        "cluster_key": cluster_key,
+                        "dup_cluster_id": cluster_id,
+                        "id": record_id,
+                        "text": text,
+                        "text_truncated": text_truncated,
+                        "file_idx": shard.file_idx,
+                    }
+                    emitted += 1
+
+    if attributes:
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/candidates_without_text", len(attributes))
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/shards_with_missing_text", 1)
+        raise ValueError(
+            f"{shard.candidate_path} holds {len(attributes)} IDs absent from {shard.normalized_path} "
+            f"against {emitted} joined, first {sorted(attributes)[:3]!r}"
+        )
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/members", emitted)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/shards_joined", 1)
+
+
+def group_key_of(cluster_key: str, groups: int) -> int:
+    """Stable output group for one cluster group.
+
+    Partitions on the *split* key, not the cluster ID. The largest component
+    holds 831 million members: routing all of its splits to one file would
+    hand one reduce task the whole component and undo the split.
+
+    Keep ``groups`` well above the reduce-task count. Zephyr hashes this key
+    again to pick a reduce task, so one group per task is balls-into-bins:
+    ``e**-1`` of the tasks get nothing and the unlucky ones get five or more
+    groups. The v5 run measured 37% idle reducers and a 31 GB partition
+    against a 5.6 GB mean. Eight groups per task flattens that tail.
+    """
+    return dupekit.hash_xxh3_64(cluster_key.encode("utf-8")) % groups
+
+
+def cluster_sort_key(record: Mapping[str, Any]) -> tuple[str, int, str]:
+    """Keep a cluster contiguous and put its longest documents first."""
+    return record["cluster_key"], -len(record["text"]), record["id"]
+
+
+def _write_group(group: int, records: Iterator[dict[str, Any]], output_dir: str) -> dict[str, Any]:
+    path = prefix_join(output_dir, f"part-{group:06d}.parquet")
+    result = write_parquet_file(records, path, schema=_TEXT_SCHEMA)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/rows_written", result["count"])
+    return {**result, "group": group}
+
+
+def build_shards(prefix: str, candidates: str, output_path: str) -> list[TextShard]:
+    """Pair every normalized shard with its candidate attribute shard.
+
+    Candidate source keys identify the normalized inputs. Candidate attributes
+    can omit empty shards, but they cannot contain a shard absent from the
+    normalized source.
+    """
+    candidate_path = resolve_data_path(prefix, candidates)
+    record = read_record(candidate_path)
+    if record is None or record.result is None:
+        raise FileNotFoundError(f"No candidate artifact payload at {candidate_path}")
+    candidate_artifact = FuzzyDupsAttrData.model_validate(record.result)
+    entries, _ = build_copartitioned_shards(
+        sources=[
+            CopartitionedSource(source_key=source_key, input_dir=prefix_join(prefix, source_key))
+            for source_key in sorted(candidate_artifact.sources)
+        ],
+        output_path=output_path,
+    )
+
+    expected_by_source: dict[str, set[str]] = {}
+    for entry in entries:
+        expected_by_source.setdefault(entry.source_key, set()).add(entry.basename)
+    for source_key, source in candidate_artifact.sources.items():
+        candidate_dir = resolve_data_path(prefix, source.attr_dir)
+        candidate_paths = StoragePath(prefix_join(candidate_dir, "*.parquet")).glob()
+        candidate_basenames = {os.path.basename(str(path)) for path in candidate_paths}
+        extra = candidate_basenames - expected_by_source[source_key]
+        if extra:
+            raise ValueError(f"Candidate source {source_key!r} has unexpected shards: {sorted(extra)!r}")
+
+    return [
+        TextShard(
+            file_idx=entry.file_idx,
+            normalized_path=entry.input_path,
+            candidate_path=prefix_join(
+                resolve_data_path(prefix, candidate_artifact.sources[entry.source_key].attr_dir), entry.basename
+            ),
+            source_key=entry.source_key,
+            source_tag=entry.source_tag,
+            basename=entry.basename,
+        )
+        for entry in entries
+    ]
+
+
+def load_oversized(large_clusters_path: str, max_cluster_size: int) -> tuple[dict[str, int], int]:
+    """Return split counts and the estimated member count for oversized clusters."""
+    summary_path = StoragePath(prefix_join(str(StoragePath(large_clusters_path).parent), "summary.json"))
+    if not summary_path.exists():
+        raise FileNotFoundError(f"Large-cluster planner summary is absent: {summary_path}")
+    summary = json.loads(summary_path.read_bytes())
+    minimum_size = int(summary["minimum_size"])
+    if minimum_size > max_cluster_size:
+        raise ValueError(
+            f"Large-cluster plan starts at {minimum_size} members, above the materializer cap {max_cluster_size}"
+        )
+    with StoragePath(large_clusters_path).open("rb") as handle:
+        table = pq.ParquetFile(handle).read(columns=["dup_cluster_id", "size"])
+    oversized = {
+        str(cluster_id): -(-int(size) // max_cluster_size)
+        for cluster_id, size in zip(
+            table.column("dup_cluster_id").to_pylist(), table.column("size").to_pylist(), strict=True
+        )
+        if size > max_cluster_size
+    }
+    members = sum(int(size) for size in table.column("size").to_pylist() if size > max_cluster_size)
+    return oversized, members
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prefix", required=True)
+    parser.add_argument("--candidates", required=True)
+    parser.add_argument("--large-clusters", required=True, help="large_clusters.parquet from fuzzy_large_clusters.py")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--max-cluster-size", type=int, default=100_000)
+    parser.add_argument("--output-shards", type=int, default=4096, help="Reduce tasks")
+    parser.add_argument("--groups-per-shard", type=int, default=8, help="Output files assigned to each reduce task")
+    parser.add_argument("--shards-per-task", type=int, default=8, help="Input shards joined by one map task")
+    parser.add_argument("--max-workers", type=int, default=64)
+    parser.add_argument("--worker-cpu", type=float, default=32)
+    parser.add_argument("--worker-ram", default="128g")
+    parser.add_argument("--worker-disk", default="512g")
+    parser.add_argument("--task-cpu", type=float, default=1)
+    parser.add_argument("--task-ram", default="12g", help="Map task memory")
+    parser.add_argument("--task-disk", default="48g")
+    parser.add_argument("--reduce-task-ram", default="26g", help="Reduce holds a partition and its sort spill")
+    parser.add_argument("--max-shard-failures", type=int, default=DEFAULT_MAX_SHARD_FAILURES)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    shards = build_shards(args.prefix, args.candidates, args.out)
+    oversized, oversized_cluster_members = load_oversized(args.large_clusters, args.max_cluster_size)
+    logger.info(
+        "Grouping %d shards; %d clusters exceed %d members and will be split",
+        len(shards),
+        len(oversized),
+        args.max_cluster_size,
+    )
+
+    manifest = ClusterTextManifest(
+        candidates=resolve_data_path(args.prefix, args.candidates),
+        max_cluster_size=args.max_cluster_size,
+        output_shards=args.output_shards,
+        groups_per_shard=args.groups_per_shard,
+        split_ngram_size=SPLIT_NGRAM_SIZE,
+        oversized_clusters=oversized,
+        oversized_cluster_members=oversized_cluster_members,
+        shards=[
+            ClusterTextShard(
+                file_idx=shard.file_idx,
+                source_key=shard.source_key,
+                source_tag=shard.source_tag,
+                basename=shard.basename,
+            )
+            for shard in shards
+        ],
+    )
+    write_cluster_text_manifest(args.out, manifest)
+
+    worker = ResourceConfig(cpu=args.worker_cpu, ram=args.worker_ram, disk=args.worker_disk)
+    task = ResourceConfig(cpu=args.task_cpu, ram=args.task_ram, disk=args.task_disk)
+    reduce_task = ResourceConfig(cpu=args.task_cpu, ram=args.reduce_task_ram, disk=args.task_disk)
+    context = ZephyrContext(
+        name="fuzzy-cluster-text",
+        resources=worker,
+        max_workers=args.max_workers,
+        max_shard_failures=args.max_shard_failures,
+    )
+    context.put(_SHARED_OVERSIZED_KEY, oversized)
+    shard_groups = [
+        shards[start : start + args.shards_per_task] for start in range(0, len(shards), args.shards_per_task)
+    ]
+    logger.info("Map side: %d tasks of up to %d shards", len(shard_groups), args.shards_per_task)
+
+    key_groups = args.output_shards * args.groups_per_shard
+    logger.info("Reduce side: %d output files across %d reduce tasks", key_groups, args.output_shards)
+    pipeline = (
+        Dataset.from_list(shard_groups)
+        .flat_map(_join_shard_group)
+        .group_by(
+            key=lambda record: group_key_of(record["cluster_key"], key_groups),
+            reducer=lambda group, records: _write_group(
+                group, records, prefix_join(args.out, CLUSTER_TEXT_SUBDIRECTORY)
+            ),
+            sort_by=cluster_sort_key,
+            num_output_shards=args.output_shards,
+        )
+    )
+    outcome = context.execute(pipeline, verbose=True, map_task_resources=task, reduce_task_resources=reduce_task)
+
+    payload = {
+        "manifest": prefix_join(args.out, "manifest.json"),
+        "shards": len(shards),
+        "oversized_clusters": len(oversized),
+        "oversized_cluster_members": oversized_cluster_members,
+        "counters": dict(sorted(outcome.counters.items())),
+    }
+    StoragePath(prefix_join(args.out, "summary.json")).write_bytes(json.dumps(payload, indent=2).encode())
+    write_cluster_text_success(args.out)
+    logger.info("Wrote %s", prefix_join(args.out, "summary.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/scripts/fuzzy_large_clusters.py
+++ b/experiments/datakit/scripts/fuzzy_large_clusters.py
@@ -1,0 +1,195 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find the fuzzy-duplicate clusters that are too large to group in one piece.
+
+The stage that groups candidate text by cluster has to know which clusters are
+oversized before it shuffles, because the split key is assigned on the map
+side. Only clusters of at least ``--minimum-size`` members matter, and a
+cluster that large keeps hundreds of rows under a coarse row sample, so the
+count does not have to be exact.
+
+Sampling turns this into a map-only job: each task counts a stride of its own
+shards and writes the counts, and the driver adds them up. A shuffle over the
+5.95 billion cluster members would move two orders of magnitude more data and
+put every map output in every reducer's merge.
+
+    uv run iris --cluster=cw-us-east-02a job run --no-wait --priority batch \
+        --cpu 16 --memory 64GB -- python experiments/datakit/scripts/fuzzy_large_clusters.py \
+            --prefix s3://.../marin --candidates datakit/dedup_709f5997 \
+            --out s3://.../user/rav/dedup/large_clusters/v1
+"""
+
+import argparse
+import json
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import dupekit
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from marin.execution.artifact import read_record
+from marin.processing.classification.deduplication.cluster_text import resolve_data_path
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData
+from rigging.filesystem.factory import url_to_fs
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+from zephyr import counters
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.writers import write_parquet_file
+
+logger = logging.getLogger(__name__)
+
+COUNTER_PREFIX = "fuzzy/large_clusters"
+_COUNT_SCHEMA = pa.schema(
+    [
+        pa.field("dup_cluster_id", pa.string(), nullable=False),
+        pa.field("n", pa.int64(), nullable=False),
+    ]
+)
+
+
+def candidate_shard_paths(prefix: str, candidates: str) -> list[str]:
+    """List the candidate attribute shards in source and filename order."""
+    candidate_path = resolve_data_path(prefix, candidates)
+    record = read_record(candidate_path)
+    if record is None or record.result is None:
+        raise FileNotFoundError(f"No candidate artifact payload at {candidate_path}")
+    artifact = FuzzyDupsAttrData.model_validate(record.result)
+    paths: list[str] = []
+    for entry in sorted(artifact.sources.values(), key=lambda item: item.attr_dir):
+        directory = resolve_data_path(prefix, entry.attr_dir)
+        fs, root = url_to_fs(directory)
+        if not fs.exists(root):
+            continue
+        names = sorted(
+            str(path).rsplit("/", 1)[-1] for path in fs.ls(root, detail=False) if str(path).endswith(".parquet")
+        )
+        paths.extend(prefix_join(directory, name) for name in names)
+    return paths
+
+
+def _sample_indices(ids: list[str], stride: int) -> list[int]:
+    if stride < 1:
+        raise ValueError(f"stride must be at least 1, got {stride}")
+    hashes = dupekit.hash_xxh3_64_batch([record_id.encode("utf-8", "surrogatepass") for record_id in ids])
+    return [index for index, value in enumerate(hashes) if value % stride == 0]
+
+
+def _count_group(task: dict[str, Any]) -> dict[str, Any]:
+    """Count sampled cluster members across one group of candidate shards."""
+    tallies = []
+    rows_seen = 0
+    for path in task["paths"]:
+        with StoragePath(path).open("rb") as handle:
+            parquet = pq.ParquetFile(handle)
+            if parquet.metadata.num_rows == 0:
+                continue
+            table = parquet.read(columns=["id", "dup_cluster_id"])
+            column = table.column("dup_cluster_id").combine_chunks()
+        rows_seen += len(column)
+        selected = _sample_indices(table.column("id").to_pylist(), task["stride"])
+        sampled = column.take(pa.array(selected, type=pa.int64()))
+        if len(sampled):
+            tallies.append(pa.table({"dup_cluster_id": sampled}))
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/rows_seen", rows_seen)
+
+    def rows() -> Iterator[dict[str, Any]]:
+        if not tallies:
+            return
+        merged = pa.concat_tables(tallies).column("dup_cluster_id").combine_chunks()
+        counted = pc.value_counts(merged)
+        for cluster_id, count in zip(
+            counted.field("values").to_pylist(), counted.field("counts").to_pylist(), strict=True
+        ):
+            yield {"dup_cluster_id": cluster_id, "n": count}
+
+    path = prefix_join(task["output_dir"], f"part-{task['index']:05d}.parquet")
+    result = write_parquet_file(rows(), path, schema=_COUNT_SCHEMA)
+    return {"index": task["index"], "path": path, "count": result["count"]}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prefix", required=True)
+    parser.add_argument("--candidates", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--stride", type=int, default=256)
+    parser.add_argument("--minimum-size", type=int, default=100_000)
+    parser.add_argument("--shards-per-task", type=int, default=64)
+    parser.add_argument("--max-workers", type=int, default=48)
+    parser.add_argument("--worker-cpu", type=float, default=16)
+    parser.add_argument("--worker-ram", default="128g")
+    parser.add_argument("--worker-disk", default="64g")
+    parser.add_argument("--task-cpu", type=float, default=1)
+    parser.add_argument("--task-ram", default="7g")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    started = time.monotonic()
+
+    paths = candidate_shard_paths(args.prefix, args.candidates)
+    counts_dir = prefix_join(args.out, "counts")
+    tasks = [
+        {
+            "index": index,
+            "paths": paths[start : start + args.shards_per_task],
+            "stride": args.stride,
+            "output_dir": counts_dir,
+        }
+        for index, start in enumerate(range(0, len(paths), args.shards_per_task))
+    ]
+    logger.info("Counting %d shards in %d map tasks at stride %d", len(paths), len(tasks), args.stride)
+
+    worker = ResourceConfig(cpu=args.worker_cpu, ram=args.worker_ram, disk=args.worker_disk)
+    task_resources = ResourceConfig(cpu=args.task_cpu, ram=args.task_ram, disk="32g")
+    context = ZephyrContext(name="fuzzy-large-clusters", resources=worker, max_workers=args.max_workers)
+    outcome = context.execute(
+        Dataset.from_list(tasks).map(_count_group),
+        verbose=True,
+        map_task_resources=task_resources,
+    )
+    logger.info("Map stage wrote %d count files in %.0fs", len(outcome.results), time.monotonic() - started)
+
+    fs, root = url_to_fs(counts_dir)
+    names = sorted(str(path).rsplit("/", 1)[-1] for path in fs.ls(root, detail=False) if str(path).endswith(".parquet"))
+    tables = []
+    for name in names:
+        with StoragePath(prefix_join(counts_dir, name)).open("rb") as handle:
+            tables.append(pq.ParquetFile(handle).read(columns=["dup_cluster_id", "n"]))
+    merged = pa.concat_tables(tables)
+    logger.info("Aggregating %d sampled count rows", merged.num_rows)
+    grouped = merged.group_by("dup_cluster_id").aggregate([("n", "sum")])
+    sizes = pc.multiply(grouped.column("n_sum"), pa.scalar(args.stride, type=pa.int64()))
+    keep = pc.greater_equal(sizes, pa.scalar(args.minimum_size, type=pa.int64()))
+    large = pa.table(
+        {"dup_cluster_id": grouped.column("dup_cluster_id").filter(keep), "size": sizes.filter(keep)}
+    ).sort_by([("size", "descending")])
+
+    with StoragePath(prefix_join(args.out, "large_clusters.parquet")).open("wb") as handle:
+        pq.write_table(large, handle)
+    payload = {
+        "candidates": args.candidates,
+        "stride": args.stride,
+        "minimum_size": args.minimum_size,
+        "sampled_rows": merged.num_rows,
+        "distinct_sampled_clusters": grouped.num_rows,
+        "large_clusters": large.num_rows,
+        "large_cluster_members": int(pc.sum(large.column("size")).as_py() or 0),
+        "largest": large.column("size").to_pylist()[:20],
+        "elapsed_seconds": time.monotonic() - started,
+        "counters": dict(sorted(outcome.counters.items())),
+    }
+    StoragePath(prefix_join(args.out, "summary.json")).write_bytes(json.dumps(payload, indent=2).encode())
+    logger.info("Large clusters: %s", json.dumps({k: v for k, v in payload.items() if k != "counters"}, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/marin/src/marin/processing/classification/deduplication/cluster_text.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/cluster_text.py
@@ -1,0 +1,95 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Artifact contract for fuzzy-duplicate text grouped by cluster."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+
+CLUSTER_TEXT_MANIFEST_FILENAME = "manifest.json"
+CLUSTER_TEXT_MANIFEST_VERSION = "v1"
+CLUSTER_TEXT_SUBDIRECTORY = "text"
+CLUSTER_TEXT_SUCCESS_FILENAME = "_SUCCESS"
+MAXIMUM_VERIFICATION_TEXT_CHARS = 8 * 1024 * 1024
+
+
+class ClusterTextShard(BaseModel):
+    """One normalized shard in a cluster-text artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    file_idx: int = Field(ge=0)
+    source_key: str
+    source_tag: str
+    basename: str
+
+
+class ClusterTextManifest(BaseModel):
+    """Inputs, split parameters, and shard layout for grouped cluster text."""
+
+    model_config = ConfigDict(frozen=True)
+
+    version: str = CLUSTER_TEXT_MANIFEST_VERSION
+    candidates: str
+    max_cluster_size: int = Field(ge=1)
+    output_shards: int = Field(ge=1)
+    groups_per_shard: int = Field(ge=1)
+    split_ngram_size: int = Field(ge=1)
+    split_strategy: Literal["minhash_jaccard_v1"] = "minhash_jaccard_v1"
+    oversized_clusters: dict[str, int]
+    oversized_cluster_members: int = Field(ge=0)
+    shards: list[ClusterTextShard]
+
+    @model_validator(mode="after")
+    def _valid_layout(self) -> "ClusterTextManifest":
+        file_indices = [shard.file_idx for shard in self.shards]
+        if file_indices != list(range(len(self.shards))):
+            raise ValueError("cluster-text file indices must be contiguous and start at zero")
+        shard_keys = [(shard.source_key, shard.basename) for shard in self.shards]
+        if len(shard_keys) != len(set(shard_keys)):
+            raise ValueError("cluster-text manifest contains a duplicate source shard")
+        source_tags: dict[str, str] = {}
+        tag_sources: dict[str, str] = {}
+        for shard in self.shards:
+            if not _is_path_component(shard.source_tag) or not _is_path_component(shard.basename):
+                raise ValueError("cluster-text source tags and basenames must be single path components")
+            if source_tags.setdefault(shard.source_key, shard.source_tag) != shard.source_tag:
+                raise ValueError(f"cluster-text source {shard.source_key!r} has more than one source tag")
+            if tag_sources.setdefault(shard.source_tag, shard.source_key) != shard.source_key:
+                raise ValueError(f"cluster-text source tag {shard.source_tag!r} names more than one source")
+        if any(splits < 2 for splits in self.oversized_clusters.values()):
+            raise ValueError("cluster-text oversized cluster split counts must be at least two")
+        return self
+
+
+def _is_path_component(value: str) -> bool:
+    return bool(value) and value not in {".", ".."} and "/" not in value and "\\" not in value
+
+
+def resolve_data_path(prefix: str, path: str) -> str:
+    """Resolve a stored relative path against an explicit data prefix."""
+    storage_path = StoragePath(path)
+    if storage_path.scheme or path.startswith("/"):
+        return str(storage_path)
+    return prefix_join(prefix, path)
+
+
+def read_cluster_text_manifest(cluster_text: str) -> ClusterTextManifest:
+    """Read the manifest from a cluster-text artifact."""
+    path = StoragePath(prefix_join(cluster_text, CLUSTER_TEXT_MANIFEST_FILENAME))
+    return ClusterTextManifest.model_validate_json(path.read_bytes())
+
+
+def write_cluster_text_manifest(cluster_text: str, manifest: ClusterTextManifest) -> None:
+    """Write the manifest to a cluster-text artifact."""
+    path = StoragePath(prefix_join(cluster_text, CLUSTER_TEXT_MANIFEST_FILENAME))
+    path.parent.mkdirs()
+    path.write_text(manifest.model_dump_json(indent=2) + "\n")
+
+
+def write_cluster_text_success(cluster_text: str) -> None:
+    """Mark a cluster-text artifact complete after all data and metadata exist."""
+    path = StoragePath(prefix_join(cluster_text, CLUSTER_TEXT_SUCCESS_FILENAME))
+    path.write_text(CLUSTER_TEXT_MANIFEST_VERSION + "\n")

--- a/tests/datakit/test_fuzzy_cluster_text.py
+++ b/tests/datakit/test_fuzzy_cluster_text.py
@@ -1,0 +1,331 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for the materialized fuzzy-cluster text artifact."""
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from marin.execution.artifact import write_artifact
+from marin.processing.classification.deduplication.cluster_text import (
+    ClusterTextManifest,
+    ClusterTextShard,
+    read_cluster_text_manifest,
+    write_cluster_text_manifest,
+)
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
+from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams
+
+import experiments.datakit.scripts.fuzzy_cluster_text as cluster_text_script
+from experiments.datakit.scripts.fuzzy_cluster_text import (
+    TextShard,
+    _join_shard,
+    build_shards,
+    cluster_sort_key,
+    load_oversized,
+)
+
+
+def _write_parquet(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), path)
+
+
+def _candidate_artifact(prefix: Path, sources: dict[str, Path]) -> None:
+    write_artifact(
+        FuzzyDupsAttrData(
+            params=MinHashParams(num_perms=16, num_bands=4, ngram_size=5, seed=0),
+            sources={
+                source_key: FuzzyDupsPerSource(attr_dir=str(path.relative_to(prefix)))
+                for source_key, path in sources.items()
+            },
+            counters={},
+        ),
+        str(prefix / "candidates"),
+    )
+
+
+def test_build_shards_uses_candidate_source_keys_and_normalized_basenames(tmp_path: Path) -> None:
+    first_key = "normalized/first"
+    second_key = "normalized/second"
+    first_attr = tmp_path / "attributes" / "first"
+    second_attr = tmp_path / "attributes" / "second"
+    _write_parquet(tmp_path / first_key / "part-1.parquet", [{"id": "a", "text": "first"}])
+    _write_parquet(tmp_path / second_key / "part-2.parquet", [{"id": "b", "text": "second"}])
+    _write_parquet(
+        first_attr / "part-1.parquet",
+        [{"id": "a", "dup_cluster_id": "1", "is_cluster_canonical": True}],
+    )
+    _candidate_artifact(tmp_path, {second_key: second_attr, first_key: first_attr})
+
+    shards = build_shards(str(tmp_path), "candidates", str(tmp_path / "cluster-text"))
+
+    assert [(shard.file_idx, shard.source_key, shard.source_tag, shard.basename) for shard in shards] == [
+        (0, first_key, "source_000", "part-1.parquet"),
+        (1, second_key, "source_001", "part-2.parquet"),
+    ]
+    assert shards[0].candidate_path == str(first_attr / "part-1.parquet")
+    assert shards[1].candidate_path == str(second_attr / "part-2.parquet")
+
+
+def test_build_shards_rejects_candidate_shard_absent_from_normalized_source(tmp_path: Path) -> None:
+    source_key = "normalized/source"
+    attr_dir = tmp_path / "attributes" / "source"
+    _write_parquet(tmp_path / source_key / "part-1.parquet", [{"id": "a", "text": "first"}])
+    _write_parquet(
+        attr_dir / "part-extra.parquet",
+        [{"id": "a", "dup_cluster_id": "1", "is_cluster_canonical": True}],
+    )
+    _candidate_artifact(tmp_path, {source_key: attr_dir})
+
+    with pytest.raises(ValueError, match="unexpected shards"):
+        build_shards(str(tmp_path), "candidates", str(tmp_path / "cluster-text"))
+
+
+def test_join_shard_writes_candidate_text_and_provenance(tmp_path: Path) -> None:
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    _write_parquet(normalized, [{"id": "a", "text": "first"}, {"id": "b", "text": "second"}])
+    _write_parquet(
+        candidates,
+        [{"id": "b", "dup_cluster_id": "7", "is_cluster_canonical": False}],
+    )
+    shard = TextShard(
+        file_idx=3,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    rows = list(_join_shard(shard, {}))
+
+    assert rows == [
+        {
+            "cluster_key": "7",
+            "dup_cluster_id": "7",
+            "id": "b",
+            "text": "second",
+            "text_truncated": False,
+            "file_idx": 3,
+        }
+    ]
+
+
+def test_join_shard_rejects_candidate_without_normalized_text(tmp_path: Path) -> None:
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    _write_parquet(normalized, [{"id": "a", "text": "first"}])
+    _write_parquet(
+        candidates,
+        [{"id": "missing", "dup_cluster_id": "7", "is_cluster_canonical": False}],
+    )
+    shard = TextShard(
+        file_idx=0,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    with pytest.raises(ValueError, match="IDs absent"):
+        list(_join_shard(shard, {}))
+
+
+def test_oversized_cluster_keeps_equal_text_in_one_split(tmp_path: Path) -> None:
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    text = "the same normalized text stays together in an oversized cluster"
+    _write_parquet(normalized, [{"id": "a", "text": text}, {"id": "b", "text": text}])
+    _write_parquet(
+        candidates,
+        [
+            {"id": "a", "dup_cluster_id": "7", "is_cluster_canonical": True},
+            {"id": "b", "dup_cluster_id": "7", "is_cluster_canonical": False},
+        ],
+    )
+    shard = TextShard(
+        file_idx=0,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    rows = list(_join_shard(shard, {"7": 8}))
+
+    assert len({row["cluster_key"] for row in rows}) == 1
+    assert rows[0]["cluster_key"].startswith("7:")
+
+
+def test_load_oversized_uses_the_required_split_count(tmp_path: Path) -> None:
+    sizes = tmp_path / "large-clusters.parquet"
+    (tmp_path / "summary.json").write_text(json.dumps({"minimum_size": 100}))
+    _write_parquet(
+        sizes,
+        [
+            {"dup_cluster_id": "at-cap", "size": 100},
+            {"dup_cluster_id": "one-over", "size": 101},
+            {"dup_cluster_id": "large", "size": 250},
+        ],
+    )
+
+    assert load_oversized(str(sizes), max_cluster_size=100) == ({"one-over": 2, "large": 3}, 351)
+
+
+def test_load_oversized_rejects_a_planner_threshold_above_the_cap(tmp_path: Path) -> None:
+    sizes = tmp_path / "large-clusters.parquet"
+    (tmp_path / "summary.json").write_text(json.dumps({"minimum_size": 200}))
+    _write_parquet(sizes, [{"dup_cluster_id": "large", "size": 250}])
+
+    with pytest.raises(ValueError, match="above the materializer cap"):
+        load_oversized(str(sizes), max_cluster_size=100)
+
+
+def test_cluster_sort_puts_longest_documents_first() -> None:
+    records = [
+        {"cluster_key": "2", "id": "b", "text": "short"},
+        {"cluster_key": "1", "id": "b", "text": "the longest text"},
+        {"cluster_key": "1", "id": "a", "text": "short"},
+    ]
+
+    ordered = sorted(records, key=cluster_sort_key)
+
+    assert [(record["cluster_key"], record["id"]) for record in ordered] == [("1", "b"), ("1", "a"), ("2", "b")]
+
+
+def test_cluster_text_manifest_round_trip_preserves_layout(tmp_path: Path) -> None:
+    manifest = ClusterTextManifest(
+        candidates="candidates",
+        max_cluster_size=100,
+        output_shards=8,
+        groups_per_shard=2,
+        split_ngram_size=5,
+        oversized_clusters={"7": 3},
+        oversized_cluster_members=250,
+        shards=[
+            ClusterTextShard(
+                file_idx=0,
+                source_key="normalized/source",
+                source_tag="source_000",
+                basename="part.parquet",
+            )
+        ],
+    )
+
+    write_cluster_text_manifest(str(tmp_path), manifest)
+
+    assert read_cluster_text_manifest(str(tmp_path)) == manifest
+
+
+def test_cluster_text_manifest_rejects_noncontiguous_file_indices() -> None:
+    with pytest.raises(ValueError, match="contiguous"):
+        ClusterTextManifest(
+            candidates="candidates",
+            max_cluster_size=100,
+            output_shards=8,
+            groups_per_shard=2,
+            split_ngram_size=5,
+            oversized_clusters={},
+            oversized_cluster_members=0,
+            shards=[
+                ClusterTextShard(
+                    file_idx=1,
+                    source_key="normalized/source",
+                    source_tag="source_000",
+                    basename="part.parquet",
+                )
+            ],
+        )
+
+
+@pytest.mark.parametrize("field", ["source_tag", "basename"])
+def test_cluster_text_manifest_rejects_path_components(field: str) -> None:
+    shard = {
+        "file_idx": 0,
+        "source_key": "normalized/source",
+        "source_tag": "source_000",
+        "basename": "part.parquet",
+    }
+    shard[field] = "../outside"
+
+    with pytest.raises(ValueError, match="path components"):
+        ClusterTextManifest(
+            candidates="candidates",
+            max_cluster_size=100,
+            output_shards=8,
+            groups_per_shard=2,
+            split_ngram_size=5,
+            oversized_clusters={},
+            oversized_cluster_members=0,
+            shards=[ClusterTextShard.model_validate(shard)],
+        )
+
+
+def test_duplicate_candidate_ids_are_rejected(tmp_path: Path) -> None:
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    _write_parquet(normalized, [{"id": "a", "text": "first"}])
+    _write_parquet(
+        candidates,
+        [
+            {"id": "a", "dup_cluster_id": "7"},
+            {"id": "a", "dup_cluster_id": "8"},
+        ],
+    )
+    shard = TextShard(
+        file_idx=0,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    with pytest.raises(ValueError, match="duplicate candidate IDs"):
+        list(_join_shard(shard, {}))
+
+
+def test_truncated_text_is_marked_for_conservative_verification(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cluster_text_script, "MAXIMUM_VERIFICATION_TEXT_CHARS", 8)
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    _write_parquet(normalized, [{"id": "a", "text": "a document longer than the test cap"}])
+    _write_parquet(candidates, [{"id": "a", "dup_cluster_id": "7"}])
+    shard = TextShard(
+        file_idx=0,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    (row,) = list(_join_shard(shard, {}))
+
+    assert row["text"] == ""
+    assert row["text_truncated"] is True
+
+
+def test_repeated_normalized_id_requires_equal_text(tmp_path: Path) -> None:
+    normalized = tmp_path / "normalized.parquet"
+    candidates = tmp_path / "candidates.parquet"
+    _write_parquet(normalized, [{"id": "a", "text": "first"}, {"id": "a", "text": "different"}])
+    _write_parquet(candidates, [{"id": "a", "dup_cluster_id": "7"}])
+    shard = TextShard(
+        file_idx=0,
+        normalized_path=str(normalized),
+        candidate_path=str(candidates),
+        source_key="normalized/source",
+        source_tag="source_000",
+        basename="part.parquet",
+    )
+
+    with pytest.raises(ValueError, match="inconsistent text"):
+        list(_join_shard(shard, {}))

--- a/tests/datakit/test_fuzzy_large_clusters.py
+++ b/tests/datakit/test_fuzzy_large_clusters.py
@@ -1,0 +1,49 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for the large fuzzy-cluster planner."""
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from marin.execution.artifact import write_artifact
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
+from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams
+
+from experiments.datakit.scripts.fuzzy_large_clusters import _sample_indices, candidate_shard_paths
+
+
+def _write_parquet(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), path)
+
+
+def test_candidate_shard_paths_skip_a_source_with_no_candidate_files(tmp_path: Path) -> None:
+    first_attr = tmp_path / "attributes" / "first"
+    second_attr = tmp_path / "attributes" / "second"
+    _write_parquet(first_attr / "part-1.parquet", [{"id": "a", "dup_cluster_id": "1"}])
+    write_artifact(
+        FuzzyDupsAttrData(
+            params=MinHashParams(num_perms=16, num_bands=4, ngram_size=5, seed=0),
+            sources={
+                "normalized/second": FuzzyDupsPerSource(attr_dir="attributes/second"),
+                "normalized/first": FuzzyDupsPerSource(attr_dir="attributes/first"),
+            },
+            counters={},
+        ),
+        str(tmp_path / "candidates"),
+    )
+
+    assert candidate_shard_paths(str(tmp_path), "candidates") == [str(first_attr / "part-1.parquet")]
+    assert not second_attr.exists()
+
+
+def test_hash_sample_is_independent_of_row_position() -> None:
+    ids = [f"document-{index}" for index in range(100)]
+    selected = {ids[index] for index in _sample_indices(ids, stride=8)}
+    reversed_ids = list(reversed(ids))
+    selected_reversed = {reversed_ids[index] for index in _sample_indices(reversed_ids, stride=8)}
+
+    assert selected
+    assert selected_reversed == selected


### PR DESCRIPTION
- join fuzzy-candidate attributes to normalized text once and group rows by cluster
- record source layout, split policy, affected member count, and completion in a versioned manifest
- identify oversized clusters with deterministic hash sampling; reject planner thresholds that leave clusters above the materializer cap unplanned
- use a MinHash partition for oversized components and record its Jaccard-based containment recall limit
- reject mismatched or repeated IDs; flag oversized text so verification keeps it
- stacked on #8723