### PR TITLE
[datakit] Verify materialized fuzzy clusters

### DIFF
--- a/experiments/datakit/scripts/fuzzy_cluster_verify.py
+++ b/experiments/datakit/scripts/fuzzy_cluster_verify.py
@@ -1,0 +1,95 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Solve every materialized fuzzy-duplicate cluster and write duplicate markers.
+
+A thin command line over
+:func:`marin.processing.classification.deduplication.cluster_verify.verify_cluster_text`,
+which holds the rule, the memory guards, and the output layout. This script
+chooses the worker shape and writes the artifact record, so a hand-run output
+is readable by the store exactly like a step output.
+
+    uv run iris --cluster=cw-us-east-02a job run --no-wait --priority batch \
+        --cpu 4 --memory 16GB -- python experiments/datakit/scripts/fuzzy_cluster_verify.py \
+            --cluster-text s3://.../user/rav/dedup/cluster_text/v1 \
+            --out s3://.../user/rav/dedup/verified/v1
+"""
+
+import argparse
+import logging
+
+from fray.types import ResourceConfig
+from marin.execution.artifact import write_artifact
+from marin.processing.classification.deduplication.cluster_dedup import ClusterDedupParams
+from marin.processing.classification.deduplication.cluster_verify import (
+    COUNTER_PREFIX,
+    DEFAULT_FILES_PER_TASK,
+    DEFAULT_MAX_SHARD_FAILURES,
+    DEFAULT_REDUCE_SHARDS,
+    verify_cluster_text,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cluster-text", required=True, help="Root written by fuzzy_cluster_text.py")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--minimum-containment", type=float, default=0.60)
+    parser.add_argument("--ngram-size", type=int, default=3)
+    parser.add_argument("--probe-ngrams", type=int, default=32)
+    parser.add_argument("--maximum-posting-length", type=int, default=512)
+    parser.add_argument("--maximum-candidates", type=int, default=32)
+    parser.add_argument("--exact-scan-maximum", type=int, default=256)
+    parser.add_argument(
+        "--files-per-task", type=int, default=DEFAULT_FILES_PER_TASK, help="Grouped text files solved by one map task"
+    )
+    parser.add_argument("--reduce-shards", type=int, default=DEFAULT_REDUCE_SHARDS, help="Reduce tasks")
+    parser.add_argument(
+        "--max-shard-failures",
+        type=int,
+        default=DEFAULT_MAX_SHARD_FAILURES,
+        help="Attempts one shard gets before the pipeline aborts",
+    )
+    parser.add_argument("--max-workers", type=int, default=64)
+    parser.add_argument("--worker-cpu", type=float, default=32)
+    parser.add_argument("--worker-ram", default="192g")
+    parser.add_argument("--worker-disk", default="256g")
+    parser.add_argument("--task-cpu", type=float, default=1)
+    parser.add_argument("--task-ram", default="12g")
+    parser.add_argument("--task-disk", default="48g")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    params = ClusterDedupParams(
+        ngram_size=args.ngram_size,
+        minimum_containment=args.minimum_containment,
+        probe_ngrams=args.probe_ngrams,
+        maximum_posting_length=args.maximum_posting_length,
+        maximum_candidates=args.maximum_candidates,
+        exact_scan_maximum=args.exact_scan_maximum,
+    )
+    task = ResourceConfig(cpu=args.task_cpu, ram=args.task_ram, disk=args.task_disk)
+    result = verify_cluster_text(
+        cluster_text=args.cluster_text,
+        output_path=args.out,
+        params=params,
+        max_workers=args.max_workers,
+        worker_resources=ResourceConfig(cpu=args.worker_cpu, ram=args.worker_ram, disk=args.worker_disk),
+        map_task_resources=task,
+        reduce_task_resources=task,
+        files_per_task=args.files_per_task,
+        reduce_shards=args.reduce_shards,
+        max_shard_failures=args.max_shard_failures,
+    )
+    write_artifact(result, args.out)
+    logger.info("Wrote %s duplicate markers to %s", result.counters[f"{COUNTER_PREFIX}/markers"], args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -41,7 +41,7 @@ from marin.datakit.decon import DeconAttributes
 from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import write_artifact
 from marin.processing.classification.deduplication.verify_fuzzy_dups import (
-    VerifiedFuzzyDupsAttrData,
+    VerifiedFuzzyDupsArtifact,
     VerifiedFuzzyDupsPerSource,
 )
 from marin.processing.tokenize._core import CHUNK_INDEX_FIELD
@@ -629,7 +629,7 @@ def build_clustered_store(
     cluster_assign: dict[str, AssignmentAttrData],
     quality: dict[str, QualityScores],
     exact_dedup: GlobalExactDedupData,
-    dedup: VerifiedFuzzyDupsAttrData,
+    dedup: VerifiedFuzzyDupsArtifact,
     output_path: str,
     cluster_view: int = 40,
     split: str = "train",

--- a/lib/marin/src/marin/processing/classification/deduplication/cluster_verify.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/cluster_verify.py
@@ -1,0 +1,316 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Solve every materialized fuzzy-duplicate cluster and write duplicate markers.
+
+Reads the cluster-grouped candidate text, solves each cluster with the
+containment rule in :mod:`~marin.processing.classification.deduplication.cluster_dedup`,
+and writes the decisions into a co-partitioned attribute tree that the store
+filters on. The text arrives already grouped, so this stage is an embarrassingly
+parallel map: no memory store, no re-join, and no cross-cluster communication.
+
+Output rows follow the shape the store already consumes::
+
+    {id, dup_doc, dup_cluster_id, dup_representative_id,
+     dup_representative_source_key, dup_representative_kind,
+     dup_member_containment, dup_jaccard, dup_comparisons, ...}
+
+One file per normalized shard, named after it, so the tree is co-partitioned
+with the normalized data and with every other attribute tree.
+
+The result records the cluster rule and the source mapping needed by the store.
+"""
+
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any, Literal
+
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from pydantic import model_validator
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+from zephyr import counters
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.worker_context import zephyr_worker_ctx
+from zephyr.writers import write_parquet_file
+
+from marin.datakit.copartitioned import write_copartitioned_source_manifest
+from marin.processing.classification.deduplication.cluster_dedup import (
+    ClusterDedupParams,
+    ClusterDocument,
+    find_duplicates,
+)
+from marin.processing.classification.deduplication.cluster_text import (
+    CLUSTER_TEXT_SUBDIRECTORY,
+    CLUSTER_TEXT_SUCCESS_FILENAME,
+    read_cluster_text_manifest,
+)
+from marin.processing.classification.deduplication.verify_fuzzy_dups import (
+    VERIFIED_FUZZY_DUPLICATE_SCHEMA,
+    RepresentativeKind,
+    VerifiedFuzzyDupsArtifact,
+    VerifiedFuzzyDupsPerSource,
+)
+
+logger = logging.getLogger(__name__)
+
+COUNTER_PREFIX = "fuzzy/cluster_verify"
+# N-gram preparation expands text into Python and NumPy objects. This cap is
+# paired with the CLI's 12 GiB default task memory.
+MAXIMUM_CLUSTER_CHARS = 256 * 1024 * 1024
+# Grouping map inputs and bounding reducers limits the shuffle fan-in while
+# retaining enough map tasks to use the cluster.
+DEFAULT_FILES_PER_TASK = 32
+DEFAULT_REDUCE_SHARDS = 2048
+
+# A reduce attempt opens every mapper's chunk, so brief object-store failures
+# can affect several shards in one wave.
+DEFAULT_MAX_SHARD_FAILURES = 20
+_SHARED_SHARDS_KEY = "fuzzy_cluster_verify_shards"
+
+_SIZE_BINS = (2, 4, 8, 16, 32, 64, 256, 1024, 4096, 16384, 65536)
+
+
+class ClusterVerifiedFuzzyDupsAttrData(VerifiedFuzzyDupsArtifact):
+    """Sparse markers from whole-cluster containment verification."""
+
+    producer: Literal["pipeline", "cluster"] = "cluster"
+    version: str = "v1"
+    rule: ClusterDedupParams
+
+    @model_validator(mode="after")
+    def _cluster_producer(self) -> "ClusterVerifiedFuzzyDupsAttrData":
+        if self.producer != "cluster":
+            raise ValueError("Cluster verified-marker artifacts require producer='cluster'")
+        return self
+
+
+def _size_bin(size: int) -> str:
+    for edge in _SIZE_BINS:
+        if size < edge:
+            return f"{edge:06d}"
+    return "999999"
+
+
+def _solve_text_shards(paths: list[str], params: ClusterDedupParams) -> Iterator[dict[str, Any]]:
+    for path in paths:
+        yield from solve_text_shard(path, params)
+
+
+def solve_text_shard(path: str, params: ClusterDedupParams) -> Iterator[dict[str, Any]]:
+    """Solve every cluster in one grouped text file.
+
+    The file is written sorted by ``cluster_key``, so a cluster is a contiguous
+    run and the whole file streams without holding more than one cluster.
+    """
+    started = time.monotonic()
+    columns = ["cluster_key", "dup_cluster_id", "id", "text", "text_truncated", "file_idx"]
+    clusters = 0
+    duplicates = 0
+    documents = 0
+    chars = 0
+    pending: list[dict[str, Any]] = []
+    current: str | None = None
+
+    def record_cluster(size: int) -> None:
+        nonlocal clusters
+        clusters += 1
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/cluster_size/{_size_bin(size)}", 1)
+        if size < 2:
+            counters.pipeline.update_counter(f"{COUNTER_PREFIX}/singleton_groups", 1)
+
+    def _solve_batch(members: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+        nonlocal duplicates
+        eligible = [member for member in members if not member["text_truncated"]]
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/truncated_documents_skipped", len(members) - len(eligible))
+        if len(eligible) < 2:
+            return
+        cluster = [ClusterDocument(id=row["id"], text=row["text"]) for row in eligible]
+        shards: dict[int, tuple[str, str, str]] = zephyr_worker_ctx().get_shared(_SHARED_SHARDS_KEY)
+        for removal in find_duplicates(cluster, params):
+            member = eligible[removal.member_index]
+            representative = eligible[removal.representative_index]
+            duplicates += 1
+            yield {
+                "file_idx": member["file_idx"],
+                "id": member["id"],
+                "dup_doc": True,
+                "dup_cluster_id": member["dup_cluster_id"],
+                "dup_representative_id": representative["id"],
+                "dup_representative_source_key": shards[representative["file_idx"]][0],
+                "dup_representative_kind": RepresentativeKind.CLUSTER_LONGEST.value,
+                "dup_shared_lsh_buckets": 0,
+                "dup_member_containment": removal.containment,
+                "dup_jaccard": removal.jaccard,
+                "dup_comparisons": removal.comparisons,
+                "dup_under_tokenized": False,
+                "dup_char_jaccard": None,
+                "dup_local_line_count_ratio": None,
+            }
+
+    pending_chars = 0
+    cluster_members = 0
+    cluster_flushed = False
+    with StoragePath(path).open("rb") as handle:
+        for batch in pq.ParquetFile(handle).iter_batches(columns=columns, batch_size=8192):
+            for row in batch.to_pylist():
+                documents += 1
+                chars += len(row["text"])
+                if row["cluster_key"] != current:
+                    if pending:
+                        yield from _solve_batch(pending)
+                    if current is not None:
+                        record_cluster(cluster_members)
+                    pending = []
+                    pending_chars = 0
+                    cluster_members = 0
+                    cluster_flushed = False
+                    current = row["cluster_key"]
+                elif pending and pending_chars + len(row["text"]) > MAXIMUM_CLUSTER_CHARS:
+                    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/mid_cluster_flushes", 1)
+                    if not cluster_flushed:
+                        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/oversized_clusters", 1)
+                        cluster_flushed = True
+                    yield from _solve_batch(pending)
+                    pending = []
+                    pending_chars = 0
+                pending.append(row)
+                pending_chars += len(row["text"])
+                cluster_members += 1
+    if pending:
+        yield from _solve_batch(pending)
+    if current is not None:
+        record_cluster(cluster_members)
+
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/documents", documents)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/text_chars", chars)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/clusters", clusters)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicates", duplicates)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/solve_seconds_milli", int((time.monotonic() - started) * 1000))
+
+
+def _write_markers(file_idx: int, records: Iterator[dict[str, Any]], output_path: str) -> dict[str, Any]:
+    """Write one shard's markers into the co-partitioned attribute tree."""
+    shards: dict[int, tuple[str, str, str]] = zephyr_worker_ctx().get_shared(_SHARED_SHARDS_KEY)
+    _, source_tag, basename = shards[file_idx]
+    path = prefix_join(_attr_dir(output_path, source_tag), basename)
+    rows = ({field.name: record[field.name] for field in VERIFIED_FUZZY_DUPLICATE_SCHEMA} for record in records)
+    result = write_parquet_file(rows, path, schema=VERIFIED_FUZZY_DUPLICATE_SCHEMA)
+    return {**result, "file_idx": file_idx, "markers": result["count"]}
+
+
+def _attr_dir(output_path: str, source_tag: str) -> str:
+    return prefix_join(output_path, f"outputs/{source_tag}")
+
+
+def verify_cluster_text(
+    *,
+    cluster_text: str,
+    output_path: str,
+    params: ClusterDedupParams,
+    max_workers: int | None = None,
+    worker_resources: ResourceConfig | None = None,
+    map_task_resources: ResourceConfig | None = None,
+    reduce_task_resources: ResourceConfig | None = None,
+    files_per_task: int = DEFAULT_FILES_PER_TASK,
+    reduce_shards: int = DEFAULT_REDUCE_SHARDS,
+    max_shard_failures: int = DEFAULT_MAX_SHARD_FAILURES,
+) -> ClusterVerifiedFuzzyDupsAttrData:
+    """Solve a materialized cluster-text dataset and write duplicate markers.
+
+    Args:
+        cluster_text: Root of the grouped text: ``text/*.parquet`` beside the
+            ``manifest.json`` that names every normalized shard.
+        output_path: Root of the attribute tree to write.
+        params: The duplicate rule, recorded on the result.
+        max_workers: Worker limit. Defaults to one worker per map task.
+        worker_resources: Shape of one worker.
+        map_task_resources: Shape of one solving task.
+        reduce_task_resources: Shape of one marker-writing task.
+        files_per_task: Grouped text files solved by one map task. Every reducer
+            reads every map task's chunk, so the shuffle costs the product of the
+            two counts: one file per task made 65,536 mappers against 8,192
+            reducers, and each reducer opened all 65,536 chunks to find its
+            120 MB slice. Grouping the map side divides that product without
+            changing the result.
+        reduce_shards: Reduce tasks. Markers are ~380 bytes and total about a
+            terabyte, so a reducer holds a few hundred megabytes whatever this
+            is; it exists to bound the fan-in, not to fit memory.
+        max_shard_failures: Attempts one shard gets before the pipeline aborts.
+            Zephyr defaults to 3, which is too few here: one reduce attempt
+            opens every mapper's chunk, so the wave issues millions of requests
+            and a brief object-store outage lands on several shards at once. The
+            first production run died that way with seven shards out of 2,048
+            exhausted, having already written most of its markers.
+
+    Returns:
+        The marker attribute tree, one directory per source key.
+    """
+    success_path = prefix_join(cluster_text, CLUSTER_TEXT_SUCCESS_FILENAME)
+    if not StoragePath(success_path).exists():
+        raise FileNotFoundError(f"Cluster-text artifact is incomplete: {success_path} is absent")
+    manifest = read_cluster_text_manifest(cluster_text)
+    if not manifest.shards:
+        raise ValueError(f"{cluster_text} manifest names no normalized shards")
+    shards = {shard.file_idx: (shard.source_key, shard.source_tag, shard.basename) for shard in manifest.shards}
+
+    text_dir = prefix_join(cluster_text, CLUSTER_TEXT_SUBDIRECTORY)
+    paths = sorted(str(path) for path in StoragePath(prefix_join(text_dir, "*.parquet")).glob())
+    if not paths:
+        raise FileNotFoundError(f"No grouped text files under {text_dir}")
+    if files_per_task < 1:
+        raise ValueError(f"files_per_task must be at least 1, got {files_per_task}")
+    groups = [paths[start : start + files_per_task] for start in range(0, len(paths), files_per_task)]
+    reduce_shards = max(1, min(len(shards), reduce_shards))
+    logger.info(
+        "Solving %d grouped text files as %d map tasks into %d reduce tasks with %s",
+        len(paths),
+        len(groups),
+        reduce_shards,
+        params.model_dump_json(),
+    )
+
+    context = ZephyrContext(
+        name="fuzzy-cluster-verify",
+        resources=worker_resources,
+        max_workers=max_workers or len(groups),
+        max_shard_failures=max_shard_failures,
+    )
+    context.put(_SHARED_SHARDS_KEY, shards)
+    pipeline = (
+        Dataset.from_list(groups)
+        .flat_map(lambda group: _solve_text_shards(group, params))
+        .group_by(
+            key=lambda record: record["file_idx"],
+            reducer=lambda file_idx, records: _write_markers(file_idx, records, output_path),
+            sort_by=lambda record: record["id"],
+            num_output_shards=reduce_shards,
+        )
+    )
+    outcome = context.execute(
+        pipeline,
+        verbose=True,
+        map_task_resources=map_task_resources,
+        reduce_task_resources=reduce_task_resources,
+    )
+
+    # Consumers resolve an attribute tree through its source manifest, the same
+    # way they resolve every other co-partitioned Datakit output.
+    source_tags = {shard.source_key: shard.source_tag for shard in manifest.shards}
+    attr_dirs = {source_key: _attr_dir(output_path, source_tag) for source_key, source_tag in source_tags.items()}
+    write_copartitioned_source_manifest(output_path=output_path, attr_dirs=attr_dirs)
+    markers = sum(result["markers"] for result in outcome.results)
+    output_counters: dict[str, int | float] = dict(outcome.counters)
+    output_counters[f"{COUNTER_PREFIX}/markers"] = markers
+    output_counters[f"{COUNTER_PREFIX}/text_files"] = len(paths)
+    logger.info("Wrote %d duplicate markers from %d grouped text files", markers, len(paths))
+    return ClusterVerifiedFuzzyDupsAttrData(
+        rule=params,
+        sources={
+            source_key: VerifiedFuzzyDupsPerSource(attr_dir=attr_dirs[source_key], source_tag=source_tag)
+            for source_key, source_tag in source_tags.items()
+        },
+        counters=output_counters,
+    )

--- a/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from functools import partial
 from itertools import batched, chain, groupby
-from typing import Any
+from typing import Any, Literal
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -111,12 +111,11 @@ class VerifiedFuzzyDupsPerSource(BaseModel):
     source_tag: str
 
 
-class VerifiedFuzzyDupsAttrData(BaseModel):
-    """Sparse, co-partitioned markers for verified fuzzy duplicates."""
+class VerifiedFuzzyDupsArtifact(BaseModel):
+    """Source mapping and counters shared by verified-marker producers."""
 
-    version: str = f"v{VERIFIED_FUZZY_DUPS_ATTR_DATA_VERSION}"
-    verification: FuzzyVerificationParams
-    local_representatives: LocalRepresentativeParams
+    producer: Literal["pipeline", "cluster"] = "pipeline"
+    version: str
     sources: dict[str, VerifiedFuzzyDupsPerSource]
     counters: dict[str, int | float]
 
@@ -127,6 +126,21 @@ class VerifiedFuzzyDupsAttrData(BaseModel):
         if entry is None:
             raise KeyError(f"Verified fuzzy duplicate attributes have no entry for source_key={source_key!r}")
         return entry.attr_dir
+
+
+class VerifiedFuzzyDupsAttrData(VerifiedFuzzyDupsArtifact):
+    """Sparse markers from the pipeline fuzzy-duplicate verifier."""
+
+    producer: Literal["pipeline", "cluster"] = "pipeline"
+    version: str = f"v{VERIFIED_FUZZY_DUPS_ATTR_DATA_VERSION}"
+    verification: FuzzyVerificationParams
+    local_representatives: LocalRepresentativeParams
+
+    @model_validator(mode="after")
+    def _pipeline_producer(self) -> "VerifiedFuzzyDupsAttrData":
+        if self.producer != "pipeline":
+            raise ValueError("Pipeline verified-marker artifacts require producer='pipeline'")
+        return self
 
 
 @dataclass(frozen=True)
@@ -166,7 +180,7 @@ class FuzzyVerificationStoreConfig:
             raise ValueError("lookup_batch_size must be at least 1")
 
 
-_VERIFIED_DUPLICATE_SCHEMA = pa.schema(
+VERIFIED_FUZZY_DUPLICATE_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string(), nullable=False),
         pa.field("dup_doc", pa.bool_(), nullable=False),
@@ -676,9 +690,9 @@ def _write_verified_shard(file_idx: int, records: Iterator[dict[str, Any]]) -> d
             if record["kind"] == "sentinel":
                 continue
             verified += 1
-            yield {field.name: record[field.name] for field in _VERIFIED_DUPLICATE_SCHEMA}
+            yield {field.name: record[field.name] for field in VERIFIED_FUZZY_DUPLICATE_SCHEMA}
 
-    result = write_parquet_file(output_rows(), shard.output_path, schema=_VERIFIED_DUPLICATE_SCHEMA)
+    result = write_parquet_file(output_rows(), shard.output_path, schema=VERIFIED_FUZZY_DUPLICATE_SCHEMA)
     return {**result, "file_idx": file_idx, "verified_duplicates": verified}
 
 

--- a/tests/processing/classification/deduplication/test_cluster_verify.py
+++ b/tests/processing/classification/deduplication/test_cluster_verify.py
@@ -1,0 +1,253 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior of the cluster-text verification stage and its marker artifact."""
+
+import json
+from pathlib import Path
+
+import pytest
+from fray.current_client import set_current_client
+from fray.local_backend import LocalClient
+from marin.datakit.copartitioned import SOURCE_MANIFEST_FILENAME
+from marin.execution.artifact import read_artifact, write_artifact
+from marin.processing.classification.deduplication.cluster_dedup import ClusterDedupParams
+from marin.processing.classification.deduplication.cluster_text import (
+    CLUSTER_TEXT_SUCCESS_FILENAME,
+    ClusterTextManifest,
+    ClusterTextShard,
+    write_cluster_text_manifest,
+    write_cluster_text_success,
+)
+from marin.processing.classification.deduplication.cluster_verify import (
+    ClusterVerifiedFuzzyDupsAttrData,
+    verify_cluster_text,
+)
+from marin.processing.classification.deduplication.verify_fuzzy_dups import (
+    VERIFIED_FUZZY_DUPLICATE_SCHEMA,
+    VerifiedFuzzyDupsArtifact,
+    VerifiedFuzzyDupsPerSource,
+)
+from zephyr.readers import load_parquet
+from zephyr.writers import write_parquet_file
+
+ORIGINAL = (
+    "the reference implementation walks every cluster member from the longest "
+    "document and keeps the first representative that already holds the member "
+    "content so a shorter copy never survives a longer original"
+)
+"""31 words, thus 29 distinct 3-grams."""
+
+NEAR_COPY = ORIGINAL.replace("already holds", "now holds")
+"""The original with one word replaced: shorter, and containment 26/29."""
+
+UNRELATED = (
+    "a calibration table maps each humidity reading to the pressure coefficient "
+    "that the sensor firmware applies before it reports a value to the flight recorder bus"
+)
+"""Shares no 3-gram with the original."""
+
+SOURCES = {"datakit/normalize/left": "source_000", "datakit/normalize/right": "source_001"}
+
+
+@pytest.fixture
+def local_client():
+    client = LocalClient()
+    try:
+        with set_current_client(client):
+            yield client
+    finally:
+        client.shutdown()
+
+
+def _write_cluster_text(root: Path, rows: list[dict]) -> str:
+    """Materialize one grouped text file and the manifest that names the shards.
+
+    The cluster-text stage writes ``file_idx`` 0 for the left source's only
+    shard and 1 for the right source's, and sorts the text by ``cluster_key``.
+    """
+    text_dir = root / "text"
+    text_dir.mkdir(parents=True)
+    write_parquet_file(
+        sorted(rows, key=lambda row: (row["cluster_key"], row["id"])), str(text_dir / "part-000000.parquet")
+    )
+    manifest = ClusterTextManifest(
+        candidates="candidates",
+        max_cluster_size=100_000,
+        output_shards=1,
+        groups_per_shard=1,
+        split_ngram_size=5,
+        oversized_clusters={},
+        oversized_cluster_members=0,
+        shards=[
+            ClusterTextShard(
+                file_idx=file_idx,
+                source_key=source_key,
+                source_tag=source_tag,
+                basename="shard-000.parquet",
+            )
+            for file_idx, (source_key, source_tag) in enumerate(SOURCES.items())
+        ],
+    )
+    write_cluster_text_manifest(str(root), manifest)
+    write_cluster_text_success(str(root))
+    return str(root)
+
+
+def _member(*, cluster: str, doc_id: str, text: str, file_idx: int) -> dict:
+    return {
+        "cluster_key": cluster,
+        "dup_cluster_id": cluster,
+        "id": doc_id,
+        "text": text,
+        "text_truncated": False,
+        "file_idx": file_idx,
+    }
+
+
+def test_marker_lands_beside_the_normalized_shard_that_holds_the_duplicate(tmp_path, local_client):
+    """A cross-source duplicate is marked in the *member's* tree, not its representative's."""
+    cluster_text = _write_cluster_text(
+        tmp_path / "cluster_text",
+        [
+            _member(cluster="c1", doc_id="left-original", text=ORIGINAL, file_idx=0),
+            _member(cluster="c1", doc_id="right-copy", text=NEAR_COPY, file_idx=1),
+            _member(cluster="c2", doc_id="left-only", text=UNRELATED, file_idx=0),
+        ],
+    )
+    output_path = str(tmp_path / "verified")
+
+    result = verify_cluster_text(
+        cluster_text=cluster_text,
+        output_path=output_path,
+        params=ClusterDedupParams(),
+    )
+
+    markers = list(load_parquet(str(Path(output_path) / "outputs/source_001/shard-000.parquet")))
+    assert set(markers[0]) == set(VERIFIED_FUZZY_DUPLICATE_SCHEMA.names)
+    assert [(row["id"], row["dup_doc"], row["dup_cluster_id"], row["dup_representative_id"]) for row in markers] == [
+        ("right-copy", True, "c1", "left-original")
+    ]
+    assert markers[0]["dup_representative_source_key"] == "datakit/normalize/left"
+    assert markers[0]["dup_representative_kind"] == "cluster_longest"
+    assert markers[0]["dup_member_containment"] == pytest.approx(26 / 29, rel=1e-3)
+    # The left source holds only a representative and a singleton, so it gets no
+    # file at all: the store reads a missing shard as "no duplicates here".
+    assert not list((Path(output_path) / "outputs/source_000").glob("*.parquet"))
+    assert result.counters["fuzzy/cluster_verify/markers"] == 1
+
+
+def test_every_source_is_resolvable_even_when_it_has_no_markers(tmp_path, local_client):
+    """The store resolves one attribute directory per source key, marked or not."""
+    cluster_text = _write_cluster_text(
+        tmp_path / "cluster_text",
+        [
+            _member(cluster="c1", doc_id="left-original", text=ORIGINAL, file_idx=0),
+            _member(cluster="c1", doc_id="left-copy", text=NEAR_COPY, file_idx=0),
+        ],
+    )
+    output_path = str(tmp_path / "verified")
+
+    result = verify_cluster_text(
+        cluster_text=cluster_text,
+        output_path=output_path,
+        params=ClusterDedupParams(),
+    )
+
+    assert {source_key: entry.attr_dir for source_key, entry in result.sources.items()} == {
+        source_key: f"{output_path}/outputs/{source_tag}" for source_key, source_tag in SOURCES.items()
+    }
+    manifest = json.loads((Path(output_path) / SOURCE_MANIFEST_FILENAME).read_text())
+    assert {entry["source_key"]: entry["attribute_dir"] for entry in manifest["sources"]} == {
+        source_key: f"outputs/{source_tag}" for source_key, source_tag in SOURCES.items()
+    }
+
+
+def test_a_rule_the_cluster_cannot_satisfy_marks_nothing(tmp_path, local_client):
+    """The threshold is a parameter: raised above the pair's containment, nothing is marked."""
+    cluster_text = _write_cluster_text(
+        tmp_path / "cluster_text",
+        [
+            _member(cluster="c1", doc_id="left-original", text=ORIGINAL, file_idx=0),
+            _member(cluster="c1", doc_id="right-copy", text=NEAR_COPY, file_idx=1),
+        ],
+    )
+    output_path = str(tmp_path / "verified")
+
+    result = verify_cluster_text(
+        cluster_text=cluster_text,
+        output_path=output_path,
+        params=ClusterDedupParams(minimum_containment=0.95),
+    )
+
+    assert result.counters["fuzzy/cluster_verify/markers"] == 0
+    assert result.rule.minimum_containment == 0.95
+
+
+def test_result_round_trips_through_the_artifact_record(tmp_path, monkeypatch):
+    """A written record reproduces the rule and the absolute attribute directories.
+
+    The store reads the stage's output through :func:`read_artifact`, and the
+    paths inside it are stored relative to ``MARIN_PREFIX``.
+    """
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    output_path = str(tmp_path / "verified")
+    params = ClusterDedupParams(minimum_containment=0.75, ngram_size=4)
+    written = ClusterVerifiedFuzzyDupsAttrData(
+        rule=params,
+        sources={
+            source_key: VerifiedFuzzyDupsPerSource(attr_dir=f"{output_path}/outputs/{source_tag}", source_tag=source_tag)
+            for source_key, source_tag in SOURCES.items()
+        },
+        counters={"fuzzy/cluster_verify/markers": 3},
+    )
+
+    write_artifact(written, output_path)
+    loaded = read_artifact(output_path, ClusterVerifiedFuzzyDupsAttrData)
+    common = read_artifact(output_path, VerifiedFuzzyDupsArtifact)
+
+    assert loaded.rule == params
+    assert common.producer == "cluster" and common.version == "v1"
+    assert loaded.attr_dir_for_source("datakit/normalize/right") == f"{output_path}/outputs/source_001"
+
+
+def test_attr_dir_for_an_unknown_source_names_the_missing_key(tmp_path, monkeypatch):
+    """The store drops or rebuilds a source on this error, so it must name the key."""
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    result = ClusterVerifiedFuzzyDupsAttrData(rule=ClusterDedupParams(), sources={}, counters={})
+
+    with pytest.raises(KeyError, match="datakit/normalize/left"):
+        result.attr_dir_for_source("datakit/normalize/left")
+
+
+def test_incomplete_cluster_text_is_rejected(tmp_path, local_client):
+    cluster_text = _write_cluster_text(
+        tmp_path / "cluster_text",
+        [_member(cluster="c1", doc_id="left-original", text=ORIGINAL, file_idx=0)],
+    )
+    (Path(cluster_text) / CLUSTER_TEXT_SUCCESS_FILENAME).unlink()
+
+    with pytest.raises(FileNotFoundError, match="incomplete"):
+        verify_cluster_text(
+            cluster_text=cluster_text,
+            output_path=str(tmp_path / "verified"),
+            params=ClusterDedupParams(),
+        )
+
+
+def test_truncated_document_is_not_removed_or_used_as_a_representative(tmp_path, local_client):
+    original = _member(cluster="c1", doc_id="left-original", text=ORIGINAL, file_idx=0)
+    original["text_truncated"] = True
+    cluster_text = _write_cluster_text(
+        tmp_path / "cluster_text",
+        [original, _member(cluster="c1", doc_id="right-copy", text=NEAR_COPY, file_idx=1)],
+    )
+
+    result = verify_cluster_text(
+        cluster_text=cluster_text,
+        output_path=str(tmp_path / "verified"),
+        params=ClusterDedupParams(),
+    )
+
+    assert result.counters["fuzzy/cluster_verify/markers"] == 0
+    assert result.counters["fuzzy/cluster_verify/truncated_documents_skipped"] == 1


### PR DESCRIPTION
- require a complete cluster-text artifact before verification starts
- solve grouped clusters in bounded distributed map tasks and route sparse markers back to normalized shards
- write the existing verified-marker Parquet schema with stable representative source keys
- keep truncated documents and exclude them from representative selection
- distinguish pipeline and cluster marker producers while preserving the common store input contract
- stacked on #8724