### PR TITLE
[grafana] Show vLLM collector health in inference dashboard

### DIFF
--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -117,7 +117,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 10,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -198,6 +198,92 @@
       ]
     },
     {
+      "id": 10,
+      "type": "table",
+      "title": "Collector telemetry health",
+      "description": "Reports known collection loss in the selected window. Incomplete means any observed resource reported an unavailable source, a positive collection-stage failure delta, or dropped samples. Healthy means only that collector polls reported none of those signals; unknown means no collector-poll evidence. Serving freshness and metric-family completeness are separate.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "telemetry_health"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "status",
+              "text": "status",
+              "type": "string"
+            },
+            {
+              "selector": "metric",
+              "text": "signal",
+              "type": "string"
+            },
+            {
+              "selector": "series",
+              "text": "stage / reason",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "window value",
+              "type": "number"
+            },
+            {
+              "selector": "unit",
+              "text": "unit",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": 9,
       "type": "table",
       "title": "Replica freshness detail",
@@ -208,8 +294,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 14,
-        "x": 10,
+        "w": 8,
+        "x": 16,
         "y": 0
       },
       "fieldConfig": {

--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -26,6 +26,7 @@ VLLM_OVERVIEW_SECTIONS = frozenset(
         "request_outcome",
         "saturation",
         "saturation_summary",
+        "telemetry_health",
         "token_rate",
     }
 )
@@ -77,7 +78,13 @@ _HISTOGRAM_COMPONENTS = ("bucket", "count", "sum")
 _HISTOGRAM_NAMES = tuple(
     f"{family}_{component}" for family, _ in _HISTOGRAM_FAMILIES for component in _HISTOGRAM_COMPONENTS
 )
-_METRIC_NAMES = (*_TOKEN_COUNTERS, *_PREEMPTION_COUNTERS, *_OUTCOME_COUNTERS, *_GAUGES, *_HISTOGRAM_NAMES)
+_SERVING_METRIC_NAMES = (*_TOKEN_COUNTERS, *_PREEMPTION_COUNTERS, *_OUTCOME_COUNTERS, *_GAUGES, *_HISTOGRAM_NAMES)
+_HEALTH_METRIC_NAMES = (
+    "prometheus_source_available",
+    "prometheus_stage_failures",
+    "prometheus_dropped_samples",
+)
+_METRIC_NAMES = (*_SERVING_METRIC_NAMES, *_HEALTH_METRIC_NAMES)
 
 
 def sql_string(value: str) -> str:
@@ -147,6 +154,7 @@ def vllm_overview_query(
     scan_start_ms = max(0, start_ms - VLLM_SNAPSHOT_LOOKBACK_MS)
     identity_literal = sql_string(identity)
     metric_names = _sql_values(_METRIC_NAMES)
+    serving_metric_names = _sql_values(_SERVING_METRIC_NAMES)
     token_counters = _sql_values(_TOKEN_COUNTERS)
     preemption_counters = _sql_values(_PREEMPTION_COUNTERS)
     outcome_counters = _sql_values(_OUTCOME_COUNTERS)
@@ -403,9 +411,48 @@ WITH base AS (
     WHERE name IN ({outcome_counters})
       AND delta IS NOT NULL
     GROUP BY 1
+), collector_polls AS (
+    SELECT COUNT(*) AS polls,
+           SUM(CASE WHEN value <= 0 THEN 1 ELSE 0 END) AS unavailable_polls
+    FROM base
+    WHERE timestamp_ms >= {start_ms}
+      AND name = 'prometheus_source_available'
+      AND json_get(attributes_json, 'metric_source') = 'vllm'
+), collection_failure_totals AS (
+    SELECT COALESCE(json_get(attributes_json, 'stage'), 'unknown') AS stage,
+           SUM(delta) AS value
+    FROM increments
+    WHERE name = 'prometheus_stage_failures'
+      AND json_get(attributes_json, 'metric_source') = 'vllm'
+      AND delta > 0
+    GROUP BY 1
+), dropped_sample_totals AS (
+    SELECT COALESCE(json_get(attributes_json, 'drop_reason'), 'unknown') AS drop_reason,
+           SUM(value) AS value
+    FROM base
+    WHERE timestamp_ms >= {start_ms}
+      AND name = 'prometheus_dropped_samples'
+      AND json_get(attributes_json, 'metric_source') = 'vllm'
+      AND value > 0
+    GROUP BY 1
+), telemetry_health AS (
+    SELECT polls,
+           COALESCE(unavailable_polls, 0) AS unavailable_polls,
+           CASE
+               WHEN COALESCE(unavailable_polls, 0) > 0
+                 OR failure_stages > 0
+                 OR drop_reasons > 0
+               THEN 'incomplete'
+               WHEN polls > 0 THEN 'healthy'
+               ELSE 'unknown'
+           END AS status
+    FROM collector_polls
+    CROSS JOIN (SELECT COUNT(*) AS failure_stages FROM collection_failure_totals)
+    CROSS JOIN (SELECT COUNT(*) AS drop_reasons FROM dropped_sample_totals)
 ), producer_samples AS (
     SELECT DISTINCT origin_cluster, service, resource_attributes_json, timestamp_ms
     FROM base
+    WHERE name IN ({serving_metric_names})
 ), producer_ordered AS (
     SELECT *,
            LAG(timestamp_ms) OVER (
@@ -562,6 +609,63 @@ WITH base AS (
 
     UNION ALL
 
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'telemetry_health' AS section,
+           'collector' AS metric,
+           'polls' AS stat,
+           'all resources' AS series,
+           CAST(polls AS DOUBLE) AS value,
+           'polls' AS unit,
+           status AS status,
+           CAST(polls AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM telemetry_health
+
+    UNION ALL
+
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'telemetry_health' AS section,
+           'source availability' AS metric,
+           'unavailable polls' AS stat,
+           'all resources' AS series,
+           CAST(unavailable_polls AS DOUBLE) AS value,
+           'polls' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM telemetry_health
+    WHERE unavailable_polls > 0
+
+    UNION ALL
+
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'telemetry_health' AS section,
+           'collection failures' AS metric,
+           'delta' AS stat,
+           stage AS series,
+           value AS value,
+           'failures' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM collection_failure_totals
+
+    UNION ALL
+
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'telemetry_health' AS section,
+           'dropped samples' AS metric,
+           'total' AS stat,
+           drop_reason AS series,
+           value AS value,
+           'samples' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM dropped_sample_totals
+
+    UNION ALL
+
     SELECT latest_timestamp_ms AS t,
            'freshness' AS section,
            'telemetry' AS metric,
@@ -605,7 +709,12 @@ WITH base AS (
 )
 SELECT t, section, metric, stat, series, value, unit, status, samples, gap_seconds
 FROM output
-ORDER BY section, metric, stat, series, t
+ORDER BY section,
+         CASE WHEN section = 'telemetry_health' AND metric = 'collector' THEN 0 ELSE 1 END,
+         metric,
+         stat,
+         series,
+         t
 LIMIT {VLLM_MAX_RESULT_ROWS}
 """.strip()
     return VllmOverviewQuery(

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -394,6 +394,117 @@ def _histogram_records(
     return rows
 
 
+def test_query_health_only_reports_healthy_without_serving_freshness():
+    current = _attributes("current_snapshot", metric_source="vllm")
+    cumulative = _attributes("cumulative_snapshot", metric_source="vllm", stage="scrape")
+    records = [
+        _record("a", "prometheus_source_available", 1, 135_000, current),
+        _record("a", "prometheus_stage_failures", 0, 105_000, cumulative),
+        _record("a", "prometheus_stage_failures", 0, 135_000, cumulative),
+        _record(
+            "a",
+            "prometheus_dropped_samples",
+            0,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm", drop_reason="sample_limit"),
+        ),
+    ]
+
+    rows = _query_rows(_database(records))
+
+    assert [row for row in rows if row["section"] == "telemetry_health"] == [
+        {
+            "t": None,
+            "section": "telemetry_health",
+            "metric": "collector",
+            "stat": "polls",
+            "series": "all resources",
+            "value": 1.0,
+            "unit": "polls",
+            "status": "healthy",
+            "samples": 1,
+            "gap_seconds": None,
+        }
+    ]
+    assert _one(rows, "freshness", "telemetry", "latest_sample_age")["status"] == "no_data"
+
+
+def test_query_reports_combined_collector_loss_across_replicas():
+    current = _attributes("current_snapshot", metric_source="vllm")
+    records = [
+        _record("unhealthy", "num_requests_running", 1, 150_000, _attributes("current_snapshot")),
+        _record("unhealthy", "prometheus_source_available", 0, 135_000, current),
+        _record("healthy", "prometheus_source_available", 1, 135_000, current),
+        _record(
+            "unhealthy",
+            "prometheus_stage_failures",
+            4,
+            105_000,
+            _attributes("cumulative_snapshot", metric_source="vllm", stage="process"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_stage_failures",
+            6,
+            135_000,
+            _attributes("cumulative_snapshot", metric_source="vllm", stage="process"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_stage_failures",
+            3,
+            105_000,
+            _attributes("cumulative_snapshot", metric_source="vllm", stage="scrape"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_stage_failures",
+            3,
+            135_000,
+            _attributes("cumulative_snapshot", metric_source="vllm", stage="scrape"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_dropped_samples",
+            4,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm", drop_reason="sample_limit"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_dropped_samples",
+            1,
+            150_000,
+            _attributes("current_snapshot", metric_source="vllm", drop_reason="sample_limit"),
+        ),
+        _record(
+            "unhealthy",
+            "prometheus_dropped_samples",
+            2,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm", drop_reason="telemetry_loss"),
+        ),
+        _record(
+            "healthy",
+            "prometheus_dropped_samples",
+            0,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm", drop_reason="sample_limit"),
+        ),
+    ]
+
+    rows = _query_rows(_database(records))
+    health = [row for row in rows if row["section"] == "telemetry_health"]
+
+    assert [(row["metric"], row["stat"], row["series"], row["value"], row["unit"], row["status"]) for row in health] == [
+        ("collector", "polls", "all resources", 2.0, "polls", "incomplete"),
+        ("collection failures", "delta", "process", 2.0, "failures", None),
+        ("dropped samples", "total", "sample_limit", 5.0, "samples", None),
+        ("dropped samples", "total", "telemetry_loss", 2.0, "samples", None),
+        ("source availability", "unavailable polls", "all resources", 1.0, "polls", None),
+    ]
+
+
 def test_query_returns_explicit_no_data_row():
     rows = _query_rows(_database([]))
     assert rows == [
@@ -408,7 +519,19 @@ def test_query_returns_explicit_no_data_row():
             "status": "no_data",
             "samples": 0,
             "gap_seconds": None,
-        }
+        },
+        {
+            "t": None,
+            "section": "telemetry_health",
+            "metric": "collector",
+            "stat": "polls",
+            "series": "all resources",
+            "value": 0.0,
+            "unit": "polls",
+            "status": "unknown",
+            "samples": 0,
+            "gap_seconds": None,
+        },
     ]
 
 


### PR DESCRIPTION
Add collector health to the existing bounded vLLM overview and render it beside replica freshness. A selected window reports `incomplete` when any collector resource has an unavailable source poll, a positive reset-aware collection-stage failure delta, or dropped samples. Nonzero failures and dropped-sample totals retain their stage or reason.

Collector rows stay out of serving freshness, so a health-only window still reports freshness `no_data`. `healthy` means poll evidence reported no known collection loss; no poll evidence reports `unknown`. The endpoint and ordered ten-column result contract are unchanged.

A bounded production Finelog query confirmed the three health families share the existing job, run, and execution scope. Generated final SQL passed Finelog's planner and returned the ordered ten-column result. The DuckDB overview and dashboard provisioning suites passed 58 tests. The new panel's rendered production smoke remains post-merge; no deployment was performed.

Fixes #8726
