### PR TITLE
[infra] Fix stale docs, Makefile test target, and CI action pins

### DIFF
--- a/.github/actions/claude-triage/action.yaml
+++ b/.github/actions/claude-triage/action.yaml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Run claude-code-action
       id: claude
-      uses: marin-community/marin-style/actions/consult-agent@main
+      uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
       with:
         claude_code_oauth_token: ${{ inputs.oauth-token }}
         prompt: |

--- a/.github/workflows/marin-canary-datakit-tier1.yaml
+++ b/.github/workflows/marin-canary-datakit-tier1.yaml
@@ -210,7 +210,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Tier 2 Ferry failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-datakit-tier3.yaml
+++ b/.github/workflows/marin-canary-datakit-tier3.yaml
@@ -189,7 +189,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Nemotron Ferry failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -302,7 +302,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *GPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -234,7 +234,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *TPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -200,7 +200,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Grug multislice smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ops-agent-prose-cleanup.yaml
+++ b/.github/workflows/ops-agent-prose-cleanup.yaml
@@ -29,14 +29,14 @@ jobs:
       # pull_request_target can expose credentials, so execute only the
       # default-branch cleaner. Never check out or execute the PR head.
       - name: Checkout default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Rewrite for a technical reader
         id: rewrite
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
       # The publisher also executes only default-branch code. The model output is
       # untrusted data and passes through the Python validator before any write.
       - name: Checkout default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -30,13 +30,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Review
         id: claude
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           track_progress: true
@@ -78,7 +78,7 @@ jobs:
       # the git token so executed PR code cannot reuse it. fetch-depth 0 gives the
       # history the merge-base diff needs.
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run Lint Review
         id: claude
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
@@ -112,7 +112,7 @@ jobs:
 
       - name: Triage Issue
         id: claude
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
@@ -230,7 +230,7 @@ jobs:
 
       - name: Apply Autofix
         id: claude
-        uses: marin-community/marin-style/actions/consult-agent@main
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'

--- a/.github/workflows/ops-docker-images.yaml
+++ b/.github/workflows/ops-docker-images.yaml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: 'actions/checkout@v5'
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        uses: marin-community/marin-style/actions/notify-slack@main
+        uses: marin-community/marin-style/actions/notify-slack@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb  # main 2026-08-24
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Nightly slow tests failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -284,13 +284,6 @@ jobs:
             -w /workspace \
             $DOCKER_IMAGE \
             bash -c "\
-              # Install Node.js in userspace if not present (needed for protobuf generation during uv sync)
-              if ! command -v npx >/dev/null 2>&1; then \
-                echo '::group::Installing Node.js in userspace'; \
-                curl -fsSL https://nodejs.org/dist/v22.16.0/node-v22.16.0-linux-x64.tar.xz | tar -xJ -C /tmp && \
-                export PATH=/tmp/node-v22.16.0-linux-x64/bin:\$PATH; \
-                echo '::endgroup::'; \
-              fi && \
               cp -a /workspace-src/. /workspace/ && cd /workspace && \
               ( status=0; \
                 timeout --kill-after=5 --signal=TERM 1490 \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: help clean check fix setup_pre_commit rust-dev rust-user rust-status configure_gcp_registry_all
-.DEFAULT: help
+.PHONY: help clean check fix lint test init dev_setup setup_pre_commit rust-dev rust-user rust-status configure_gcp_registry_all
+.DEFAULT_GOAL := help
 
 
 help:
@@ -12,7 +12,7 @@ help:
 	@echo "make lint"
 	@echo "    Run infra/pre-commit.py --all-files (no auto-fixing)."
 	@echo "make test"
-	@echo "    Run all tests"
+	@echo "    Run the safe tests affected by the current branch and working tree"
 	@echo "make init"
 	@echo "    Init the repo for development"
 	@echo "make rust-dev"
@@ -54,9 +54,7 @@ configure_gcp_registry_all:
 	uv run infra/configure_gcp_registry.py marin --all-regions
 
 test:
-	export HUGGING_FACE_HUB_TOKEN=$HF_TOKEN
-	export HF_HUB_TOKEN=$HF_TOKEN
-	RAY_ADDRESS= PYTHONPATH=tests:. pytest tests --durations=0 -n 4 --tb=no -v
+	uv run --no-project infra/ci/run_tests.py
 
 
 # stuff for setting up locally

--- a/experiments/grug/README.md
+++ b/experiments/grug/README.md
@@ -183,5 +183,5 @@ enforces these minimum interfaces:
 - Backward-flow recipe: [`/docs/recipes/add_grug_backward_flow_logging.md`](../../docs/recipes/add_grug_backward_flow_logging.md)
 - HBM/OOM tuning guide: [`/docs/references/hbm-optimization.md`](../../docs/references/hbm-optimization.md)
 - Lazy artifact mechanics: [`/docs/explanations/lazy-artifacts.md`](../../docs/explanations/lazy-artifacts.md)
-- TPU debug workflow: [`.agents/skills/reserve-tpu/`](../../.agents/skills/reserve-tpu/SKILL.md)
+- TPU debug workflow: [`.agents/skills/use-iris/`](../../.agents/skills/use-iris/SKILL.md)
 - Cluster launch details: [`lib/iris/OPS.md`](../../lib/iris/OPS.md), [`.agents/skills/run-ferries/SKILL.md`](../../.agents/skills/run-ferries/SKILL.md)

--- a/infra/README.md
+++ b/infra/README.md
@@ -3,8 +3,8 @@ Marin compute runs on GCP TPUs (provided by TRC) and CoreWeave GPUs. The named
 cluster configs in `lib/iris/config/` are the source of truth:
 
 - `marin` (production GCP): a single multi-region cluster whose TPU pools span
-  v5e (us-west4, europe-west4), v5p (us-central1, us-east5), and v6e
-  (us-east1, us-east5, europe-west4).
+  v4 (us-central2), v5e (us-west4, europe-west4), v5p (us-central1, us-east5),
+  and v6e (us-east1, us-east5, europe-west4).
 - `marin-dev`: dev cluster with smaller scale caps.
 - `cw-rno2a`, `cw-us-east-02a`, `cw-us-east-08a`, `cw-us-west-04a`: CoreWeave
   GPU clusters (see `lib/iris/docs/coreweave.md`).

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,14 +1,13 @@
-# Autoscaling Cluster for Marin Data Processing
-In Marin, we use GCP TPUs (provided by TRC) to do all of our work, including non-training tasks.
-We have several clusters for Marin, each with a different TPU type:
+# Autoscaling Clusters for Marin Data Processing
+Marin compute runs on GCP TPUs (provided by TRC) and CoreWeave GPUs. The named
+cluster configs in `lib/iris/config/` are the source of truth:
 
-- `marin-us-central2` (default): v4's
-- `marin-us-west4`: v5e's
-- `marin-eu-west4`: v5e's
-- `marin-us-east5` (v6e's)
-- `marin-us-east1` (v6e's)
-- `marin-us-central1` (v6e's)
-- `marin-big-run` (v4, reserved for the hero run, whatever it may be. Do not use for anything else.)
+- `marin` (production GCP): a single multi-region cluster whose TPU pools span
+  v5e (us-west4, europe-west4), v5p (us-central1, us-east5), and v6e
+  (us-east1, us-east5, europe-west4).
+- `marin-dev`: dev cluster with smaller scale caps.
+- `cw-rno2a`, `cw-us-east-02a`, `cw-us-east-08a`, `cw-us-west-04a`: CoreWeave
+  GPU clusters (see `lib/iris/docs/coreweave.md`).
 
 
 

--- a/infra/check_docs_source_links.py
+++ b/infra/check_docs_source_links.py
@@ -38,15 +38,20 @@ def _normalize_url(url: str) -> str:
     return url
 
 
+def _iter_links(md_path: Path):
+    """Yield (raw, normalized) markdown link targets in one file."""
+    text = md_path.read_text(encoding="utf-8")
+    for match in LINK_RE.finditer(text):
+        yield match.group(1), _normalize_url(match.group(1))
+
+
 def _check_docs() -> list[str]:
     errors: list[str] = []
     if not DOCS_DIR.exists():
         return errors
 
     for md_path in DOCS_DIR.rglob("*.md"):
-        text = md_path.read_text(encoding="utf-8")
-        for match in LINK_RE.finditer(text):
-            url = _normalize_url(match.group(1))
+        for _, url in _iter_links(md_path):
             gh_match = GITHUB_RE.match(url)
             if not gh_match:
                 continue
@@ -83,9 +88,7 @@ def _iter_relative_check_files() -> list[Path]:
 def _check_relative_links() -> list[str]:
     findings: list[str] = []
     for md_path in _iter_relative_check_files():
-        text = md_path.read_text(encoding="utf-8")
-        for match in LINK_RE.finditer(text):
-            url = _normalize_url(match.group(1))
+        for raw, url in _iter_links(md_path):
             if not url or "://" in url or url.startswith(("mailto:", "#", "{")):
                 continue
             if GITHUB_RE.match(url):
@@ -94,7 +97,7 @@ def _check_relative_links() -> list[str]:
             base = ROOT_DIR if url.startswith("/") else md_path.parent
             target = (base / url.lstrip("/")).resolve()
             if not target.exists():
-                findings.append(f"{md_path.relative_to(ROOT_DIR)}: {match.group(1)}")
+                findings.append(f"{md_path.relative_to(ROOT_DIR)}: {raw}")
     return findings
 
 

--- a/infra/check_docs_source_links.py
+++ b/infra/check_docs_source_links.py
@@ -1,7 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Validate GitHub source links in docs point to paths that exist locally."""
+"""Validate GitHub source links in docs point to paths that exist locally.
+
+Also reports (advisory-only) broken relative links in markdown outside docs/,
+which mkdocs --strict does not cover: lib/*/docs, OPS.md, AGENTS.md, READMEs.
+"""
 
 import re
 from pathlib import Path
@@ -9,11 +13,18 @@ from pathlib import Path
 DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
 ROOT_DIR = DOCS_DIR.parent
 
-LINK_RE = re.compile(r"\]\(([^)]+)\)")
+LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 GITHUB_RE = re.compile(r"https://github\.com/marin-community/marin/(blob|tree)/(?P<ref>[^/]+)/(?P<path>.+)")
 # A commit-pinned ref (full or abbreviated SHA) names an immutable snapshot, so its
 # target may legitimately no longer exist at HEAD; only branch/tag links must resolve.
 SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+# projects/ and logbooks/ under any .agents dir are historical snapshots: links
+# there describe the tree as of writing and rot by design. snapshots/ holds test
+# fixture data. Top-level docs/ is covered by mkdocs --strict.
+SKIP_PART_NAMES = {"node_modules", "dist", "build", "target", "projects", "logbooks", "snapshots"}
+KEEP_HIDDEN_DIRS = {".agents", ".github", ".claude"}
+LINE_SUFFIX_RE = re.compile(r":(\d+)(-\d+)?$")
 
 
 def _normalize_url(url: str) -> str:
@@ -54,16 +65,56 @@ def _check_docs() -> list[str]:
     return errors
 
 
+def _iter_relative_check_files() -> list[Path]:
+    files = []
+    for md_path in ROOT_DIR.rglob("*.md"):
+        rel = md_path.relative_to(ROOT_DIR)
+        if rel.parts[0] == "docs":
+            continue
+        parts = set(rel.parts[:-1])
+        if parts & SKIP_PART_NAMES:
+            continue
+        if any(p.startswith(".") and p not in KEEP_HIDDEN_DIRS for p in parts):
+            continue
+        files.append(md_path)
+    return files
+
+
+def _check_relative_links() -> list[str]:
+    findings: list[str] = []
+    for md_path in _iter_relative_check_files():
+        text = md_path.read_text(encoding="utf-8")
+        for match in LINK_RE.finditer(text):
+            url = _normalize_url(match.group(1))
+            if not url or "://" in url or url.startswith(("mailto:", "#", "{")):
+                continue
+            if GITHUB_RE.match(url):
+                continue
+            url = LINE_SUFFIX_RE.sub("", url)
+            base = ROOT_DIR if url.startswith("/") else md_path.parent
+            target = (base / url.lstrip("/")).resolve()
+            if not target.exists():
+                findings.append(f"{md_path.relative_to(ROOT_DIR)}: {match.group(1)}")
+    return findings
+
+
 def main() -> int:
+    status = 0
     errors = _check_docs()
     if not errors:
         print("Docs source links: OK")
-        return 0
+    else:
+        print("Docs source links: broken")
+        for entry in errors:
+            print(entry)
+        status = 1
 
-    print("Docs source links: broken")
-    for entry in errors:
-        print(entry)
-    return 1
+    advisories = _check_relative_links()
+    if advisories:
+        print(f"\nAdvisory: {len(advisories)} broken relative links outside docs/ (not gating):")
+        for entry in advisories:
+            print(entry)
+    return status
 
 
 if __name__ == "__main__":

--- a/infra/finelog/Pulumi.yaml
+++ b/infra/finelog/Pulumi.yaml
@@ -1,4 +1,6 @@
 name: finelog
+backend:
+  url: gs://marin-iac-state/
 runtime:
   name: python
   # Use the shared repo venv, which contains finelog, iac, and the Pulumi providers.

--- a/lib/haliax/docs/mutable-refs.md
+++ b/lib/haliax/docs/mutable-refs.md
@@ -130,4 +130,4 @@ The helper integrates with slice refs, so you can swap just a subset of the buff
 prev = hax.swap(cache_ref, {"layer": slice(0, 2)}, hax.ones((Cache.resize(2), Head)))
 ```
 
-See [`tests/test_named_ref.py`](tests/test_named_ref.py) for runnable examples that exercise the API.
+See [`tests/test_named_ref.py`](../tests/test_named_ref.py) for runnable examples that exercise the API.

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -606,15 +606,15 @@ uv run finelog query marin "SELECT source, type, format, count(*) FROM \"iris.pr
 ```
 
 To aggregate a whole job's CPU profiles into a per-worker-sub-job breakdown + merged
-flamegraph, use `scripts/job_profile_summary.py` — it resolves the cluster's finelog
+flamegraph, use `lib/iris/scripts/job_profile_summary.py` — it resolves the cluster's finelog
 deployment, pulls every CPU capture under a job (and its descendant sub-jobs), parses the
 speedscope stacks, and reports where CPU is spent:
 
 ```bash
-uv run python scripts/job_profile_summary.py /user/job/id          # per-sub-job + top leaves
-uv run python scripts/job_profile_summary.py <dashboard-url>       # accepts iris.oa.dev URLs
-uv run python scripts/job_profile_summary.py /user/job/id --subjob <name> --show-stacks
-uv run python scripts/job_profile_summary.py /user/job/id -o merged.folded --svg flame.svg
+uv run python lib/iris/scripts/job_profile_summary.py /user/job/id          # per-sub-job + top leaves
+uv run python lib/iris/scripts/job_profile_summary.py <dashboard-url>       # accepts iris.oa.dev URLs
+uv run python lib/iris/scripts/job_profile_summary.py /user/job/id --subjob <name> --show-stacks
+uv run python lib/iris/scripts/job_profile_summary.py /user/job/id -o merged.folded --svg flame.svg
 ```
 
 ## Users & Auth

--- a/lib/iris/docs/reconcile_rpc.md
+++ b/lib/iris/docs/reconcile_rpc.md
@@ -18,19 +18,19 @@ defines `ReconcileRequest` (`worker_id`, repeated `DesiredAttempt`) and
 keyed by a 16-hex-char `attempt_uid`. `AttemptSpec.request` is populated only
 on the dispatch tick for an `ASSIGNED` attempt; subsequent ticks omit it and
 the worker pulls from its local cache (see
-[`reconcile.py`](../src/iris/cluster/controller/reconcile.py),
-`reconcile_workers`). `AttemptObservation` echoes the same `attempt_uid`, so
+[`reconcile/worker.py`](../src/iris/cluster/controller/reconcile/worker.py),
+`build_reconcile_plans`). `AttemptObservation` echoes the same `attempt_uid`, so
 routing is purely UID-based — there is no (task_id, attempt_id) fallback.
 
 ## Control flow
 
 ```mermaid
 sequenceDiagram
-    participant Loop as Controller<br/>_reconcile_worker_batch
-    participant Pure as reconcile.py<br/>reconcile_workers()
+    participant Loop as Controller<br/>plans_from_snapshot
+    participant Pure as reconcile/worker.py<br/>build_reconcile_plans()
     participant Prov as RpcTaskBackend<br/>reconcile()
     participant W as Worker
-    participant Apply as transitions<br/>apply_reconcile_result
+    participant Apply as ReconcileState<br/>reconcile()
 
     Loop->>Pure: ReconcileInputs (rows + job_specs)
     Pure-->>Loop: list[WorkerReconcilePlan]
@@ -43,17 +43,17 @@ sequenceDiagram
 
 ## Pure compute vs. transport
 
-`controller._reconcile_worker_batch`
-([`controller.py`](../src/iris/cluster/controller/controller.py)) snapshots DB
-rows and calls `reconcile_workers(inputs)`
-([`reconcile.py`](../src/iris/cluster/controller/reconcile.py),
-`reconcile_workers`) to produce one `WorkerReconcilePlan` per worker (the
+`plans_from_snapshot`
+([`backend.py`](../src/iris/cluster/controller/backend.py)) snapshots DB
+rows and calls `build_reconcile_plans(inputs)`
+([`reconcile/worker.py`](../src/iris/cluster/controller/reconcile/worker.py))
+to produce one `WorkerReconcilePlan` per worker (the
 `ReconcileRequest` proto is built once inside the plan). The plans flow
 through `RpcTaskBackend.reconcile`
 ([`backends/rpc/backend.py`](../src/iris/cluster/backends/rpc/backend.py))
-which fans them out under a single `asyncio.gather` capped by
-`self.parallelism` and returns a `ReconcileResult` per worker. The apply layer
-([`transitions.apply_reconcile_result`](../src/iris/cluster/controller/transitions.py))
+which fans them out concurrently, capped by
+`self.parallelism`, and returns a `ReconcileResult` per worker. The apply layer
+([`ReconcileState.reconcile`](../src/iris/cluster/controller/reconcile/batches.py))
 consumes those results.
 
 ## Worker side
@@ -72,7 +72,7 @@ attempt) or for zombies it is killing this tick (so the controller can confirm
 the implicit kill). Terminal local history outside the desired set is
 suppressed — otherwise a worker could emit hundreds of stale terminal
 observations per tick, each driving a DB write. The controller mirrors this
-in `_filter_observations_to_plan`
-([`transitions.py`](../src/iris/cluster/controller/transitions.py)):
+in `filter_observations_to_plan`
+([`reconcile/worker.py`](../src/iris/cluster/controller/reconcile/worker.py)):
 observations whose attempt is not in the per-worker `WorkerReconcilePlan` are
 dropped (DEBUG-logged) before any work is done.

--- a/lib/levanter/docs/recipes/port-models.md
+++ b/lib/levanter/docs/recipes/port-models.md
@@ -7,7 +7,7 @@ description: A guide for porting model architectures to the Levanter ecosystem u
 
 This guide outlines the steps to port a model architecture (e.g. from Hugging Face or another JAX framework) to
 the Levanter ecosystem using Haliax and Equinox. This guide is focused on LLMs, but the principles apply to other models as well.
-Agents can also refer to [Port-Models.md](../docs/dev/Port-Models.md), which contains a more detailed, human-oriented guide.
+Agents can also refer to [Port-Models.md](../dev/Port-Models.md), which contains a more detailed, human-oriented guide.
 
 In general, pattern match on `llama.py` or `mixtral.py` for examples of how to implement a model.
 

--- a/lib/zephyr/OPS.md
+++ b/lib/zephyr/OPS.md
@@ -145,17 +145,21 @@ maximum. Later stages can reshard while reusing that group. More shards than wor
 normal because workers pull multiple tasks. Read shard progress with alive-worker state;
 the registered-worker count alone can overstate available capacity.
 
-### Straggler Detection
+### Stragglers and Data Skew
 
-1. **Progress line**: `in-flight >> 0` with `queued == 0` means stragglers — no new work to assign, waiting on slow shards.
-2. **Memory/disk distribution**: Query `ListTasks` and bucket by `memoryMb` and `diskMb`. Idle workers: <200 MB. Finished: 1-5 GB. Stragglers: >5 GB (or high CPU/disk).
-3. **THR on high-memory workers**: Confirm they're in `_execute_shard` with `active+gil`. The user function in the stack identifies the bottleneck.
+`in-flight >> 0` with `queued == 0` means stragglers: no new work to assign,
+waiting on slow shards.
 
-### Data Skew
+```bash
+# Bucket workers by memoryMb/diskMb: <200 MB idle, 1-5 GB finished, >5 GB straggler.
+uv run iris rpc controller list-tasks --job-id <JOB_ID>
+```
 
-Symptom: most shards complete fast, a few take orders of magnitude longer.
-
-Diagnosis: THR on the straggler worker shows the user-level reduce function holding the GIL. Compare memory across workers — skewed keys produce 10-100x memory outliers.
+Take a few THR samples of a straggler (dashboard THR button, ~2s apart). The
+`zephyr-poll-*` stack in `_execute_shard` with `active+gil` names the user
+function that is the bottleneck; `idle` at `write_table` means I/O bound. Data
+skew looks like a handful of shards 10-100x slower and heavier than the rest,
+with the user-level reduce function holding the GIL.
 
 ### Worker Failures / Reassignment
 
@@ -164,18 +168,6 @@ Workers that failed and got reassigned show in the task table with `Worker ... f
 ### Misleading Diagnostics
 
 **"Terminated by user"** does not necessarily mean a human killed the job. The system uses this message for various internal termination reasons. Always check the actual logs at each level (parent job, coordinator, workers) to determine the real cause.
-
-### Poor Man's Profiling
-
-Take 5-10 THR samples from the same worker with ~2s intervals. The `zephyr-poll-*` thread stack shows where time is spent:
-
-| Thread state | Location | Meaning |
-|---|---|---|
-| `active+gil` in `_execute_shard` | `_reduce_gen`, `_scatter_items`, user fn | Doing work |
-| `idle` at `_poll_loop:1163` | — | Waiting for tasks |
-| `idle` at `write_table` (pyarrow) | — | I/O bound |
-
-Coordinator: `actor-method_0` in `_wait_for_stage` means it's blocked waiting for the current stage to finish.
 
 ## Requesting New Tools
 


### PR DESCRIPTION
`make test` invoked pytest directly with per-line no-op exports, a Make-mangled
`$HF_TOKEN` expansion, and a dead `RAY_ADDRESS` override; it now delegates to
`infra/ci/run_tests.py`, the same diff-driven runner CI uses.

Pin the marin-style `consult-agent` and `notify-slack` actions to a commit SHA
instead of the mutable `@main` ref (both run with repository secrets),
normalize the four `actions/checkout@v6` stragglers to the fleet-wide v5, and
drop the TPU-CI userspace Node.js fallback: the tpu-ci image installs Node via
nodesource, and recent levanter-tpu job logs show the fallback never fires.

`infra/check_docs_source_links.py` grows an advisory (non-gating) pass that
resolves relative markdown links outside `docs/`, skipping `.agents` snapshot
directories and test fixtures. Fix the seven links it found: the Iris
reconcile doc now points at the `reconcile/` package and its renamed entry
points, and the Zephyr straggler guidance is condensed to the commands.
Refresh the pre-consolidation cluster list in `infra/README.md`, correct the
`job_profile_summary.py` path in `lib/iris/OPS.md`, and commit the
`gs://marin-iac-state/` backend in `infra/finelog/Pulumi.yaml` to match the
other ten Pulumi projects and the login target its README already documents.
