### PR TITLE
grug: improve one-rack EP64 throughput

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -47,6 +47,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
 from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
 from experiments.grug.moe_hero_ep.train import (
     RAGGED_MOE_IMPLEMENTATION,
+    GpuCommandBufferMode,
     GrugEvalConfig,
     GrugRunConfig,
     MasterParamMode,
@@ -59,6 +60,9 @@ from experiments.grug.moe_hero_ep.train import (
 DEFAULT_HERO_STEPS = 25
 HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
 DIAGNOSTIC_PARAM_DTYPES = ("bfloat16", "float32")
+DIAGNOSTIC_SHARED_EXPERT_COMPUTE = ("separate", "fused")
+DIAGNOSTIC_SMALL_PARAM_SHARDING = ("replicated", "fsdp")
+DIAGNOSTIC_MASTER_PARAM_MODES = tuple(mode.value for mode in MasterParamMode)
 
 
 def build_diagnostic_run(
@@ -70,6 +74,7 @@ def build_diagnostic_run(
     seed: int = 0,
     batch_size: int = HERO_EP_BATCH_SIZE,
     num_experts: int | None = None,
+    num_expert_waves: int | None = None,
     num_experts_per_token: int | None = None,
     intermediate_dim: int | None = None,
     capacity_factor: float | None = None,
@@ -87,7 +92,10 @@ def build_diagnostic_run(
     profile_steps: int = 0,
     profile_start_step: int = 5,
     training_data_mode: TrainingDataMode = TrainingDataMode.MIXTURE,
-    param_dtype: str = "bfloat16",
+    param_dtype: str | None = None,
+    shared_expert_compute: str = "separate",
+    small_param_sharding: str = "replicated",
+    gpu_command_buffer_mode: GpuCommandBufferMode = GpuCommandBufferMode.DISABLED,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
     """Build a bounded diagnostic run for the production EP64 hero recipe.
@@ -113,8 +121,18 @@ def build_diagnostic_run(
         raise ValueError(f"profile_start_step must be non-negative, got {profile_start_step}")
     if profile_steps > 0 and profile_start_step >= num_steps:
         raise ValueError(f"profile_start_step must be less than num_steps={num_steps}, got {profile_start_step}")
-    if param_dtype not in DIAGNOSTIC_PARAM_DTYPES:
+    if param_dtype is not None and param_dtype not in DIAGNOSTIC_PARAM_DTYPES:
         raise ValueError(f"param_dtype must be one of {DIAGNOSTIC_PARAM_DTYPES}, got {param_dtype}")
+    if shared_expert_compute not in DIAGNOSTIC_SHARED_EXPERT_COMPUTE:
+        raise ValueError(
+            f"shared_expert_compute must be one of {DIAGNOSTIC_SHARED_EXPERT_COMPUTE}, got {shared_expert_compute}"
+        )
+    if small_param_sharding not in DIAGNOSTIC_SMALL_PARAM_SHARDING:
+        raise ValueError(
+            f"small_param_sharding must be one of {DIAGNOSTIC_SMALL_PARAM_SHARDING}, got {small_param_sharding}"
+        )
+    if master_param_mode == MasterParamMode.DEVICE and param_dtype not in (None, "float32"):
+        raise ValueError("device master parameters require float32 device parameters")
     # `schedule_steps` sets the whole learning-rate schedule; `num_steps` is the absolute step the
     # run stops at (a restore resumes mid-schedule, so it must lie past the restored step).
     # Both matter, and they enter in different places. The optimizer heuristic scales learning rate,
@@ -132,11 +150,16 @@ def build_diagnostic_run(
         num_train_steps=total_schedule_steps,
         batch_size=batch_size,
     )
-    model = HERO_MODEL_CONFIG
+    model = dataclasses.replace(
+        HERO_MODEL_CONFIG,
+        shared_expert_compute=shared_expert_compute,
+        small_param_sharding=small_param_sharding,
+    )
     overrides = {
         name: value
         for name, value in (
             ("num_experts", num_experts),
+            ("num_expert_waves", num_expert_waves),
             ("num_experts_per_token", num_experts_per_token),
             ("intermediate_dim", intermediate_dim),
             ("capacity_factor", capacity_factor),
@@ -162,6 +185,11 @@ def build_diagnostic_run(
             f"{RAGGED_MOE_IMPLEMENTATION} needs one process per GPU: pass "
             f"processes_per_task={HERO_GPUS_PER_NODE}, got {processes_per_task}"
         )
+    if (
+        model.moe_implementation == RAGGED_MOE_IMPLEMENTATION
+        and gpu_command_buffer_mode != GpuCommandBufferMode.DISABLED
+    ):
+        raise ValueError(f"{RAGGED_MOE_IMPLEMENTATION} requires disabled GPU command buffers")
     pooled = model.moe_implementation == "fixed_pooled_wave_all_to_all"
     if pooled and model.pooled_transport_capacity_factor is None:
         raise AssertionError("the pooled-wave hero requires a transport capacity factor")
@@ -170,6 +198,9 @@ def build_diagnostic_run(
     # Only the pooled transport has a receiver capacity of its own to report.
     transport_capacity_tags = (f"transport-capacity-{model.pooled_transport_capacity_factor:g}",) if pooled else ()
     wave_tag = f"expert-waves-{model.num_expert_waves}"
+    shared_expert_compute_tag = f"shared-expert-compute-{shared_expert_compute}"
+    small_param_sharding_tag = f"small-param-sharding-{small_param_sharding}"
+    master_param_tag = f"master-params-{master_param_mode.value.replace('_', '-')}"
     size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
     grug_trainer = hero_grug_trainer_config(
@@ -178,6 +209,10 @@ def build_diagnostic_run(
         watch_mode=watch_mode,
         save_checkpoints=save_checkpoints,
         master_param_mode=master_param_mode,
+    )
+    grug_trainer = dataclasses.replace(
+        grug_trainer,
+        gpu_command_buffer_mode=gpu_command_buffer_mode,
     )
     train_resources = ResourceConfig.with_gpu(
         "GB200",
@@ -224,9 +259,12 @@ def build_diagnostic_run(
                     "ep",
                     backend_tag,
                     capacity_tag,
-                    f"master-params-{master_param_mode.value.replace('_', '-')}",
                     *transport_capacity_tags,
                     wave_tag,
+                    shared_expert_compute_tag,
+                    small_param_sharding_tag,
+                    master_param_tag,
+                    f"command-buffers-{gpu_command_buffer_mode.value}",
                     size_tag,
                     "gb200",
                     HARRIER_MIX_2026_08_18_TAG,
@@ -250,10 +288,11 @@ def build_diagnostic_run(
                 debug=checkpoint_debug or CheckpointDebugConfig(),
             ),
         )
-        trainer = dataclasses.replace(
-            trainer,
-            mp=jmp.get_policy(f"params={param_dtype},compute=bfloat16,output=bfloat16"),
-        )
+        if param_dtype is not None:
+            trainer = dataclasses.replace(
+                trainer,
+                mp=jmp.get_policy(f"params={param_dtype},compute=bfloat16,output=bfloat16"),
+            )
         data = harrier_mix_2026_08_18_data_config(
             ctx=ctx,
             total_steps=total_schedule_steps,
@@ -344,6 +383,13 @@ def build_diagnostic_run(
     ),
 )
 @click.option(
+    "--num-expert-waves",
+    type=click.IntRange(min=1),
+    default=HERO_MODEL_CONFIG.num_expert_waves,
+    show_default=True,
+    help="Set the number of static pooled-transport waves.",
+)
+@click.option(
     "--num-experts-per-token",
     type=click.IntRange(min=1),
     default=HERO_MODEL_CONFIG.num_experts_per_token,
@@ -371,7 +417,7 @@ def build_diagnostic_run(
 )
 @click.option(
     "--master-params",
-    type=click.Choice([mode.value for mode in MasterParamMode]),
+    type=click.Choice(DIAGNOSTIC_MASTER_PARAM_MODES),
     default=HERO_MASTER_PARAM_MODE.value,
     show_default=True,
     help=("Where the authoritative fp32 weights live: on device, or as a pinned-host master."),
@@ -458,9 +504,29 @@ def build_diagnostic_run(
 @click.option(
     "--param-dtype",
     type=click.Choice(DIAGNOSTIC_PARAM_DTYPES),
-    default="bfloat16",
+    default=None,
+    help="Override the parameter and returned-gradient dtype. Defaults to the selected master-parameter policy.",
+)
+@click.option(
+    "--shared-expert-compute",
+    type=click.Choice(DIAGNOSTIC_SHARED_EXPERT_COMPUTE),
+    default="separate",
     show_default=True,
-    help="Parameter and returned-gradient dtype. Compute and output stay bfloat16.",
+    help="Run shared experts separately or as one fused MLP.",
+)
+@click.option(
+    "--small-param-sharding",
+    type=click.Choice(DIAGNOSTIC_SMALL_PARAM_SHARDING),
+    default="replicated",
+    show_default=True,
+    help="Shard or replicate the router, attention gate, and GatedNorm factors.",
+)
+@click.option(
+    "--gpu-command-buffer-mode",
+    type=click.Choice(tuple(mode.value for mode in GpuCommandBufferMode)),
+    default=GpuCommandBufferMode.DISABLED.value,
+    show_default=True,
+    help="Capture the default GPU operation set, or disable command buffers.",
 )
 @click.option(
     "--capacity-factor",
@@ -478,6 +544,7 @@ def main(
     seed: int,
     batch_size: int,
     num_experts: int | None,
+    num_expert_waves: int | None,
     num_experts_per_token: int | None,
     intermediate_dim: int | None,
     capacity_factor: float | None,
@@ -495,7 +562,10 @@ def main(
     profile_steps: int,
     profile_start_step: int,
     training_data: str,
-    param_dtype: str,
+    param_dtype: str | None,
+    shared_expert_compute: str,
+    small_param_sharding: str,
+    gpu_command_buffer_mode: str,
 ) -> ArtifactStep[HeroThroughputResult]:
     return build_diagnostic_run(
         run_id=run_id,
@@ -505,6 +575,7 @@ def main(
         seed=seed,
         batch_size=batch_size,
         num_experts=num_experts,
+        num_expert_waves=num_expert_waves,
         num_experts_per_token=num_experts_per_token,
         intermediate_dim=intermediate_dim,
         capacity_factor=capacity_factor,
@@ -533,6 +604,9 @@ def main(
         profile_start_step=profile_start_step,
         training_data_mode=TrainingDataMode(training_data),
         param_dtype=param_dtype,
+        shared_expert_compute=shared_expert_compute,
+        small_param_sharding=small_param_sharding,
+        gpu_command_buffer_mode=GpuCommandBufferMode(gpu_command_buffer_mode),
     )
 
 

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -8,6 +8,7 @@ import os
 from datetime import timedelta
 
 import click
+import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig
 from levanter.callbacks.watch import WatchConfig
@@ -57,6 +58,7 @@ from experiments.grug.moe_hero_ep.train import (
 
 DEFAULT_HERO_STEPS = 25
 HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
+DIAGNOSTIC_PARAM_DTYPES = ("bfloat16", "float32")
 
 
 def build_diagnostic_run(
@@ -85,6 +87,7 @@ def build_diagnostic_run(
     profile_steps: int = 0,
     profile_start_step: int = 5,
     training_data_mode: TrainingDataMode = TrainingDataMode.MIXTURE,
+    param_dtype: str = "bfloat16",
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
     """Build a bounded diagnostic run for the production EP64 hero recipe.
@@ -110,6 +113,8 @@ def build_diagnostic_run(
         raise ValueError(f"profile_start_step must be non-negative, got {profile_start_step}")
     if profile_steps > 0 and profile_start_step >= num_steps:
         raise ValueError(f"profile_start_step must be less than num_steps={num_steps}, got {profile_start_step}")
+    if param_dtype not in DIAGNOSTIC_PARAM_DTYPES:
+        raise ValueError(f"param_dtype must be one of {DIAGNOSTIC_PARAM_DTYPES}, got {param_dtype}")
     # `schedule_steps` sets the whole learning-rate schedule; `num_steps` is the absolute step the
     # run stops at (a restore resumes mid-schedule, so it must lie past the restored step).
     # Both matter, and they enter in different places. The optimizer heuristic scales learning rate,
@@ -244,6 +249,10 @@ def build_diagnostic_run(
                 keep_last_temporary_checkpoints=1,
                 debug=checkpoint_debug or CheckpointDebugConfig(),
             ),
+        )
+        trainer = dataclasses.replace(
+            trainer,
+            mp=jmp.get_policy(f"params={param_dtype},compute=bfloat16,output=bfloat16"),
         )
         data = harrier_mix_2026_08_18_data_config(
             ctx=ctx,
@@ -447,6 +456,13 @@ def build_diagnostic_run(
     help="Use the configured mixture or reuse a deterministic synthetic batch without opening TensorStore.",
 )
 @click.option(
+    "--param-dtype",
+    type=click.Choice(DIAGNOSTIC_PARAM_DTYPES),
+    default="bfloat16",
+    show_default=True,
+    help="Parameter and returned-gradient dtype. Compute and output stay bfloat16.",
+)
+@click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
     default=HERO_MODEL_CONFIG.capacity_factor,
@@ -479,6 +495,7 @@ def main(
     profile_steps: int,
     profile_start_step: int,
     training_data: str,
+    param_dtype: str,
 ) -> ArtifactStep[HeroThroughputResult]:
     return build_diagnostic_run(
         run_id=run_id,
@@ -515,6 +532,7 @@ def main(
         profile_steps=profile_steps,
         profile_start_step=profile_start_step,
         training_data_mode=TrainingDataMode(training_data),
+        param_dtype=param_dtype,
     )
 
 

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -94,6 +94,15 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
 
 
 RematMode = Literal["recompute_all", "save_moe"]
+SharedExpertCompute = Literal["separate", "fused"]
+SmallParamSharding = Literal["replicated", "fsdp"]
+
+
+def _small_param_spec(sharding: SmallParamSharding, *, shard_dim: int) -> P:
+    """Partition a 2-D small parameter over the EP model's FSDP axes."""
+    if sharding == "replicated":
+        return P(None, None)
+    return P(*(_FSDP_AXES if dim == shard_dim else None for dim in range(2)))
 
 
 def _batch_spec() -> P:
@@ -163,6 +172,7 @@ class GrugModelConfig:
     intermediate_dim: int = 256
     shared_expert_intermediate_dim: int = 512
     num_shared_experts: int = 1
+    shared_expert_compute: SharedExpertCompute = "separate"
     num_experts: int = 256
     num_experts_per_token: int = 4
     # LatentMoE (arXiv 2601.18089); latent RMSNorm per issue #6822.
@@ -195,6 +205,8 @@ class GrugModelConfig:
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
     backward skips re-running expert dispatch and its EP collectives."""
+    small_param_sharding: SmallParamSharding = "replicated"
+    """Layout of the router, attention gate, and GatedNorm factors."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
     rope_fused: bool = False
 
@@ -213,6 +225,10 @@ class GrugModelConfig:
                 raise ValueError("num_kv_heads must equal the stored maximum of local/global KV heads")
         if self.global_every <= 0:
             raise ValueError("global_every must be positive")
+        if self.shared_expert_compute not in ("separate", "fused"):
+            raise ValueError(f"unknown shared expert compute: {self.shared_expert_compute}")
+        if self.small_param_sharding not in ("replicated", "fsdp"):
+            raise ValueError(f"unknown small parameter sharding: {self.small_param_sharding}")
         if self.vocab_size <= 0:
             raise ValueError("vocab_size must be positive")
         if self.max_seq_len <= 0:
@@ -304,6 +320,7 @@ class GrugModelConfig:
                 )
             ),
             num_shared_experts=int(_hf_config_attr(hf_config, ("num_shared_experts",), 1)),
+            shared_expert_compute=_hf_config_attr(hf_config, ("shared_expert_compute",), "separate"),
             num_experts=int(_hf_config_attr(hf_config, ("num_experts", "num_local_experts"), 8)),
             num_experts_per_token=int(_hf_config_attr(hf_config, ("num_experts_per_token", "num_experts_per_tok"), 2)),
             latent_dim=None if latent_dim is None else int(latent_dim),
@@ -351,6 +368,7 @@ class GrugModelConfig:
             "moe_intermediate_size": self.intermediate_dim,
             "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
             "num_shared_experts": self.num_shared_experts,
+            "shared_expert_compute": self.shared_expert_compute,
             # grug-specific (no public equivalent)
             "latent_dim": self.latent_dim,
             "qk_mult": self.qk_mult,
@@ -465,7 +483,7 @@ class CausalSelfAttention(eqx.Module):
             w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P(_FSDP_AXES, "model")),
             w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P(_FSDP_AXES, "model")),
             w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", _FSDP_AXES)),
-            attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            attn_gate=reshard(jnp.zeros((d, n)), _small_param_spec(cfg.small_param_sharding, shard_dim=0)),
             sconv_k=(ShortConv.init(m * h, cfg.sconv_kernel) if cfg.sconv and "k" in cfg.sconv_sites else None),
             cfg=cfg,
         )
@@ -580,7 +598,8 @@ class CausalSelfAttention(eqx.Module):
         v_norm_sq = jnp.sum(aligned_v * aligned_v, axis=-1, keepdims=True)
         attn_out = attn_out - (dot / (v_norm_sq + 1e-6)) * aligned_v
         # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
-        gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
+        attn_gate = reshard(self.attn_gate, P(None, None))
+        gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, attn_gate))[..., None]
         attn_out = gate * attn_out
         # Merge heads into hidden dim while keeping model-axis sharding for w_o.
         attn_out = jnp.reshape(
@@ -617,20 +636,34 @@ class GatedNorm(eqx.Module):
     w_up: jax.Array
 
     @staticmethod
-    def init(hidden_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "GatedNorm":
+    def init(
+        hidden_dim: int,
+        initializer_std: float,
+        small_param_sharding: SmallParamSharding,
+        *,
+        key: PRNGKeyArray,
+    ) -> "GatedNorm":
         k_down, k_up = random.split(key)
         return GatedNorm(
-            w_down=reshard(_init_weight(k_down, (hidden_dim, _GATED_NORM_RANK), initializer_std), P(None, None)),
-            w_up=reshard(_init_weight(k_up, (_GATED_NORM_RANK, hidden_dim), initializer_std), P(None, None)),
+            w_down=reshard(
+                _init_weight(k_down, (hidden_dim, _GATED_NORM_RANK), initializer_std),
+                _small_param_spec(small_param_sharding, shard_dim=0),
+            ),
+            w_up=reshard(
+                _init_weight(k_up, (_GATED_NORM_RANK, hidden_dim), initializer_std),
+                _small_param_spec(small_param_sharding, shard_dim=1),
+            ),
         )
 
     @named_call
     def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
-        gate_hidden = jnp.einsum("...d,dr->...r", x, self.w_down)
+        w_down = reshard(self.w_down, P(None, None))
+        w_up = reshard(self.w_up, P(None, None))
+        gate_hidden = jnp.einsum("...d,dr->...r", x, w_down)
         # TODO: silu activation here isn't explored, just cargo-culted from Qwen. Likely low-hanging ablation fruit
         # (e.g. compare no activation, relu, etc.).
         gate_hidden = jax.nn.silu(gate_hidden)
-        gate = jax.nn.sigmoid(jnp.einsum("...r,rd->...d", gate_hidden, self.w_up))
+        gate = jax.nn.sigmoid(jnp.einsum("...r,rd->...d", gate_hidden, w_up))
         return x * gate.astype(x.dtype)
 
 
@@ -676,6 +709,29 @@ class DenseMLP(eqx.Module):
         # leaks the `expert` mesh axis onto the seq dim, so the shared+routed
         # residual add fails with a ShardingTypeError on a multi-node mesh.
         return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
+
+
+def _fused_shared_expert_mlp(
+    experts: tuple[DenseMLP, ...],
+    x: Float[Array, "B S D"],
+) -> Float[Array, "B S D"]:
+    b, s, _ = x.shape
+    x_flat = rearrange(x, "b s d -> (b s) d")
+    gate_width = sum(expert.w_gate.shape[-1] for expert in experts)
+    gate_up_weight = jnp.concatenate(
+        tuple(expert.w_gate for expert in experts) + tuple(expert.w_up for expert in experts),
+        axis=-1,
+    )
+    gate_up = jnp.einsum("td,dm->tm", x_flat, gate_up_weight)
+    gate, up = jnp.split(gate_up, (gate_width,), axis=-1)
+    down_weight = jnp.concatenate(tuple(expert.w_down for expert in experts), axis=0)
+    out_flat = jnp.einsum(
+        "tm,md->td",
+        jax.nn.silu(gate) * up,
+        down_weight,
+        out_sharding=_batch_spec(),
+    )
+    return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
 
 
 def _local_routing_stats(
@@ -930,7 +986,10 @@ class MoEMLP(eqx.Module):
         expert_width = cfg.latent_dim if cfg.latent_dim is not None else d
         latent = cfg.latent_dim
         return MoEMLP(
-            router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
+            router=reshard(
+                _init_weight(k_router, (d, e), cfg.initializer_std),
+                _small_param_spec(cfg.small_param_sharding, shard_dim=0),
+            ),
             router_bias=jnp.zeros((e,)),
             w_latent_down=(
                 None
@@ -1107,10 +1166,12 @@ class Block(eqx.Module):
             )
         return Block(
             rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
-            attn_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_attn_key),
+            attn_gated_norm=GatedNorm.init(
+                cfg.hidden_dim, cfg.initializer_std, cfg.small_param_sharding, key=gn_attn_key
+            ),
             attn=CausalSelfAttention.init(cfg, key=attn_key),
             rms_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
-            mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_mlp_key),
+            mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, cfg.small_param_sharding, key=gn_mlp_key),
             mlp=MoEMLP.init(cfg, key=mlp_key),
             shared=shared,
             sconv_attn=(
@@ -1141,8 +1202,11 @@ class Block(eqx.Module):
         mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
         mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
-            for shared_expert in self.shared:
-                mlp_out = mlp_out + shared_expert(mlp_in, activation=ActivationFunctionEnum.silu)
+            if self.mlp.cfg.shared_expert_compute == "fused":
+                mlp_out = mlp_out + _fused_shared_expert_mlp(self.shared, mlp_in)
+            else:
+                for shared_expert in self.shared:
+                    mlp_out = mlp_out + shared_expert(mlp_in, activation=ActivationFunctionEnum.silu)
         if self.sconv_mlp is not None:
             mlp_out = self.sconv_mlp(mlp_out, sconv_segment_ids)
         x = x + mlp_out
@@ -1197,11 +1261,15 @@ class Transformer(eqx.Module):
         return Transformer(
             token_embed=token_embed,
             embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
-            embed_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=embed_gn_key),
+            embed_gated_norm=GatedNorm.init(
+                cfg.hidden_dim, cfg.initializer_std, cfg.small_param_sharding, key=embed_gn_key
+            ),
             output_proj=output_proj,
             stacked_blocks=stacked_blocks,
             final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
-            final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
+            final_gated_norm=GatedNorm.init(
+                cfg.hidden_dim, cfg.initializer_std, cfg.small_param_sharding, key=final_gn_key
+            ),
             config=cfg,
         )
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -96,9 +96,8 @@ INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # (#8317); a follow-up lands that offload and turns the scheduler on.
 RAGGED_COLLECTIVE_OVERLAP_LIMIT = 1
 RAGGED_MOE_IMPLEMENTATION = "ragged_all_to_all"
-# TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
-# command buffers after the CUDA graph failure is fixed.
-XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
+XLA_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer"
+XLA_DEFAULT_GPU_COMMAND_BUFFER_CAPTURE_SET = "CONDITIONAL,CUBLAS,CUBLASLT,CUDNN,CUSTOM_CALL,DYNAMIC_SLICE_FUSION,FUSION"
 _RAGGED_REQUIRED_XLA_FLAG_NAMES = frozenset(flag.partition("=")[0] for flag in RAGGED_REQUIRED_XLA_FLAGS)
 PJRT_DISTRIBUTION = "jax-cuda13-pjrt"
 _FP32_POLICY = jmp.get_policy("params=float32,compute=float32,output=float32")
@@ -120,6 +119,13 @@ class MasterParamMode(StrEnum):
 
     DEVICE = "device"
     FP32_PINNED_HOST = "fp32_pinned_host"
+
+
+class GpuCommandBufferMode(StrEnum):
+    """GPU operation classes captured in XLA command buffers."""
+
+    DISABLED = "disabled"
+    DEFAULT = "default"
 
 
 class TrainingDataMode(StrEnum):
@@ -193,7 +199,11 @@ def take_master_as_params(state: "GrugTrainState") -> "GrugTrainState":
 
 
 def _apply_hero_ep_runtime_defaults(
-    *, inline_watch_enabled: bool, moe_implementation: MoeImplementation | None, processes_per_task: int = 1
+    *,
+    inline_watch_enabled: bool,
+    moe_implementation: MoeImplementation | None,
+    processes_per_task: int = 1,
+    gpu_command_buffer_mode: GpuCommandBufferMode = GpuCommandBufferMode.DISABLED,
 ) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
@@ -205,12 +215,20 @@ def _apply_hero_ep_runtime_defaults(
         os.environ.setdefault(name, value)
     xla_flags = os.environ.get("XLA_FLAGS", "").split()
     ragged = moe_implementation == RAGGED_MOE_IMPLEMENTATION
+    if ragged and gpu_command_buffer_mode != GpuCommandBufferMode.DISABLED:
+        raise ValueError(f"{RAGGED_MOE_IMPLEMENTATION} requires disabled GPU command buffers")
     if ragged:
         overlap_limit = RAGGED_COLLECTIVE_OVERLAP_LIMIT
     elif inline_watch_enabled:
         overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT
     else:
         overlap_limit = DEFAULT_COLLECTIVE_OVERLAP_LIMIT
+    if gpu_command_buffer_mode == GpuCommandBufferMode.DISABLED:
+        command_buffer_flag = f"{XLA_GPU_COMMAND_BUFFER_FLAG}="
+    elif gpu_command_buffer_mode == GpuCommandBufferMode.DEFAULT:
+        command_buffer_flag = f"{XLA_GPU_COMMAND_BUFFER_FLAG}={XLA_DEFAULT_GPU_COMMAND_BUFFER_CAPTURE_SET}"
+    else:
+        raise AssertionError(f"unknown GPU command-buffer mode: {gpu_command_buffer_mode}")
     flag_defaults = (
         f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
         f"--xla_gpu_enable_latency_hiding_scheduler={'false' if ragged else 'true'}",
@@ -223,7 +241,7 @@ def _apply_hero_ep_runtime_defaults(
         # lower percentage costs throughput, because a smaller arena makes `HloRematerialization`
         # recompute more of the step.
         "--xla_gpu_memory_limit_slop_factor=85",
-        XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
+        command_buffer_flag,
     )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
@@ -273,6 +291,7 @@ class GrugTrainerConfig:
     # This keeps one training executable resident. A diagnostic watch repeats forward and backward
     # in a separate executable, which costs compute but shortens gradient liveness.
     watch_mode: WatchMode = WatchMode.INLINE
+    gpu_command_buffer_mode: GpuCommandBufferMode = GpuCommandBufferMode.DISABLED
     # A short throughput gate leaves this off. A compute-optimal run needs it: the loop already
     # restores from the latest committed checkpoint, so without a writer an interrupted run
     # restarts at step 0.
@@ -1238,6 +1257,7 @@ def run_grug(config: GrugRunConfig) -> None:
         inline_watch_enabled=inline_watch_enabled,
         processes_per_task=config.processes_per_task,
         moe_implementation=config.model.moe_implementation,
+        gpu_command_buffer_mode=config.trainer.gpu_command_buffer_mode,
     )
     dispatch_grug_training_run(
         run_id=trainer.id,
@@ -1251,6 +1271,7 @@ def run_grug(config: GrugRunConfig) -> None:
 
 
 __all__ = [
+    "GpuCommandBufferMode",
     "GrugEvalConfig",
     "GrugRunConfig",
     "GrugTrainState",

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -282,14 +282,13 @@ def _expand_compacted_fwd(compacted_output, receiver_linear_indices, receiver_ke
 
 
 def _expand_compacted_bwd(residual, cotangent):
-    receiver_linear_indices, receiver_keep, compacted_shape = residual
-    compact_size = compacted_shape[0] * compacted_shape[1]
-    compacted_grad = (
-        jnp.zeros((compact_size + 1, compacted_shape[2]), dtype=cotangent.dtype)
-        .at[receiver_linear_indices]
-        .set(jnp.where(receiver_keep[:, None], cotangent, 0), mode="drop")
-    )
-    return compacted_grad[:compact_size].reshape(compacted_shape), None, None
+    receiver_linear_indices, _receiver_keep, compacted_shape = residual
+    compact_size = math.prod(compacted_shape[:-1])
+    source_indices = _assignment_sources(receiver_linear_indices, send_size=compact_size)
+    source_valid = source_indices < cotangent.shape[0]
+    source_indices = jnp.minimum(source_indices, cotangent.shape[0] - 1)
+    compacted_grad = jnp.where(source_valid[:, None], cotangent[source_indices], 0)
+    return compacted_grad.reshape(compacted_shape), None, None
 
 
 _expand_compacted.defvjp(_expand_compacted_fwd, _expand_compacted_bwd)
@@ -449,14 +448,14 @@ def _dispatch_pooled(
 def _compute_pooled(
     dispatch: _PooledDispatch,
     *,
-    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w_gate_local: Float[Array, "Elocal H I"],
+    moe_w_up_local: Float[Array, "Elocal H I"],
     moe_w2_local: Float[Array, "Elocal I H"],
     activation_fn: Callable[[jax.Array], jax.Array],
 ) -> _PooledOutput:
     with jax.named_scope("moe_up_down"):
-        moe_dim = moe_w2_local.shape[1]
-        hidden = jnp.einsum("erh,ehi->eri", dispatch.compacted_x, moe_w13_local)
-        gate, up = jnp.split(hidden, [moe_dim], axis=-1)
+        gate = jnp.einsum("erh,ehi->eri", dispatch.compacted_x, moe_w_gate_local)
+        up = jnp.einsum("erh,ehi->eri", dispatch.compacted_x, moe_w_up_local)
         compacted_output = jnp.einsum("eri,eih->erh", activation_fn(gate) * up, moe_w2_local)
 
     return _PooledOutput(
@@ -505,7 +504,8 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
     x_local: Float[Array, "Tlocal H"],
     selected_experts_local: Int[Array, "Tlocal K"],
     combine_weights_local: Float[Array, "Tlocal K"],
-    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w_gate_local: Float[Array, "Elocal H I"],
+    moe_w_up_local: Float[Array, "Elocal H I"],
     moe_w2_local: Float[Array, "Elocal I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
@@ -515,7 +515,7 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
     num_expert_waves: int,
 ) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
     """Stripe each destination pool over fixed waves and report drops at each transport stage."""
-    local_experts = moe_w13_local.shape[0]
+    local_experts = moe_w_gate_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(f"num_experts={num_experts} must be divisible by local expert count={local_experts}")
     if capacity_factor <= 0:
@@ -578,7 +578,8 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
         )
         compute = partial(
             _compute_pooled,
-            moe_w13_local=moe_w13_local,
+            moe_w_gate_local=moe_w_gate_local,
+            moe_w_up_local=moe_w_up_local,
             moe_w2_local=moe_w2_local,
             activation_fn=activation_fn,
         )

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -281,17 +281,15 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _segmented_kernel_config(head_dim: int):
+def _segmented_kernel_config(head_dim: int, num_query_heads: int):
     arch = gpu_compute_capability()
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
-    # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in
-    # flash_attn/cute/interface.py. This Grug port is not that native SM100
-    # kernel: it carries dynamic lower-bound metadata through the SM80/SM120
-    # segmented fork. On B200 d5120 Grug shapes, 64x64 fwd/bwd is consistently
-    # faster than both the prior 128x64/64x64 config and dense-upstream 128x128.
+    # The d6144 EP64 hero profile gains 0.318 MFU points with a 128x64 forward
+    # tile. Keep the 64x64 backward tile selected by the separate sweep.
     if arch // 10 == 10 and head_dim == 128:
-        return replace(kernel_config, forward_tile=(64, 64), backward_tile=(64, 64), num_threads=128)
+        forward_tile = (128, 64) if num_query_heads == 48 else (64, 64)
+        return replace(kernel_config, forward_tile=forward_tile, backward_tile=(64, 64), num_threads=128)
     return kernel_config
 
 
@@ -317,7 +315,7 @@ def gpu_fa4_cute_attention(
             mask,
             backend_name="gpu_fa4_cute_attention",
         )
-    kernel_config = _segmented_kernel_config(q.shape[-1])
+    kernel_config = _segmented_kernel_config(q.shape[-1], q.shape[-2])
 
     return _fa4_cute_attention_forward_sharded(
         q,

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -124,12 +124,12 @@ class MoEExpertMlp(eqx.Module):
         mesh: jax.sharding.AbstractMesh | None = None,
         report_capacity_overflow: bool = False,
     ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], CapacityOverflow]:
+        w_gate_up = jnp.concatenate([self.w_gate, self.w_up], axis=-1)
         return moe_mlp(
             x,
             selected_experts,
             combine_weights,
-            self.w_gate,
-            self.w_up,
+            w_gate_up,
             self.w_down,
             activation=self.activation,
             implementation=self.implementation,
@@ -147,8 +147,7 @@ def moe_mlp(
     x: Float[Array, "T D"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-    w_gate: Float[Array, "E D I"],
-    w_up: Float[Array, "E D I"],
+    w_up_gate: Float[Array, "E D I2"],
     w_down: Float[Array, "E I D"],
     *,
     activation: MoeActivation = ActivationFunctionEnum.silu,
@@ -201,23 +200,16 @@ def moe_mlp(
             f"dim ({x.shape[0]})"
         )
 
-    if w_gate.shape != w_up.shape:
-        raise ValueError(f"w_gate and w_up must have identical [E, D, I] shapes; got {w_gate.shape} vs {w_up.shape}")
-    num_experts = int(w_gate.shape[0])
+    num_experts = int(w_up_gate.shape[0])
     if w_down.shape[0] != num_experts:
         raise ValueError(
-            f"w_down expert dimension ({w_down.shape[0]}) must match gate/up expert dimension ({num_experts})"
-        )
-    if w_down.shape[1] != w_gate.shape[2]:
-        raise ValueError(
-            f"w_down intermediate dimension ({w_down.shape[1]}) must match gate/up width ({w_gate.shape[2]})"
+            f"w_down expert dimension ({w_down.shape[0]}) must match w_up_gate expert dimension ({num_experts})"
         )
 
     has_expert_axis = _mesh_has_axis(mesh, "expert")
     expert_axis_size = _mesh_axis_size(mesh, "expert")
 
     if mesh is None or mesh.empty:
-        w_up_gate = jnp.concatenate([w_gate, w_up], axis=-1)
         out, dropped = _moe_mlp_local(
             x,
             selected_experts,
@@ -274,10 +266,15 @@ def moe_mlp(
         selected_experts = _reshard_for_shard_map(selected_experts, mesh, batch_spec)
         combine_weights = _reshard_for_shard_map(combine_weights, mesh, batch_spec)
         if separate_gate_up:
+            w_gate, w_up = split_moe_w13_output(
+                w_up_gate,
+                intermediate_dim=w_down.shape[1],
+                interleaved=False,
+            )
             weight_values = (w_gate, w_up, w_down)
             weight_specs = (w_gate_up_spec, w_gate_up_spec, w_down_spec)
         else:
-            weight_values = (jnp.concatenate([w_gate, w_up], axis=-1), w_down)
+            weight_values = (w_up_gate, w_down)
             weight_specs = (w_gate_up_spec, w_down_spec)
         weight_values = tuple(
             _reshard_for_shard_map(weight, mesh, spec)
@@ -313,7 +310,6 @@ def moe_mlp(
     x_spec = _value_spec_or_default(x, batch_spec, replace_replicated=True)
     selected_experts_spec = _value_spec_or_default(selected_experts, batch_spec, replace_replicated=True)
     combine_weights_spec = _value_spec_or_default(combine_weights, batch_spec, replace_replicated=True)
-    w_up_gate = jnp.concatenate([w_gate, w_up], axis=-1)
     if expert_chunks > 1 and resolved_implementation == "sonic_cute":
         # The chunked sonic_cute path all-gathers the hidden dim per expert-chunk over ``data``, so it
         # needs a real data axis; without one the local kernel hits an unbound-axis error.

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -124,12 +124,12 @@ class MoEExpertMlp(eqx.Module):
         mesh: jax.sharding.AbstractMesh | None = None,
         report_capacity_overflow: bool = False,
     ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], CapacityOverflow]:
-        w_gate_up = jnp.concatenate([self.w_gate, self.w_up], axis=-1)
         return moe_mlp(
             x,
             selected_experts,
             combine_weights,
-            w_gate_up,
+            self.w_gate,
+            self.w_up,
             self.w_down,
             activation=self.activation,
             implementation=self.implementation,
@@ -147,7 +147,8 @@ def moe_mlp(
     x: Float[Array, "T D"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-    w_up_gate: Float[Array, "E D I2"],
+    w_gate: Float[Array, "E D I"],
+    w_up: Float[Array, "E D I"],
     w_down: Float[Array, "E I D"],
     *,
     activation: MoeActivation = ActivationFunctionEnum.silu,
@@ -200,16 +201,23 @@ def moe_mlp(
             f"dim ({x.shape[0]})"
         )
 
-    num_experts = int(w_up_gate.shape[0])
+    if w_gate.shape != w_up.shape:
+        raise ValueError(f"w_gate and w_up must have identical [E, D, I] shapes; got {w_gate.shape} vs {w_up.shape}")
+    num_experts = int(w_gate.shape[0])
     if w_down.shape[0] != num_experts:
         raise ValueError(
-            f"w_down expert dimension ({w_down.shape[0]}) must match w_up_gate expert dimension ({num_experts})"
+            f"w_down expert dimension ({w_down.shape[0]}) must match gate/up expert dimension ({num_experts})"
+        )
+    if w_down.shape[1] != w_gate.shape[2]:
+        raise ValueError(
+            f"w_down intermediate dimension ({w_down.shape[1]}) must match gate/up width ({w_gate.shape[2]})"
         )
 
     has_expert_axis = _mesh_has_axis(mesh, "expert")
     expert_axis_size = _mesh_axis_size(mesh, "expert")
 
     if mesh is None or mesh.empty:
+        w_up_gate = jnp.concatenate([w_gate, w_up], axis=-1)
         out, dropped = _moe_mlp_local(
             x,
             selected_experts,
@@ -239,6 +247,7 @@ def moe_mlp(
         if num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={num_experts} must be divisible by expert axis size={expert_axis_size}")
 
+        separate_gate_up = resolved_implementation == "fixed_pooled_wave_all_to_all"
         if resolved_implementation == "ring":
             shard_local_fn = _moe_mlp_ep_ring_local
         elif resolved_implementation == "ragged_all_to_all":
@@ -258,14 +267,22 @@ def moe_mlp(
         else:
             raise AssertionError(f"Unhandled MoE implementation {resolved_implementation!r}")
 
-        w_up_gate_spec = P("expert", None, None)
+        w_gate_up_spec = P("expert", None, None)
         w_down_spec = P("expert", None, None)
 
         x = _reshard_for_shard_map(x, mesh, batch_spec)
         selected_experts = _reshard_for_shard_map(selected_experts, mesh, batch_spec)
         combine_weights = _reshard_for_shard_map(combine_weights, mesh, batch_spec)
-        w_up_gate = _reshard_for_shard_map(w_up_gate, mesh, w_up_gate_spec)
-        w_down = _reshard_for_shard_map(w_down, mesh, w_down_spec)
+        if separate_gate_up:
+            weight_values = (w_gate, w_up, w_down)
+            weight_specs = (w_gate_up_spec, w_gate_up_spec, w_down_spec)
+        else:
+            weight_values = (jnp.concatenate([w_gate, w_up], axis=-1), w_down)
+            weight_specs = (w_gate_up_spec, w_down_spec)
+        weight_values = tuple(
+            _reshard_for_shard_map(weight, mesh, spec)
+            for weight, spec in zip(weight_values, weight_specs, strict=True)
+        )
 
         shard_fn = shard_map(
             partial(
@@ -279,13 +296,12 @@ def moe_mlp(
                 batch_spec,
                 batch_spec,
                 batch_spec,
-                w_up_gate_spec,
-                w_down_spec,
+                *weight_specs,
             ),
             out_specs=(batch_spec, CapacityOverflow(sender=P(), receiver=P())),
             check_vma=False,
         )
-        out, overflow = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        out, overflow = shard_fn(x, selected_experts, combine_weights, *weight_values)
         if report_capacity_overflow:
             return out, overflow
         return out
@@ -297,6 +313,7 @@ def moe_mlp(
     x_spec = _value_spec_or_default(x, batch_spec, replace_replicated=True)
     selected_experts_spec = _value_spec_or_default(selected_experts, batch_spec, replace_replicated=True)
     combine_weights_spec = _value_spec_or_default(combine_weights, batch_spec, replace_replicated=True)
+    w_up_gate = jnp.concatenate([w_gate, w_up], axis=-1)
     if expert_chunks > 1 and resolved_implementation == "sonic_cute":
         # The chunked sonic_cute path all-gathers the hidden dim per expert-chunk over ``data``, so it
         # needs a real data axis; without one the local kernel hits an unbound-axis error.

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -140,6 +140,16 @@ def test_simple_causal_lower_bounds_match_full_causal_semantics():
     np.testing.assert_array_equal(valid, np.ones((2, 4), dtype=np.bool_))
 
 
+def test_segmented_kernel_config_selects_the_d6144_b200_forward_tile(monkeypatch):
+    monkeypatch.setattr(fa4_cute, "gpu_compute_capability", lambda: 100)
+
+    hero_config = fa4_cute._segmented_kernel_config(128, 48)
+    other_config = fa4_cute._segmented_kernel_config(128, 40)
+
+    assert hero_config.forward_tile == (128, 64)
+    assert other_config.forward_tile == (64, 64)
+
+
 def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     def fake_forward(q, k, v, lower_bounds, valid, *, sm_scale, kernel_config):
         del k, v, sm_scale, kernel_config
@@ -150,7 +160,7 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
         return q
 
     monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim: object())
+    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim, num_query_heads: object())
     monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", fake_forward)
     mesh = AbstractMesh(
         axis_sizes=(1, 2, 8, 1),

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -47,14 +47,6 @@ _BF16_MOE_RELATIVE_TOLERANCE = 0.02
 _FP32_MOE_RELATIVE_TOLERANCE = 1e-4
 
 
-def _split_gate_up_weights(w_gate_up: jax.Array) -> tuple[jax.Array, jax.Array]:
-    return grug_moe.split_moe_w13_output(
-        w_gate_up,
-        intermediate_dim=w_gate_up.shape[-1] // 2,
-        interleaved=False,
-    )
-
-
 def _make_dense_mesh() -> Mesh:
     devices = jax.devices()
     if not devices:
@@ -284,7 +276,7 @@ def test_moe_mlp_runs_without_ep_axis():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             activation=ActivationFunctionEnum.silu,
             mesh=None,
@@ -295,7 +287,7 @@ def test_moe_mlp_runs_without_ep_axis():
 
         jit_fn = jax.jit(
             lambda x, sel, cw, up_gate, down: moe_mlp(
-                x, sel, cw, *_split_gate_up_weights(up_gate), down, activation=ActivationFunctionEnum.silu, mesh=None
+                x, sel, cw, up_gate, down, activation=ActivationFunctionEnum.silu, mesh=None
             )
         )
         out_jit = jit_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
@@ -312,9 +304,8 @@ def test_moe_mlp_default_matches_explicit_ring_without_ep_axis():
         topk=2,
     )
 
-    w_gate, w_up = _split_gate_up_weights(w_up_gate)
-    y_default = moe_mlp(x, selected_experts, combine_weights, w_gate, w_up, w_down, mesh=None)
-    y_ring = moe_mlp(x, selected_experts, combine_weights, w_gate, w_up, w_down, implementation="ring", mesh=None)
+    y_default = moe_mlp(x, selected_experts, combine_weights, w_up_gate, w_down, mesh=None)
+    y_ring = moe_mlp(x, selected_experts, combine_weights, w_up_gate, w_down, implementation="ring", mesh=None)
     np.testing.assert_allclose(np.asarray(y_default), np.asarray(y_ring), rtol=1e-5, atol=1e-5)
 
 
@@ -472,7 +463,7 @@ def test_moe_mlp_sonic_backend_reports_missing_optional_dependencies():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             mesh=None,
             implementation="sonic",
@@ -548,7 +539,7 @@ def test_moe_mlp_sonic_matches_jax_gather_reference_on_gpu():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             activation=ActivationFunctionEnum.silu,
             implementation="sonic",
@@ -628,7 +619,7 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
                 x,
                 sel,
                 cw,
-                *_split_gate_up_weights(up_gate),
+                up_gate,
                 down,
                 activation=ActivationFunctionEnum.silu,
                 implementation=implementation,
@@ -749,7 +740,11 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            *grug_moe.split_moe_w13_output(
+                w_up_gate,
+                intermediate_dim=w_down.shape[1],
+                interleaved=False,
+            ),
             w_down,
             activation_fn=jax.nn.silu,
             num_experts=num_experts,
@@ -842,7 +837,11 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            *grug_moe.split_moe_w13_output(
+                w_up_gate,
+                intermediate_dim=w_down.shape[1],
+                interleaved=False,
+            ),
             w_down,
             activation_fn=jax.nn.silu,
             num_experts=num_experts,
@@ -930,13 +929,11 @@ def test_portable_ep_backends_match_dense_cross_shard_value_and_gradients(implem
             extra["pooled_transport_capacity_factor"] = 4.0
 
         def backend_output(x, w_up_gate, w_down):
-            w_gate, w_up = jnp.split(w_up_gate, 2, axis=-1)
             return moe_mlp(
                 x,
                 selected_experts,
                 combine_weights,
-                w_gate,
-                w_up,
+                w_up_gate,
                 w_down,
                 activation=jax.nn.silu,
                 implementation=implementation,
@@ -1175,7 +1172,7 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             implementation=implementation,
             mesh=mesh,
@@ -1235,7 +1232,7 @@ def test_moe_mlp_runs_with_ep_axis_when_available():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             activation=ActivationFunctionEnum.silu,
             mesh=None,
@@ -1247,7 +1244,7 @@ def test_moe_mlp_runs_with_ep_axis_when_available():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             activation=ActivationFunctionEnum.silu,
             implementation="ragged_all_to_all",
@@ -1277,7 +1274,7 @@ def test_functional_moe_mlp_accepts_enum_and_callable_activation():
         x,
         selected_experts,
         combine_weights,
-        *_split_gate_up_weights(w_up_gate),
+        w_up_gate,
         w_down,
         activation=ActivationFunctionEnum.silu,
         mesh=None,
@@ -1286,7 +1283,7 @@ def test_functional_moe_mlp_accepts_enum_and_callable_activation():
         x,
         selected_experts,
         combine_weights,
-        *_split_gate_up_weights(w_up_gate),
+        w_up_gate,
         w_down,
         activation=lambda t: jax.nn.silu(t),
         mesh=None,
@@ -1327,7 +1324,7 @@ def test_moe_mlp_reports_positive_drop_count_in_ring_ep_when_over_capacity():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             implementation="ring",
             mesh=None,
@@ -1372,7 +1369,7 @@ def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
             x,
             selected_experts,
             combine_weights,
-            *_split_gate_up_weights(w_up_gate),
+            w_up_gate,
             w_down,
             implementation="ragged_all_to_all",
             mesh=None,

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -26,6 +26,7 @@ from levanter.grug._moe.common import (
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
+    _expand_compacted,
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
     _interleaved_receiver_ranks,
     _receiver_ranks,
@@ -44,6 +45,14 @@ from levanter.utils.activation import ActivationFunctionEnum
 
 _BF16_MOE_RELATIVE_TOLERANCE = 0.02
 _FP32_MOE_RELATIVE_TOLERANCE = 1e-4
+
+
+def _split_gate_up_weights(w_gate_up: jax.Array) -> tuple[jax.Array, jax.Array]:
+    return grug_moe.split_moe_w13_output(
+        w_gate_up,
+        intermediate_dim=w_gate_up.shape[-1] // 2,
+        interleaved=False,
+    )
 
 
 def _make_dense_mesh() -> Mesh:
@@ -275,7 +284,7 @@ def test_moe_mlp_runs_without_ep_axis():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation=ActivationFunctionEnum.silu,
             mesh=None,
@@ -286,7 +295,7 @@ def test_moe_mlp_runs_without_ep_axis():
 
         jit_fn = jax.jit(
             lambda x, sel, cw, up_gate, down: moe_mlp(
-                x, sel, cw, up_gate, down, activation=ActivationFunctionEnum.silu, mesh=None
+                x, sel, cw, *_split_gate_up_weights(up_gate), down, activation=ActivationFunctionEnum.silu, mesh=None
             )
         )
         out_jit = jit_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
@@ -303,8 +312,9 @@ def test_moe_mlp_default_matches_explicit_ring_without_ep_axis():
         topk=2,
     )
 
-    y_default = moe_mlp(x, selected_experts, combine_weights, w_up_gate, w_down, mesh=None)
-    y_ring = moe_mlp(x, selected_experts, combine_weights, w_up_gate, w_down, implementation="ring", mesh=None)
+    w_gate, w_up = _split_gate_up_weights(w_up_gate)
+    y_default = moe_mlp(x, selected_experts, combine_weights, w_gate, w_up, w_down, mesh=None)
+    y_ring = moe_mlp(x, selected_experts, combine_weights, w_gate, w_up, w_down, implementation="ring", mesh=None)
     np.testing.assert_allclose(np.asarray(y_default), np.asarray(y_ring), rtol=1e-5, atol=1e-5)
 
 
@@ -462,7 +472,7 @@ def test_moe_mlp_sonic_backend_reports_missing_optional_dependencies():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             mesh=None,
             implementation="sonic",
@@ -538,7 +548,7 @@ def test_moe_mlp_sonic_matches_jax_gather_reference_on_gpu():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation=ActivationFunctionEnum.silu,
             implementation="sonic",
@@ -618,7 +628,7 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
                 x,
                 sel,
                 cw,
-                up_gate,
+                *_split_gate_up_weights(up_gate),
                 down,
                 activation=ActivationFunctionEnum.silu,
                 implementation=implementation,
@@ -739,7 +749,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation_fn=jax.nn.silu,
             num_experts=num_experts,
@@ -795,6 +805,21 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
     assert _count_jaxpr_primitives(gradient_jaxpr, "all_to_all") == 6 * num_expert_waves
 
 
+def test_expand_compacted_routes_cotangents_with_dropped_and_unused_rows():
+    compacted = jnp.arange(12.0, dtype=jnp.float32).reshape(2, 3, 2)
+    receiver_linear_indices = jnp.array([0, 6, 2, 4, 6], dtype=jnp.int32)
+    receiver_keep = receiver_linear_indices < 6
+    cotangent = jnp.arange(10.0, dtype=jnp.float32).reshape(5, 2)
+
+    gradient = jax.grad(
+        lambda values: jnp.sum(_expand_compacted(values, receiver_linear_indices, receiver_keep) * cotangent)
+    )(compacted)
+
+    expected = jnp.zeros_like(compacted).reshape(6, 2).at[jnp.array([0, 2, 4])].set(cotangent[jnp.array([0, 2, 3])])
+    np.testing.assert_array_equal(np.asarray(gradient), np.asarray(expected.reshape(compacted.shape)))
+
+
+@pytest.mark.timeout(180)
 def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     mesh = _make_single_expert_mesh()
     tokens = 6
@@ -817,7 +842,7 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation_fn=jax.nn.silu,
             num_experts=num_experts,
@@ -905,11 +930,13 @@ def test_portable_ep_backends_match_dense_cross_shard_value_and_gradients(implem
             extra["pooled_transport_capacity_factor"] = 4.0
 
         def backend_output(x, w_up_gate, w_down):
+            w_gate, w_up = jnp.split(w_up_gate, 2, axis=-1)
             return moe_mlp(
                 x,
                 selected_experts,
                 combine_weights,
-                w_up_gate,
+                w_gate,
+                w_up,
                 w_down,
                 activation=jax.nn.silu,
                 implementation=implementation,
@@ -1148,7 +1175,7 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             implementation=implementation,
             mesh=mesh,
@@ -1208,7 +1235,7 @@ def test_moe_mlp_runs_with_ep_axis_when_available():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation=ActivationFunctionEnum.silu,
             mesh=None,
@@ -1220,7 +1247,7 @@ def test_moe_mlp_runs_with_ep_axis_when_available():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             activation=ActivationFunctionEnum.silu,
             implementation="ragged_all_to_all",
@@ -1250,7 +1277,7 @@ def test_functional_moe_mlp_accepts_enum_and_callable_activation():
         x,
         selected_experts,
         combine_weights,
-        w_up_gate,
+        *_split_gate_up_weights(w_up_gate),
         w_down,
         activation=ActivationFunctionEnum.silu,
         mesh=None,
@@ -1259,7 +1286,7 @@ def test_functional_moe_mlp_accepts_enum_and_callable_activation():
         x,
         selected_experts,
         combine_weights,
-        w_up_gate,
+        *_split_gate_up_weights(w_up_gate),
         w_down,
         activation=lambda t: jax.nn.silu(t),
         mesh=None,
@@ -1300,7 +1327,7 @@ def test_moe_mlp_reports_positive_drop_count_in_ring_ep_when_over_capacity():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             implementation="ring",
             mesh=None,
@@ -1345,7 +1372,7 @@ def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
             x,
             selected_experts,
             combine_weights,
-            w_up_gate,
+            *_split_gate_up_weights(w_up_gate),
             w_down,
             implementation="ragged_all_to_all",
             mesh=None,

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -86,6 +86,166 @@ def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
     )
 
 
+def test_diagnostic_run_selects_the_profiled_performance_modes():
+    step = launch.build_diagnostic_run(
+        run_id="profiled-modes",
+        dp_racks=1,
+        num_steps=1,
+        moe_implementation="fixed_pooled_wave_all_to_all",
+        num_expert_waves=1,
+        param_dtype="float32",
+        shared_expert_compute="fused",
+        small_param_sharding="fsdp",
+        master_param_mode=train.MasterParamMode.DEVICE,
+        gpu_command_buffer_mode=train.GpuCommandBufferMode.DEFAULT,
+        version="dev",
+    )
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert config.model.num_expert_waves == 1
+    assert config.model.shared_expert_compute == "fused"
+    assert config.model.small_param_sharding == "fsdp"
+    assert config.trainer.trainer.mp.param_dtype == jnp.float32
+    assert config.trainer.master_param_mode == train.MasterParamMode.DEVICE
+    assert config.trainer.offload_opt_state
+    assert config.trainer.gpu_command_buffer_mode == train.GpuCommandBufferMode.DEFAULT
+
+
+def test_diagnostic_run_rejects_bfloat16_device_parameters():
+    with pytest.raises(ValueError, match="device master parameters require float32"):
+        launch.build_diagnostic_run(
+            run_id="invalid-master-mode",
+            dp_racks=1,
+            num_steps=1,
+            param_dtype="bfloat16",
+            master_param_mode=train.MasterParamMode.DEVICE,
+            version="dev",
+        )
+
+
+def test_diagnostic_run_rejects_command_buffers_for_ragged_transport():
+    with pytest.raises(ValueError, match="ragged_all_to_all requires disabled GPU command buffers"):
+        launch.build_diagnostic_run(
+            run_id="invalid-ragged-command-buffers",
+            dp_racks=1,
+            num_steps=1,
+            moe_implementation=train.RAGGED_MOE_IMPLEMENTATION,
+            processes_per_task=4,
+            gpu_command_buffer_mode=train.GpuCommandBufferMode.DEFAULT,
+            version="dev",
+        )
+
+
+@pytest.mark.timeout(180)
+def test_small_parameter_sharding_preserves_model_value_and_gradients():
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import dataclasses
+        import math
+
+        import equinox as eqx
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, set_mesh
+
+        from experiments.grug.moe_hero_ep import model
+
+
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(1, 1, 4, 1),
+            ("replica_dcn", "data", "expert", "model"),
+            axis_types=(AxisType.Explicit,) * 4,
+        )
+        base = model.GrugModelConfig(
+            vocab_size=32,
+            hidden_dim=16,
+            intermediate_dim=8,
+            shared_expert_intermediate_dim=0,
+            num_shared_experts=1,
+            num_experts=4,
+            num_experts_per_token=1,
+            num_layers=1,
+            num_heads=2,
+            num_kv_heads=1,
+            local_kv_heads=1,
+            global_kv_heads=1,
+            head_dim=8,
+            max_seq_len=4,
+            sliding_window=4,
+            global_every=1,
+            capacity_factor=1.0,
+            initializer_std=0.5 / math.sqrt(16),
+            attention_implementation="reference",
+            moe_implementation="fixed_all_to_all",
+        )
+        tokens = jnp.arange(16, dtype=jnp.int32).reshape(4, 4)
+        weights = jnp.ones_like(tokens, dtype=jnp.float32)
+
+        def loss(transformer):
+            return transformer.next_token_loss(tokens, weights)
+
+        with set_mesh(mesh):
+            replicated = model.Transformer.init(base, key=jax.random.key(0))
+            sharded = model.Transformer.init(
+                dataclasses.replace(base, small_param_sharding="fsdp"),
+                key=jax.random.key(0),
+            )
+            replicated_value, replicated_grad = eqx.filter_value_and_grad(loss)(replicated)
+            sharded_value, sharded_grad = eqx.filter_value_and_grad(loss)(sharded)
+
+        np.testing.assert_allclose(sharded_value, replicated_value, rtol=1e-5, atol=1e-5)
+        replicated_leaves = jax.tree.leaves(eqx.filter(replicated_grad, eqx.is_array))
+        sharded_leaves = jax.tree.leaves(eqx.filter(sharded_grad, eqx.is_array))
+        assert len(sharded_leaves) == len(replicated_leaves)
+        for actual, expected in zip(sharded_leaves, replicated_leaves, strict=True):
+            np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+    """
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_fused_shared_experts_match_separate_value_and_gradients():
+    keys = jax.random.split(jax.random.key(1), 7)
+    x = jax.random.normal(keys[0], (2, 3, 8))
+    experts = tuple(
+        model.DenseMLP(
+            w_gate=jax.random.normal(keys[1 + index * 3], (8, 4)),
+            w_up=jax.random.normal(keys[2 + index * 3], (8, 4)),
+            w_down=jax.random.normal(keys[3 + index * 3], (4, 8)),
+        )
+        for index in range(2)
+    )
+
+    def separate_loss(experts, x):
+        output = experts[0](x) + experts[1](x)
+        return jnp.sum(output**2)
+
+    def fused_loss(experts, x):
+        return jnp.sum(model._fused_shared_expert_mlp(experts, x) ** 2)
+
+    with set_mesh(_explicit_mesh(1, 1, 1, 1)):
+        separate_value, separate_grads = jax.value_and_grad(separate_loss, argnums=(0, 1))(experts, x)
+        fused_value, fused_grads = jax.value_and_grad(fused_loss, argnums=(0, 1))(experts, x)
+
+    np.testing.assert_allclose(fused_value, separate_value, rtol=5e-5, atol=5e-5)
+    jax.tree.map(
+        lambda actual, expected: np.testing.assert_allclose(actual, expected, rtol=5e-5, atol=5e-5),
+        fused_grads,
+        separate_grads,
+    )
+
+
 def test_full_bank_top_k_is_rejected_before_launch():
     # QB routing reads the (k+1)-th logit as its threshold, so a full-bank top-k asks `top_k` for
     # more entries than there are experts. Without this the job dies in the router, which is after
@@ -214,12 +374,14 @@ def _runtime_env_config(
     watch_mode=train.WatchMode.INLINE,
     watch_interval=1,
     moe_implementation="fixed_pooled_wave_all_to_all",
+    gpu_command_buffer_mode=train.GpuCommandBufferMode.DISABLED,
 ):
     """A stand-in for GrugRunConfig holding only the fields ``run_grug``'s env setup and dispatch read."""
     return SimpleNamespace(
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
             watch_mode=watch_mode,
+            gpu_command_buffer_mode=gpu_command_buffer_mode,
         ),
         model=SimpleNamespace(moe_implementation=moe_implementation),
         resources=ResourceConfig.with_gpu("GB200", count=4),
@@ -243,7 +405,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert explicit_overlap in flags
     assert "--xla_gpu_experimental_parallel_collective_overlap_limit=4" not in flags
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
-    assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
+    assert f"{train.XLA_GPU_COMMAND_BUFFER_FLAG}=" in flags
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
     assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
@@ -431,6 +593,31 @@ def test_a_master_bearing_checkpoint_migrates_in_process_into_a_master_less_rest
     assert all(leaf.dtype == jnp.float32 for leaf in got)
     for want, have in zip(jax.tree.leaves(written.master_params), got, strict=True):
         np.testing.assert_array_equal(np.asarray(want), np.asarray(have))
+
+
+def test_run_grug_uses_the_default_noncollective_command_buffer_set(monkeypatch):
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = _runtime_env_config(gpu_command_buffer_mode=train.GpuCommandBufferMode.DEFAULT)
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    flags = os.environ["XLA_FLAGS"].split()
+    expected = f"{train.XLA_GPU_COMMAND_BUFFER_FLAG}={train.XLA_DEFAULT_GPU_COMMAND_BUFFER_CAPTURE_SET}"
+    assert expected in flags
+    assert "COLLECTIVES" not in expected
+
+
+def test_run_grug_rejects_command_buffers_for_ragged_transport(monkeypatch):
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = _runtime_env_config(
+        moe_implementation=train.RAGGED_MOE_IMPLEMENTATION,
+        gpu_command_buffer_mode=train.GpuCommandBufferMode.DEFAULT,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        with pytest.raises(ValueError, match="ragged_all_to_all requires disabled GPU command buffers"):
+            train.run_grug(config)
 
 
 def test_ep_newton_schulz_returns_to_expert_sharding():


### PR DESCRIPTION
* add a one-rack diagnostic launcher for the EP hero shape, with FP32 parameter and profile controls
* use one expert wave, fused shared experts, small-parameter FSDP, direct FP32 device parameters, and safe noncollective command buffers
* keep gate and up weights separate through the fixed-pooled expert GEMMs, and use the inverse gather in the combine backward pass
* select the 128x64 FA4 forward tile for the d6144 B200 shape
* measure 22.898% p50 MFU and 244,738 token/s on the 64-step, 64xGB200 treatment
  * control: 21.724% p50 MFU and 231,739 token/s
  * change: +1.173 MFU percentage points and +12,999 token/s (+5.61%)
  * the control ran for 20 steps with the same hero shape, 1.15 capacity factors, synthetic data, FP32 parameters, overlap 4, and default command buffers
  * [treatment W&B run](https://wandb.ai/marin-community/rav_moe/runs/mhep-minimal-winner-64step-prod-20260827-1729)
  * [control Iris job](https://iris.oa.dev/#/job/%2Frav%2Fmhep-cmdbuf-default-fp32-prof-20260826-1148-coord)
* keep `launch_scaling_ladder.py` and production checkpoint behavior unchanged
* record the [TPU parity CI incident](https://echo.oa.dev/wiki/272)
* cc @mcwitt
