### PR TITLE
[ci] Give the lint review Finelog credentials

### DIFF
--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -96,6 +96,28 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
+      # The review ships one telemetry row per run through the finelog client
+      # (infra/codehealth/log_stats.py). Sync just that package so the write
+      # does not cold-resolve the whole workspace mid-review.
+      - name: Sync the finelog client
+        run: uv sync --package marin-finelog --frozen
+
+      # Finelog sits behind Iris IAP, and the unattended write mints its own
+      # token from these credentials. consult-agent is a composite action whose
+      # inner step defines its own environment, so a step-level `env:` would not
+      # reach the nested agent that spawns log_stats.py; $GITHUB_ENV does.
+      # Without the credentials the review still runs and the row is lost with a
+      # message in its log.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Export the Finelog IAP audience
+        env:
+          IAP_AUDIENCE: ${{ secrets.IRIS_IAP_AUDIENCE }}
+        run: echo "MARIN_FINELOG_IAP_AUDIENCE=${IAP_AUDIENCE}" >> "$GITHUB_ENV"
+
       - name: Run Lint Review
         id: claude
         uses: marin-community/marin-style/actions/consult-agent@main

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -102,11 +102,10 @@ jobs:
       - name: Sync the finelog client
         run: uv sync --package marin-finelog --frozen
 
-      # Finelog sits behind Iris IAP, and the unattended write mints its own
-      # token from these credentials. consult-agent is a composite action whose
-      # inner step defines its own environment, so a step-level `env:` would not
-      # reach the nested agent that spawns log_stats.py; $GITHUB_ENV does.
-      # Without the credentials the review still runs and the row is lost with a
+      # Finelog sits behind Iris IAP and the unattended write mints its own edge
+      # token from these credentials, so the identity behind the key needs
+      # roles/iap.httpsResourceAccessor on the Iris backend service. Without
+      # usable credentials the review still runs and the row is lost with a
       # message in its log.
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -115,15 +114,15 @@ jobs:
 
       # The checkout above is the synthetic merge ref, so local git state names
       # the merge commit. Name the reviewed branch explicitly, or the row cannot
-      # be joined to its pull request.
+      # be joined to its pull request. consult-agent is a composite action whose
+      # inner step defines its own environment, so a step-level `env:` would not
+      # reach the nested agent that spawns log_stats.py; $GITHUB_ENV does.
       - name: Export the review telemetry environment
         env:
-          IAP_AUDIENCE: ${{ secrets.IRIS_IAP_AUDIENCE }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           {
-            echo "MARIN_FINELOG_IAP_AUDIENCE=${IAP_AUDIENCE}"
             echo "MARIN_REVIEW_TRIGGER=ci"
             echo "MARIN_REVIEW_PR_NUMBER=${PR_NUMBER}"
             echo "MARIN_REVIEW_HEAD_SHA=${HEAD_SHA}"

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -113,10 +113,21 @@ jobs:
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
-      - name: Export the Finelog IAP audience
+      # The checkout above is the synthetic merge ref, so local git state names
+      # the merge commit. Name the reviewed branch explicitly, or the row cannot
+      # be joined to its pull request.
+      - name: Export the review telemetry environment
         env:
           IAP_AUDIENCE: ${{ secrets.IRIS_IAP_AUDIENCE }}
-        run: echo "MARIN_FINELOG_IAP_AUDIENCE=${IAP_AUDIENCE}" >> "$GITHUB_ENV"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          {
+            echo "MARIN_FINELOG_IAP_AUDIENCE=${IAP_AUDIENCE}"
+            echo "MARIN_REVIEW_TRIGGER=ci"
+            echo "MARIN_REVIEW_PR_NUMBER=${PR_NUMBER}"
+            echo "MARIN_REVIEW_HEAD_SHA=${HEAD_SHA}"
+          } >> "$GITHUB_ENV"
 
       - name: Run Lint Review
         id: claude


### PR DESCRIPTION
The `lint-review` job runs `pre-commit.py --review` on every non-draft member
pull request, and the review ships one telemetry row per run. The job had no
Finelog credentials, so roughly 124 successful runs a month were never recorded:
exactly one row in the 1,417-row history carries a `pr_number`.

The job now authenticates with the CI service account. No audience secret is
involved: when a cluster configures no `programmatic_audiences`, the finelog
client mints its IAP edge token for the Marin desktop OAuth client id, which is
checked in and which IAP registers as a programmatic client. Syncing
`marin-finelog` on its own keeps the write from cold-resolving the whole
workspace mid-review.

The checkout is the synthetic merge ref, so local git state names the merge
commit. The job exports the pull request number and head SHA through
`$GITHUB_ENV`, without which the row carries a SHA that `review.py`'s findings
lookup never queries and `bot_findings_count` stays understated for every pull
request. `consult-agent` is a composite action whose inner step defines its own
environment, so a step-level `env:` block would not reach the nested agent that
spawns `log_stats.py`.

The write lands only once the identity behind `IRIS_CI_GCP_SA_KEY` holds
`roles/iap.httpsResourceAccessor` on the Iris backend service. Today that role
is granted to `iris-controller@hai-gcp-models` and `ravwojdyla@rav-openathena`
only. Until the grant exists the review runs exactly as it does today and the
row is lost with a message in its log, so merging this ahead of the grant is
safe.

Both jobs in this workflow fail on this pull request: `claude-code-action`
exchanges its app token only when the workflow file matches the version on the
default branch. The guard clears on merge, and the first post-merge pull request
is where the wiring can actually be validated.

Depends on #8735, which adds the writer.
