### PR TITLE
[grug] Compute MuonH hyperball norm over matrix dims only

### DIFF
--- a/experiments/grug/moe_hero_ep/optimizer.py
+++ b/experiments/grug/moe_hero_ep/optimizer.py
@@ -73,7 +73,11 @@ def _scale_invariant_hyperball_updates(params, direction_updates, learning_rate:
             new_param_norm = jnp.sqrt(jnp.sum(jnp.square(new_param.astype(jnp.float32))))
             return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
 
-        axes = tuple(range(1, param.ndim))
+        # Compute the Frobenius norm over the last two dims (the matrix axes).
+        # range(1, ndim) included the expert dimension for 4D
+        # [n_layers, n_experts, d_in, d_out] tensors, collapsing distinct
+        # expert matrices into a shared norm constraint (issue #8621).
+        axes = (param.ndim - 2, param.ndim - 1)
         param_norm = jnp.sqrt(jnp.sum(jnp.square(param), axis=axes, keepdims=True))
         update_norm = jnp.sqrt(jnp.sum(jnp.square(update), axis=axes, keepdims=True))
         new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)


### PR DESCRIPTION
The MuonH scale-invariant update computed the Frobenius norm over axes
range(1, ndim), which for 4D [n_layers, n_experts, d_in, d_out] tensors
includes the expert dimension (axes 1, 2, 3). Each expert matrix was then
constrained to a shared norm across all experts in a layer, relaxing the
per-matrix hypersphere constraint that MuonH is designed to enforce.

Norm axes now use the last two dimensions (ndim-2, ndim-1) for ndim >= 3.
For 3D [n_experts, d_in, d_out]: axes (1, 2), unchanged.
For 4D [n_layers, n_experts, d_in, d_out]: axes (2, 3), expert dimension
excluded.

Fixes #8621