### PR TITLE
[grug] Preserve per-expert MuonH norms (#8621)

### DIFF
--- a/experiments/grug/moe_hero_ep/optimizer.py
+++ b/experiments/grug/moe_hero_ep/optimizer.py
@@ -73,7 +73,9 @@ def _scale_invariant_hyperball_updates(params, direction_updates, learning_rate:
             new_param_norm = jnp.sqrt(jnp.sum(jnp.square(new_param.astype(jnp.float32))))
             return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
 
-        axes = tuple(range(1, param.ndim))
+        # A stacked parameter has leading layer/expert dimensions; each matrix
+        # must keep its own Frobenius radius rather than sharing one across experts.
+        axes = (-2, -1)
         param_norm = jnp.sqrt(jnp.sum(jnp.square(param), axis=axes, keepdims=True))
         update_norm = jnp.sqrt(jnp.sum(jnp.square(update), axis=axes, keepdims=True))
         new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -24,9 +24,24 @@ from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from marin.execution.lazy import StepContext
 from marin.testing.moe import ragged_ep
 
-from experiments.grug.moe_hero_ep import grugmuon_hero, model, train
+from experiments.grug.moe_hero_ep import grugmuon_hero, model, optimizer, train
 from experiments.grug.moe_hero_ep import launch_diagnostics as launch
 from experiments.grug.moe_hero_ep import small_scale_abl_launch as abl
+
+
+def test_muonh_preserves_each_expert_matrix_frobenius_norm():
+    params = jnp.array(
+        [[[[3.0, 4.0], [0.0, 0.0]], [[0.0, 1.0], [0.0, 0.0]]]],
+    )
+    direction_updates = jnp.ones_like(params)
+
+    updates = optimizer._scale_invariant_hyperball_updates(params, direction_updates, learning_rate=0.1)
+    updated_params = params + updates
+
+    np.testing.assert_allclose(
+        jnp.linalg.norm(updated_params, axis=(-2, -1)),
+        jnp.linalg.norm(params, axis=(-2, -1)),
+    )
 
 
 def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():


### PR DESCRIPTION
<!--
See .agents/skills/writing-style/pull-requests.md for the prose rules.

Lead with what changes, then why. Keep the measured results, constraints, and
caveats a future reader needs; length follows useful content rather than a fixed
limit. Do not add Summary/Changes/Testing headings, an implementation inventory,
checkboxes, attribution, or validation narration. If an issue exists, end with
"Fixes #NNNN" or "Part of #NNNN".

Example:

Normalize DAPO loss over all response tokens instead of normalizing each
example separately. Per-example normalization over-weights short responses,
hurting math tasks where correct answers need longer derivations.

Fixes #1234
-->
