### PR TITLE
[zephyr] Retry lost memory-store operations after actor restart

### DIFF
--- a/lib/zephyr/src/zephyr/memory_store.py
+++ b/lib/zephyr/src/zephyr/memory_store.py
@@ -11,6 +11,8 @@ from collections.abc import Callable, Hashable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar, cast
 
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from fray.actor import ActorFuture, ActorHandle, ActorUnavailableError
 from rigging.timing import ExponentialBackoff
 
@@ -302,7 +304,9 @@ def actor_result_with_recovery(
             raise MemoryStoreUnavailable(
                 f"memory-store actor {actor_index} did not respond within {timeout:g} seconds"
             ) from exc
-        except ActorUnavailableError as exc:
+        except (ActorUnavailableError, ConnectError) as exc:
+            if isinstance(exc, ConnectError) and exc.code is not Code.NOT_FOUND:
+                raise
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise MemoryStoreUnavailable(

--- a/lib/zephyr/tests/test_memory_store.py
+++ b/lib/zephyr/tests/test_memory_store.py
@@ -10,6 +10,8 @@ import cloudpickle
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from fray.actor import ActorHandle, ActorUnavailableError
 from fray.local_backend import LocalClient
 from zephyr.context import ZephyrContext, _require_resolvable_worker_handles
@@ -201,7 +203,7 @@ def test_memory_store_pickle_round_trip_works_in_later_pipelines(local_client, t
     assert second_result.results == ["text-1-a", "text-2-b", "text-0-a", "text-3-b"]
 
 
-def test_memory_store_retries_only_actor_unavailability():
+def test_memory_store_retries_actor_unavailability_and_preserves_application_errors():
     recovering_actor = _SequencedActor(
         [
             _TestActorFuture(error=ActorUnavailableError("restarting")),
@@ -213,6 +215,17 @@ def test_memory_store_retries_only_actor_unavailability():
     failing_actor = _SequencedActor([_TestActorFuture(error=_ApplicationError())])
     with pytest.raises(_ApplicationError):
         _fake_store(failing_actor).get("key")
+
+
+def test_memory_store_retries_lost_operation_after_actor_recovery():
+    recovering_actor = _SequencedActor(
+        [
+            _TestActorFuture(error=ConnectError(Code.NOT_FOUND, "Operation 'lost' not found")),
+            _TestActorFuture(value=MemoryTableLookup(MemoryTableStatus.READY, [(True, "value")])),
+        ]
+    )
+
+    assert _fake_store(recovering_actor).get("key") == "value"
 
 
 def test_memory_store_bounds_actor_call_by_recovery_timeout():


### PR DESCRIPTION
Reissue a memory-store call when polling an operation after its actor restarts returns NOT_FOUND. Other Connect errors still propagate.

Fixes #8615

<!--
See .agents/skills/writing-style/pull-requests.md for the prose rules.

Lead with what changes, then why. Keep the measured results, constraints, and
caveats a future reader needs; length follows useful content rather than a fixed
limit. Do not add Summary/Changes/Testing headings, an implementation inventory,
checkboxes, attribution, or validation narration. If an issue exists, end with
"Fixes #NNNN" or "Part of #NNNN".

Example:

Normalize DAPO loss over all response tokens instead of normalizing each
example separately. Per-example normalization over-weights short responses,
hurting math tasks where correct answers need longer derivations.

Fixes #1234
-->
