### PR TITLE
[grug] Raise hero EP64 throughput

### DIFF
--- a/experiments/benchmarks/fa4/tile_sweep.py
+++ b/experiments/benchmarks/fa4/tile_sweep.py
@@ -104,7 +104,7 @@ def _forced(candidate: Candidate):
     selection = fa4_cute_kernels._BackwardArchSelection(
         path_arch=candidate.backward_path, postprocess_arch=candidate.backward_path
     )
-    with patch.object(fa4_cute, "_segmented_kernel_config", lambda head_dim, *, wide_forward_tile: candidate.config):
+    with patch.object(fa4_cute, "_segmented_kernel_config", lambda head_dim: candidate.config):
         with patch.object(fa4_cute_kernels, "_segmented_backward_arches", lambda **_: selection):
             yield
 

--- a/experiments/benchmarks/fa4/tile_sweep.py
+++ b/experiments/benchmarks/fa4/tile_sweep.py
@@ -104,7 +104,7 @@ def _forced(candidate: Candidate):
     selection = fa4_cute_kernels._BackwardArchSelection(
         path_arch=candidate.backward_path, postprocess_arch=candidate.backward_path
     )
-    with patch.object(fa4_cute, "_segmented_kernel_config", lambda head_dim: candidate.config):
+    with patch.object(fa4_cute, "_segmented_kernel_config", lambda head_dim, *, wide_forward_tile: candidate.config):
         with patch.object(fa4_cute_kernels, "_segmented_backward_arches", lambda **_: selection):
             yield
 

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -27,8 +27,10 @@ data-parallel rack uses one 64-device expert mesh.
   (the bf16 compute copy goes unread), and the next save writes the new layout. The reverse
   (synthesizing a master) is refused.
 - Runtime: Each GPU has one JAX process. The recipe uses `cuda_async`, no PGLE, and no GPU
-  command buffers. The ragged transport fixes collective overlap at 1 and turns the latency-hiding
-  scheduler off, for memory rather than scheduling.
+  command buffers. The ragged transport stages each layer's residual carry on pinned host, which
+  frees the HBM the latency-hiding scheduler needs to run. Collective overlap stays at 1: the
+  offload, the scheduler, and a higher limit corrupt training together, though no pair of them
+  does.
 - Resources: Each four-GPU worker requests 120 CPU, 890 GB of RAM, and 1 TB of disk.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -18,8 +18,9 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 
 from experiments.datasets.paloma import paloma_datasets
 from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL
-from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
 from experiments.grug.moe_hero_ep.train import (
+    RAGGED_MOE_IMPLEMENTATION,
     GrugTrainerConfig,
     MasterParamMode,
     TrainingDataMode,
@@ -54,6 +55,22 @@ HERO_MODEL_CONFIG = dataclasses.replace(
     qb_estimator=QbEstimator.HIST,
     qb_hist_bins=HERO_QB_HIST_BINS,
 )
+
+
+def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
+    """Give the ragged transport the layer-carry offload that its scheduling posture depends on.
+
+    Staging the carry on pinned host lowered the measured HBM peak by 36 GiB, which is what makes
+    the latency-hiding scheduler fit. The other transports are unmeasured with the offload, which
+    is the only reason they do not take it.
+
+    The hero recipes apply this. The small-scale ablation arms do not, and keep the scheduling
+    posture they were measured under: the scheduler reads the remat mode, so a model without the
+    offload schedules exactly as it did before the mode existed.
+    """
+    if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
+        return model
+    return dataclasses.replace(model, remat_mode="offload_carry")
 
 
 class HeroThroughputResult(Artifact):

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -18,8 +18,9 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 
 from experiments.datasets.paloma import paloma_datasets
 from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL
-from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
 from experiments.grug.moe_hero_ep.train import (
+    RAGGED_MOE_IMPLEMENTATION,
     GrugTrainerConfig,
     MasterParamMode,
     TrainingDataMode,
@@ -54,6 +55,18 @@ HERO_MODEL_CONFIG = dataclasses.replace(
     qb_estimator=QbEstimator.HIST,
     qb_hist_bins=HERO_QB_HIST_BINS,
 )
+
+
+def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
+    """Give the ragged transport the layer-carry offload that its scheduling posture depends on.
+
+    Staging the carry on pinned host lowers the measured HBM peak by 36 GiB. That headroom is
+    what lets the latency-hiding scheduler fit. Only the ragged transport is measured with the
+    offload, so the other transports keep plain remat.
+    """
+    if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
+        return model
+    return dataclasses.replace(model, remat_mode="offload_carry")
 
 
 class HeroThroughputResult(Artifact):

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -58,7 +58,6 @@ HERO_MODEL_CONFIG = dataclasses.replace(
 
 
 def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
-    """Select carry-offload rematerialization for the ragged transport."""
     if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
         return model
     return dataclasses.replace(model, remat_mode="offload_carry")

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -58,12 +58,7 @@ HERO_MODEL_CONFIG = dataclasses.replace(
 
 
 def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
-    """Give the ragged transport the layer-carry offload that its scheduling posture depends on.
-
-    Staging the carry on pinned host lowers the measured HBM peak by 36 GiB. That headroom is
-    what lets the latency-hiding scheduler fit. Only the ragged transport is measured with the
-    offload, so the other transports keep plain remat.
-    """
+    """Select carry-offload rematerialization for the ragged transport."""
     if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
         return model
     return dataclasses.replace(model, remat_mode="offload_carry")

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -64,9 +64,8 @@ def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
     the latency-hiding scheduler fit. The other transports are unmeasured with the offload, which
     is the only reason they do not take it.
 
-    The hero recipes apply this. The small-scale ablation arms do not, and keep the scheduling
-    posture they were measured under: the scheduler reads the remat mode, so a model without the
-    offload schedules exactly as it did before the mode existed.
+    The scheduler reads the remat mode, so a launcher that skips this keeps the scheduling
+    posture it was measured under, exactly as it did before the mode existed.
     """
     if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
         return model

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -18,7 +18,7 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 
 from experiments.datasets.paloma import paloma_datasets
 from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL
-from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
+from experiments.grug.moe_hero_ep.model import OFFLOAD_CARRY_REMAT_MODE, GrugModelConfig, QbEstimator
 from experiments.grug.moe_hero_ep.train import (
     RAGGED_MOE_IMPLEMENTATION,
     GrugTrainerConfig,
@@ -60,7 +60,7 @@ HERO_MODEL_CONFIG = dataclasses.replace(
 def with_transport_remat_mode(model: GrugModelConfig) -> GrugModelConfig:
     if model.moe_implementation != RAGGED_MOE_IMPLEMENTATION:
         return model
-    return dataclasses.replace(model, remat_mode="offload_carry")
+    return dataclasses.replace(model, remat_mode=OFFLOAD_CARRY_REMAT_MODE)
 
 
 class HeroThroughputResult(Artifact):

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -104,7 +104,6 @@ HERO_MODEL = GrugModelConfig(
     initializer_std=0.5 / math.sqrt(_HERO_HIDDEN),
     qk_mult=1.3,
     sconv=True,
-    # The wide 128x64 forward tile gains 0.28 MFU at the hero's 24k-restore point (#8317).
     attention_implementation="gpu_fa4_cute_wide",
     moe_implementation="ragged_all_to_all",
     pooled_transport_capacity_factor=1.15,  # pooled-wave only

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -104,7 +104,8 @@ HERO_MODEL = GrugModelConfig(
     initializer_std=0.5 / math.sqrt(_HERO_HIDDEN),
     qk_mult=1.3,
     sconv=True,
-    attention_implementation="gpu_fa4_cute",
+    # The wide 128x64 forward tile gains 0.28 MFU at the hero's 24k-restore point (#8317).
+    attention_implementation="gpu_fa4_cute_wide",
     moe_implementation="ragged_all_to_all",
     pooled_transport_capacity_factor=1.15,  # pooled-wave only
     num_expert_waves=3,  # pooled-wave only

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -104,7 +104,9 @@ HERO_MODEL = GrugModelConfig(
     initializer_std=0.5 / math.sqrt(_HERO_HIDDEN),
     qk_mult=1.3,
     sconv=True,
-    attention_implementation="gpu_fa4_cute",
+    # The wide 128x64 forward tile gains 0.28 MFU at the hero's 24k-restore operating point
+    # (mfu24-ctrl-a5/b 23.06/23.05 vs mfu24-tile-a/b 23.32/23.37, same-night interleaved).
+    attention_implementation="gpu_fa4_cute_wide",
     moe_implementation="ragged_all_to_all",
     pooled_transport_capacity_factor=1.15,  # pooled-wave only
     num_expert_waves=3,  # pooled-wave only

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -42,6 +42,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
     hero_grug_trainer_config,
     hero_trainer_config,
     validation_datasets,
+    with_transport_remat_mode,
 )
 from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
 from experiments.grug.moe_hero_ep.train import (
@@ -142,6 +143,7 @@ def build_diagnostic_run(
     }
     if overrides:
         model = dataclasses.replace(model, **overrides)
+    model = with_transport_remat_mode(model)
     # A bank that is not divisible by the expert axis fails inside `moe_mlp`, which is after the rack
     # is already allocated and the workspace is built. Reject it here instead.
     if model.num_experts % HERO_EP_EXPERT_AXIS_SIZE != 0:

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -67,6 +67,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
     hero_grug_trainer_config,
     hero_trainer_config,
     validation_datasets,
+    with_transport_remat_mode,
 )
 from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic, build_hero_configs
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
@@ -114,7 +115,8 @@ LADDER_MAX_TASK_FAILURES = 1000
 def _ladder_model(size: str):
     """The GrugModelConfig for ``size`` at the hero routing geometry with the QB histogram estimator."""
     if size == "d6144":
-        return HERO_MODEL_CONFIG
+        # Only the hero rung is measured with the layer-carry offload.
+        return with_transport_remat_mode(HERO_MODEL_CONFIG)
     shape = SMALL_SHAPES[size]
     return _small_model(
         shape,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -67,6 +67,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
     hero_grug_trainer_config,
     hero_trainer_config,
     validation_datasets,
+    with_transport_remat_mode,
 )
 from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic, build_hero_configs
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
@@ -114,7 +115,9 @@ LADDER_MAX_TASK_FAILURES = 1000
 def _ladder_model(size: str):
     """The GrugModelConfig for ``size`` at the hero routing geometry with the QB histogram estimator."""
     if size == "d6144":
-        return HERO_MODEL_CONFIG
+        # Only the hero rung was measured with the layer-carry offload. The narrow rungs keep
+        # plain remat, and with it the scheduling posture their throughput was recorded under.
+        return with_transport_remat_mode(HERO_MODEL_CONFIG)
     shape = SMALL_SHAPES[size]
     return _small_model(
         shape,

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -151,8 +151,10 @@ def build_memory_soak_run(
         capacity_factor=_EP_CAPACITY_FACTOR,
         # FA4's packed-segment helper gives equivalent size-one mesh axes distinct explicit
         # shardings. Reference attention avoids that single-device-only mismatch; attention
-        # implementation does not participate in checkpoint host staging.
-        attention_implementation="reference" if devices == 1 else HERO_MODEL_CONFIG.attention_implementation,
+        # implementation does not participate in checkpoint host staging. The soak's shapes are
+        # all small, where the hero's wide forward tile is unmeasured, so multi-device soaks
+        # keep the plain FA4 name like the narrow ladder rungs.
+        attention_implementation="reference" if devices == 1 else "gpu_fa4_cute",
         moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
         expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
         seq_len=seq_len,

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -149,10 +149,12 @@ def build_memory_soak_run(
     model = _small_model(
         shape=SOAK_SHAPES[size],
         capacity_factor=_EP_CAPACITY_FACTOR,
-        # FA4's packed-segment helper gives equivalent size-one mesh axes distinct explicit
-        # shardings. Reference attention avoids that single-device-only mismatch; attention
-        # implementation does not participate in checkpoint host staging.
-        attention_implementation="reference" if devices == 1 else HERO_MODEL_CONFIG.attention_implementation,
+        # A single-device soak uses reference attention. FA4's packed-segment helper gives
+        # equivalent size-one mesh axes distinct explicit shardings, and reference attention
+        # avoids that mismatch. The attention implementation does not participate in
+        # checkpoint host staging. Multi-device soaks use the plain FA4 name, because the
+        # soak shapes are all small and the wide forward tile is measured only at the hero.
+        attention_implementation="reference" if devices == 1 else "gpu_fa4_cute",
         moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
         expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
         seq_len=seq_len,

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -52,6 +52,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
     HERO_NODE_RAM,
     HERO_QB_HIST_BINS,
     HeroThroughputResult,
+    with_transport_remat_mode,
 )
 from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
@@ -164,6 +165,7 @@ def build_memory_soak_run(
         qb_use_histogram=True,
         qb_hist_bins=HERO_QB_HIST_BINS,
     )
+    model = with_transport_remat_mode(model)
     local_experts = num_experts // expert_axis
     if local_experts % model.num_expert_waves != 0:
         raise ValueError(f"local expert count={local_experts} must divide num_expert_waves={model.num_expert_waves}")

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
-from haliax.jax_utils import named_call
+from haliax.jax_utils import named_call, tree_checkpoint_name
 from haliax.nn import ArrayStacked
 from jax import core, random
 from jax.sharding import NamedSharding, get_abstract_mesh, reshard
@@ -93,7 +93,11 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe"]
+RematMode = Literal["recompute_all", "save_moe", "offload_carry"]
+
+# The per-layer residual-stream input. Plain remat holds it as the checkpoint argument, which
+# pins about 39 GiB of HBM across the hero's 48 layers.
+LAYER_CARRY_REMAT_NAME = "grug_layer_carry"
 
 
 def _batch_spec() -> P:
@@ -194,7 +198,9 @@ class GrugModelConfig:
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
-    backward skips re-running expert dispatch and its EP collectives."""
+    backward skips re-running expert dispatch and its EP collectives; "offload_carry"
+    recomputes everything but stages the layer-input residual on pinned host, which
+    releases its HBM between forward and backward."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
     rope_fused: bool = False
 
@@ -1129,6 +1135,9 @@ class Block(eqx.Module):
         disable_rope: bool | jax.Array = False,
         is_global: bool | jax.Array = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        # A remat policy acts on named intermediates, and a block argument is not one. This
+        # reassignment routes every use below through the name, which lets the policy offload it.
+        x = tree_checkpoint_name(x, LAYER_CARRY_REMAT_NAME)
         # segment_ids (packed-document boundaries) for the branch-output SConvs; None when unpacked.
         _seg = mask.segment_ids if isinstance(mask, AttentionMask) else None
         sconv_segment_ids = _seg[0] if _seg is not None else None
@@ -1237,6 +1246,16 @@ class Transformer(eqx.Module):
 
         if cfg.remat_mode == "save_moe":
             remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+        elif cfg.remat_mode == "offload_carry":
+            # XLA stacks each offloaded name's scan residuals into one pinned allocation. Adding
+            # names is therefore not free: carry plus the attention residuals asked for 72.56 GiB
+            # per rank, above the node's host budget.
+            remat_policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+                names_which_can_be_saved=[],
+                names_which_can_be_offloaded=[LAYER_CARRY_REMAT_NAME],
+                offload_src="device",
+                offload_dst="pinned_host",
+            )
         else:
             remat_policy = None
 

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
-from haliax.jax_utils import named_call
+from haliax.jax_utils import named_call, tree_checkpoint_name
 from haliax.nn import ArrayStacked
 from jax import core, random
 from jax.sharding import NamedSharding, get_abstract_mesh, reshard
@@ -93,7 +93,11 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe"]
+RematMode = Literal["recompute_all", "save_moe", "offload_carry"]
+
+# The per-layer residual-stream input. Plain remat holds it as the checkpoint argument, which
+# pins about 39 GiB of HBM across the hero's 48 layers.
+LAYER_CARRY_REMAT_NAME = "grug_layer_carry"
 
 
 def _batch_spec() -> P:
@@ -194,7 +198,9 @@ class GrugModelConfig:
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
-    backward skips re-running expert dispatch and its EP collectives."""
+    backward skips re-running expert dispatch and its EP collectives; "offload_carry"
+    recomputes everything but stages the layer-input residual on pinned host, which
+    releases its HBM between forward and backward."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
     rope_fused: bool = False
 
@@ -1129,6 +1135,9 @@ class Block(eqx.Module):
         disable_rope: bool | jax.Array = False,
         is_global: bool | jax.Array = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        # A remat policy acts on named intermediates, and a block argument is not one. This
+        # reassignment routes every use below through the name, which lets the policy offload it.
+        x = tree_checkpoint_name(x, LAYER_CARRY_REMAT_NAME)
         # segment_ids (packed-document boundaries) for the branch-output SConvs; None when unpacked.
         _seg = mask.segment_ids if isinstance(mask, AttentionMask) else None
         sconv_segment_ids = _seg[0] if _seg is not None else None
@@ -1237,6 +1246,16 @@ class Transformer(eqx.Module):
 
         if cfg.remat_mode == "save_moe":
             remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+        elif cfg.remat_mode == "offload_carry":
+            # XLA stacks each offloaded name's scan residuals into one pinned allocation.
+            # Adding names is therefore not free. The carry alone fits. The carry plus the
+            # attention residuals exceeds the host memory the run has.
+            remat_policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+                names_which_can_be_saved=[],
+                names_which_can_be_offloaded=[LAYER_CARRY_REMAT_NAME],
+                offload_src="device",
+                offload_dst="pinned_host",
+            )
         else:
             remat_policy = None
 

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -94,6 +94,7 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
 
 
 RematMode = Literal["recompute_all", "save_moe", "offload_carry"]
+OFFLOAD_CARRY_REMAT_MODE: RematMode = "offload_carry"
 
 # The per-layer residual-stream input. Plain remat holds it as the checkpoint argument, which
 # pins about 39 GiB of HBM across the hero's 48 layers.
@@ -1246,7 +1247,7 @@ class Transformer(eqx.Module):
 
         if cfg.remat_mode == "save_moe":
             remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
-        elif cfg.remat_mode == "offload_carry":
+        elif cfg.remat_mode == OFFLOAD_CARRY_REMAT_MODE:
             # XLA stacks each offloaded name's scan residuals into one pinned allocation.
             # Adding names is therefore not free. The carry alone fits. The carry plus the
             # attention residuals exceeds the host memory the run has.

--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -314,6 +314,7 @@ def main(
     _apply_hero_ep_runtime_defaults(
         inline_watch_enabled=False,
         moe_implementation=model.moe_implementation,
+        remat_mode=model.remat_mode,
         processes_per_task=HERO_GPUS_PER_NODE,
     )
     dispatch_grug_training_run(

--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -251,7 +251,9 @@ def main(
         model = _small_model(
             shape=shape,
             capacity_factor=HERO_MODEL_CONFIG.capacity_factor,
-            attention_implementation=HERO_MODEL_CONFIG.attention_implementation,
+            # The hero's wide forward tile is unmeasured at small widths, so the small stand-ins
+            # keep the plain FA4 name like the narrow ladder rungs.
+            attention_implementation="gpu_fa4_cute",
             moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
             expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
             seq_len=HERO_MODEL_CONFIG.max_seq_len,

--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -251,7 +251,9 @@ def main(
         model = _small_model(
             shape=shape,
             capacity_factor=HERO_MODEL_CONFIG.capacity_factor,
-            attention_implementation=HERO_MODEL_CONFIG.attention_implementation,
+            # The wide forward tile is measured only at the hero shape, so the small
+            # stand-ins keep the plain FA4 name.
+            attention_implementation="gpu_fa4_cute",
             moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
             expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
             seq_len=HERO_MODEL_CONFIG.max_seq_len,

--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -59,6 +59,7 @@ from experiments.grug.moe_hero_ep.hero_recipe import (
     HERO_NODE_DISK,
     HERO_NODE_RAM,
     HERO_QB_HIST_BINS,
+    with_transport_remat_mode,
 )
 from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic, build_hero_configs
 from experiments.grug.moe_hero_ep.model import GrugModelConfig
@@ -243,7 +244,7 @@ def main(
 ) -> None:
     batch_size = HERO_EP_BATCH_SIZE * replica_groups
     if model_size == HERO_MODEL_SIZE:
-        model = HERO_MODEL_CONFIG
+        model = with_transport_remat_mode(HERO_MODEL_CONFIG)
         _, optimizer = build_hero_configs(num_train_steps=HERO_SCHEDULE_STEPS, batch_size=batch_size)
     else:
         shape = SMALL_SHAPES[model_size]

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -58,7 +58,7 @@ from experiments.grug.checkpointing import (
     restore_grug_state_from_checkpoint,
 )
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe_hero_ep.model import GrugModelConfig, RematMode, Transformer
+from experiments.grug.moe_hero_ep.model import OFFLOAD_CARRY_REMAT_MODE, GrugModelConfig, RematMode, Transformer
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
@@ -215,7 +215,7 @@ def _apply_hero_ep_runtime_defaults(
         overlap_limit = DEFAULT_COLLECTIVE_OVERLAP_LIMIT
     # The scheduler's longer buffer live ranges fit on the ragged transport only once the layer
     # carry leaves HBM. Without that offload its first-step NCCL allocations fail.
-    latency_hiding = not ragged or remat_mode == "offload_carry"
+    latency_hiding = not ragged or remat_mode == OFFLOAD_CARRY_REMAT_MODE
     flag_defaults = (
         f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
         f"--xla_gpu_enable_latency_hiding_scheduler={'true' if latency_hiding else 'false'}",
@@ -232,7 +232,7 @@ def _apply_hero_ep_runtime_defaults(
     )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
-    if remat_mode == "offload_carry":
+    if remat_mode == OFFLOAD_CARRY_REMAT_MODE:
         # A wrong overlap limit corrupts training silently, so the offload takes the flag
         # away from the caller instead of defaulting it.
         xla_flags = [f for f in xla_flags if f.partition("=")[0] != XLA_COLLECTIVE_OVERLAP_FLAG]

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -91,10 +91,7 @@ INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # dispatch and combine form one long dependent chain, so admitting several concurrent collectives
 # only contends for the SMs the transport itself needs.
 RAGGED_COLLECTIVE_OVERLAP_LIMIT = 1
-# The layer-carry offload, the latency-hiding scheduler, and an overlap limit above 1 corrupt
-# training together. No pair of the three does. The reloaded residual races its consumer in the
-# backward pass (#8317). A higher limit gains too little to accept that risk, so the offload
-# forces this value.
+# Offload and latency hiding race the reloaded residual with its consumer when overlap exceeds 1.
 OFFLOAD_CARRY_COLLECTIVE_OVERLAP_LIMIT = 1
 RAGGED_MOE_IMPLEMENTATION = "ragged_all_to_all"
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -58,7 +58,7 @@ from experiments.grug.checkpointing import (
     restore_grug_state_from_checkpoint,
 )
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe_hero_ep.model import GrugModelConfig, Transformer
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, RematMode, Transformer
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
@@ -89,12 +89,13 @@ DEFAULT_DROPLESS_MOE_IMPLEMENTATION: MoeImplementation = "sonic_cute"
 INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # The ragged transport wants the opposite scheduling posture from the fixed and pooled ones. Its
 # dispatch and combine form one long dependent chain, so admitting several concurrent collectives
-# only contends for the SMs the transport itself needs. The latency-hiding scheduler stays off for
-# a memory reason, not a scheduling one: its longer buffer live ranges push the step past the HBM
-# budget and NCCL's first-step allocations fail. With the layer activations offloaded to pinned
-# host the freed ~36 GiB fits those live ranges and the scheduler measures ~0.9 MFU faster
-# (#8317); a follow-up lands that offload and turns the scheduler on.
+# only contends for the SMs the transport itself needs.
 RAGGED_COLLECTIVE_OVERLAP_LIMIT = 1
+# The layer-carry offload, the latency-hiding scheduler, and an overlap limit above 1 corrupt
+# training together. No pair of the three does. The reloaded residual races its consumer in the
+# backward pass (#8317). A higher limit gains too little to accept that risk, so the offload
+# forces this value.
+OFFLOAD_CARRY_COLLECTIVE_OVERLAP_LIMIT = 1
 RAGGED_MOE_IMPLEMENTATION = "ragged_all_to_all"
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
@@ -193,7 +194,11 @@ def take_master_as_params(state: "GrugTrainState") -> "GrugTrainState":
 
 
 def _apply_hero_ep_runtime_defaults(
-    *, inline_watch_enabled: bool, moe_implementation: MoeImplementation | None, processes_per_task: int = 1
+    *,
+    inline_watch_enabled: bool,
+    moe_implementation: MoeImplementation | None,
+    remat_mode: RematMode,
+    processes_per_task: int = 1,
 ) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
@@ -211,9 +216,12 @@ def _apply_hero_ep_runtime_defaults(
         overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT
     else:
         overlap_limit = DEFAULT_COLLECTIVE_OVERLAP_LIMIT
+    # The scheduler's longer buffer live ranges fit on the ragged transport only once the layer
+    # carry leaves HBM. Without that offload its first-step NCCL allocations fail.
+    latency_hiding = not ragged or remat_mode == "offload_carry"
     flag_defaults = (
         f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
-        f"--xla_gpu_enable_latency_hiding_scheduler={'false' if ragged else 'true'}",
+        f"--xla_gpu_enable_latency_hiding_scheduler={'true' if latency_hiding else 'false'}",
         # The scheduler sizes the single `jit_train_step` temp arena against this percentage of
         # its memory budget, roughly `133.6 GiB x percentage`. The pool holds 138.2 GiB and
         # persistent state occupies 18.1 GiB of it, so an arena above 120.2 GiB cannot be served
@@ -227,6 +235,11 @@ def _apply_hero_ep_runtime_defaults(
     )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
+    if remat_mode == "offload_carry":
+        # A wrong overlap limit corrupts training silently, so the offload takes the flag
+        # away from the caller instead of defaulting it.
+        xla_flags = [f for f in xla_flags if f.partition("=")[0] != XLA_COLLECTIVE_OVERLAP_FLAG]
+        xla_flags.append(f"{XLA_COLLECTIVE_OVERLAP_FLAG}={OFFLOAD_CARRY_COLLECTIVE_OVERLAP_LIMIT}")
     if ragged:
         # Unlike the defaults above, these are not overridable. Selecting the host-launched
         # one-shot kernel needs both flags cleared together plus a splits-per-peer count this
@@ -1238,6 +1251,7 @@ def run_grug(config: GrugRunConfig) -> None:
         inline_watch_enabled=inline_watch_enabled,
         processes_per_task=config.processes_per_task,
         moe_implementation=config.model.moe_implementation,
+        remat_mode=config.model.remat_mode,
     )
     dispatch_grug_training_run(
         run_id=trainer.id,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -58,7 +58,7 @@ from experiments.grug.checkpointing import (
     restore_grug_state_from_checkpoint,
 )
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe_hero_ep.model import GrugModelConfig, Transformer
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, RematMode, Transformer
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
@@ -89,12 +89,13 @@ DEFAULT_DROPLESS_MOE_IMPLEMENTATION: MoeImplementation = "sonic_cute"
 INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # The ragged transport wants the opposite scheduling posture from the fixed and pooled ones. Its
 # dispatch and combine form one long dependent chain, so admitting several concurrent collectives
-# only contends for the SMs the transport itself needs. The latency-hiding scheduler stays off for
-# a memory reason, not a scheduling one: its longer buffer live ranges push the step past the HBM
-# budget and NCCL's first-step allocations fail. With the layer activations offloaded to pinned
-# host the freed ~36 GiB fits those live ranges and the scheduler measures ~0.9 MFU faster
-# (#8317); a follow-up lands that offload and turns the scheduler on.
+# only contends for the SMs the transport itself needs.
 RAGGED_COLLECTIVE_OVERLAP_LIMIT = 1
+# The layer-carry offload, the latency-hiding scheduler, and an overlap limit above 1 corrupt
+# training together, and no pair of the three does: the reloaded residual races its consumer in
+# backward, so a restored run reports a first-step loss near 9.5 instead of its checkpoint's
+# (#8317). Overlap 4 gained 0.07 MFU, so the offload forces this value rather than defaulting it.
+OFFLOAD_CARRY_COLLECTIVE_OVERLAP_LIMIT = 1
 RAGGED_MOE_IMPLEMENTATION = "ragged_all_to_all"
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
@@ -193,7 +194,11 @@ def take_master_as_params(state: "GrugTrainState") -> "GrugTrainState":
 
 
 def _apply_hero_ep_runtime_defaults(
-    *, inline_watch_enabled: bool, moe_implementation: MoeImplementation | None, processes_per_task: int = 1
+    *,
+    inline_watch_enabled: bool,
+    moe_implementation: MoeImplementation | None,
+    remat_mode: RematMode,
+    processes_per_task: int = 1,
 ) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
@@ -211,9 +216,12 @@ def _apply_hero_ep_runtime_defaults(
         overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT
     else:
         overlap_limit = DEFAULT_COLLECTIVE_OVERLAP_LIMIT
+    # The scheduler's longer buffer live ranges fit on the ragged transport only once the layer
+    # carry leaves HBM. Without that offload its first-step NCCL allocations fail.
+    latency_hiding = not ragged or remat_mode == "offload_carry"
     flag_defaults = (
         f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
-        f"--xla_gpu_enable_latency_hiding_scheduler={'false' if ragged else 'true'}",
+        f"--xla_gpu_enable_latency_hiding_scheduler={'true' if latency_hiding else 'false'}",
         # The scheduler sizes the single `jit_train_step` temp arena against this percentage of
         # its memory budget, roughly `133.6 GiB x percentage`. The pool holds 138.2 GiB and
         # persistent state occupies 18.1 GiB of it, so an arena above 120.2 GiB cannot be served
@@ -227,6 +235,13 @@ def _apply_hero_ep_runtime_defaults(
     )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
+    if remat_mode == "offload_carry":
+        # Not overridable, unlike the defaults above, including the scheduler flag it pairs with.
+        # Both flags can be inherited from another recipe, but only this one fails silently: a
+        # wrong overlap limit corrupts training, while an inherited scheduler setting either
+        # aborts in NCCL's first-step allocation and names itself, or runs the slower posture.
+        xla_flags = [f for f in xla_flags if f.partition("=")[0] != XLA_COLLECTIVE_OVERLAP_FLAG]
+        xla_flags.append(f"{XLA_COLLECTIVE_OVERLAP_FLAG}={OFFLOAD_CARRY_COLLECTIVE_OVERLAP_LIMIT}")
     if ragged:
         # Unlike the defaults above, these are not overridable. Selecting the host-launched
         # one-shot kernel needs both flags cleared together plus a splits-per-peer count this
@@ -1238,6 +1253,7 @@ def run_grug(config: GrugRunConfig) -> None:
         inline_watch_enabled=inline_watch_enabled,
         processes_per_task=config.processes_per_task,
         moe_implementation=config.model.moe_implementation,
+        remat_mode=config.model.remat_mode,
     )
     dispatch_grug_training_run(
         run_id=trainer.id,

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -19,20 +19,70 @@ _DEFAULT_EP_CAPACITY_FACTOR = 1.25
 # #2710 used 1.25 as the practical EP ring default to avoid over/under-packing.
 
 
+def _pack_pairs_u32(a: jax.Array, b: jax.Array) -> jax.Array:
+    """``[..., F]`` x2 of a 16-bit dtype -> ``[..., 2F]`` holding ``a0, b0, a1, b1, ...``.
+
+    XLA caps the equivalent ``stack``/``reshape`` near 1.9 TB/s, because its innermost
+    dimension is 2. The packed form is elementwise and reaches 7.13 TB/s on GB200.
+    """
+    ai = jax.lax.bitcast_convert_type(a, jnp.uint16).astype(jnp.uint32)
+    bi = jax.lax.bitcast_convert_type(b, jnp.uint16).astype(jnp.uint32)
+    packed = ai | (bi << jnp.uint32(16))
+    # A uint32 -> 16-bit bitcast appends an axis of 2, little end first, so `a` leads.
+    return jax.lax.bitcast_convert_type(packed, a.dtype).reshape(*a.shape[:-1], 2 * a.shape[-1])
+
+
+def _unpack_pairs_u32(x: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """``[..., 2F]`` of a 16-bit dtype -> ``([..., F], [..., F])``, undoing ``_pack_pairs_u32``."""
+    pairs = x.reshape(*x.shape[:-1], x.shape[-1] // 2, 2)
+    packed = jax.lax.bitcast_convert_type(pairs, jnp.uint32)
+    lo = (packed & jnp.uint32(0xFFFF)).astype(jnp.uint16)
+    hi = (packed >> jnp.uint32(16)).astype(jnp.uint16)
+    return (
+        jax.lax.bitcast_convert_type(lo, x.dtype),
+        jax.lax.bitcast_convert_type(hi, x.dtype),
+    )
+
+
+# `bitcast_convert_type` has no AD rule, so the interleave carries its own transpose.
+@jax.custom_vjp
+def _interleave_halves(gate: jax.Array, up: jax.Array) -> jax.Array:
+    return _pack_pairs_u32(gate, up)
+
+
+def _interleave_halves_fwd(gate, up):
+    return _pack_pairs_u32(gate, up), None
+
+
+def _interleave_halves_bwd(_, ct):
+    return _unpack_pairs_u32(ct)
+
+
+_interleave_halves.defvjp(_interleave_halves_fwd, _interleave_halves_bwd)
+
+
 def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
     """grug w13 [E,H,2I] gate=[:I], up=[I:] -> interleaved [g0,u0,g1,u1,...] (QuACK layout)."""
-    gate = moe_w13[..., :moe_dim]
-    up = moe_w13[..., moe_dim:]
-    return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
+    # The split's width check matters here: the packed path would broadcast mismatched halves
+    # against each other and return a wrong-width array instead of raising.
+    gate, up = split_moe_w13_output(moe_w13, intermediate_dim=moe_dim, interleaved=False)
+    if moe_w13.dtype.itemsize != 2:
+        return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
+    return _interleave_halves(gate, up)
 
 
 def _swiglu_gate_up_backward(gu: jax.Array, dh: jax.Array) -> jax.Array:
     """Cotangent of the interleaved gate/up pre-activations, given the SwiGLU output's."""
-    gate, up = gu[:, 0::2], gu[:, 1::2]
+    if gu.dtype.itemsize == 2:
+        gate, up = _unpack_pairs_u32(gu)
+    else:
+        gate, up = gu[..., 0::2], gu[..., 1::2]
     sg = jax.nn.sigmoid(gate)
     silu = gate * sg
     dgate = dh * up * (sg + silu * (1.0 - sg))
     dup = dh * silu
+    if gu.dtype.itemsize == 2:
+        return _pack_pairs_u32(dgate.astype(gu.dtype), dup.astype(gu.dtype))
     return jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
 
 

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -20,11 +20,7 @@ _DEFAULT_EP_CAPACITY_FACTOR = 1.25
 
 
 def _pack_pairs_u32(a: jax.Array, b: jax.Array) -> jax.Array:
-    """``[..., F]`` x2 of a 16-bit dtype -> ``[..., 2F]`` holding ``a0, b0, a1, b1, ...``.
-
-    XLA caps the equivalent ``stack``/``reshape`` near 1.9 TB/s, because its innermost
-    dimension is 2. The packed form is elementwise and reaches 7.13 TB/s on GB200.
-    """
+    """Interleave two 16-bit ``[..., F]`` arrays as ``[..., 2F]``."""
     ai = jax.lax.bitcast_convert_type(a, jnp.uint16).astype(jnp.uint32)
     bi = jax.lax.bitcast_convert_type(b, jnp.uint16).astype(jnp.uint32)
     packed = ai | (bi << jnp.uint32(16))

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -18,6 +18,24 @@ from levanter.utils.activation import ActivationFunctionEnum
 _DEFAULT_EP_CAPACITY_FACTOR = 1.25
 # #2710 used 1.25 as the practical EP ring default to avoid over/under-packing.
 
+
+def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
+    """grug w13 [E,H,2I] gate=[:I], up=[I:] -> interleaved [g0,u0,g1,u1,...] (QuACK layout)."""
+    gate = moe_w13[..., :moe_dim]
+    up = moe_w13[..., moe_dim:]
+    return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
+
+
+def _swiglu_gate_up_backward(gu: jax.Array, dh: jax.Array) -> jax.Array:
+    """Cotangent of the interleaved gate/up pre-activations, given the SwiGLU output's."""
+    gate, up = gu[:, 0::2], gu[:, 1::2]
+    sg = jax.nn.sigmoid(gate)
+    silu = gate * sg
+    dgate = dh * up * (sg + silu * (1.0 - sg))
+    dup = dh * silu
+    return jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
+
+
 PspecAxis: TypeAlias = str | tuple[str, ...] | None
 MoeActivation: TypeAlias = ActivationFunctionEnum | Callable[[jax.Array], jax.Array]
 MoeImplementation: TypeAlias = Literal[

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from haliax.nn.ragged_dot import ragged_dot
-from levanter.grug._moe.common import CapacityOverflow
+from levanter.grug._moe.common import CapacityOverflow, _interleave_gate_up
 from levanter.grug._moe.sonic import sonic_gather_sum, sonic_gather_sum_available
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
@@ -107,7 +107,7 @@ def _cute_expert_mlp(
     del activation_fn, physical_group_sizes
 
     # QuACK and CUTLASS DSL are installed only with the CUDA 13 GPU extra.
-    from levanter.grug._moe.sonic_cute import _expert_mlp_quack_wgrad, _interleave_gate_up  # noqa: PLC0415
+    from levanter.grug._moe.sonic_cute import _expert_mlp_quack_wgrad  # noqa: PLC0415
 
     moe_dim = moe_w2_local.shape[1]
     w13_interleaved = _interleave_gate_up(moe_w13_local, moe_dim)

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from haliax.nn.ragged_dot import ragged_dot
-from levanter.grug._moe.common import CapacityOverflow
+from levanter.grug._moe.common import CapacityOverflow, _interleave_gate_up
 from levanter.grug._moe.sonic import sonic_gather_sum, sonic_gather_sum_available
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
@@ -107,7 +107,7 @@ def _cute_expert_mlp(
     del activation_fn, physical_group_sizes
 
     # QuACK, cuDNN Frontend, and CUTLASS DSL are installed only with the CUDA 13 GPU extra.
-    from levanter.grug._moe.sonic_cute import _expert_mlp_cudnn, _interleave_gate_up  # noqa: PLC0415
+    from levanter.grug._moe.sonic_cute import _expert_mlp_cudnn  # noqa: PLC0415
 
     moe_dim = moe_w2_local.shape[1]
     w13_interleaved = _interleave_gate_up(moe_w13_local, moe_dim)

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -28,7 +28,9 @@ from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _chunk_capacity_drops,
+    _interleave_gate_up,
     _prepare_moe_dispatch,
+    _swiglu_gate_up_backward,
     _zero_dropped_assignments,
     _zero_inactive_grouped_rows,
 )
@@ -64,23 +66,6 @@ _QUACK_GROUPED_KW = dict(tile_mn=_QUACK_TILE_MN, cluster_mnk=(2, 2, 1), use_clc_
 # Like the activation-path settings above, it is all scheduling: none of it changes the computed
 # function.
 _QUACK_WGRAD_KW: dict = dict(tile_mn=(256, 256), cluster_mnk=(2, 2, 1), use_clc_persistence=False)
-
-
-def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
-    """grug w13 [E,H,2I] gate=[:I], up=[I:] -> interleaved [g0,u0,g1,u1,...] (QuACK layout)."""
-    gate = moe_w13[..., :moe_dim]
-    up = moe_w13[..., moe_dim:]
-    return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
-
-
-def _swiglu_gate_up_backward(gu: jax.Array, dh: jax.Array) -> jax.Array:
-    """Cotangent of the interleaved gate/up pre-activations, given the SwiGLU output's."""
-    gate, up = gu[:, 0::2], gu[:, 1::2]
-    sg = jax.nn.sigmoid(gate)
-    silu = gate * sg
-    dgate = dh * up * (sg + silu * (1.0 - sg))
-    dup = dh * silu
-    return jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
 
 
 @jax.custom_vjp

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -25,7 +25,9 @@ from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _chunk_capacity_drops,
+    _interleave_gate_up,
     _prepare_moe_dispatch,
+    _swiglu_gate_up_backward,
     _zero_dropped_assignments,
     _zero_inactive_grouped_rows,
 )
@@ -50,23 +52,6 @@ _QUACK_TILE_MN = (256, 256)
 _QUACK_USE_CLC = True
 _QUACK_GATED_KW = dict(tile_mn=_QUACK_TILE_MN, cluster_mnk=(2, 1, 1), use_clc_persistence=_QUACK_USE_CLC)
 _QUACK_GROUPED_KW = dict(tile_mn=_QUACK_TILE_MN, cluster_mnk=(2, 2, 1), use_clc_persistence=_QUACK_USE_CLC)
-
-
-def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
-    """grug w13 [E,H,2I] gate=[:I], up=[I:] -> interleaved [g0,u0,g1,u1,...] (QuACK layout)."""
-    gate = moe_w13[..., :moe_dim]
-    up = moe_w13[..., moe_dim:]
-    return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
-
-
-def _swiglu_gate_up_backward(gu: jax.Array, dh: jax.Array) -> jax.Array:
-    """Cotangent of the interleaved gate/up pre-activations, given the SwiGLU output's."""
-    gate, up = gu[:, 0::2], gu[:, 1::2]
-    sg = jax.nn.sigmoid(gate)
-    silu = gate * sg
-    dgate = dh * up * (sg + silu * (1.0 - sg))
-    dup = dh * silu
-    return jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
 
 
 @jax.custom_vjp

--- a/lib/levanter/src/levanter/grug/attention/__init__.py
+++ b/lib/levanter/src/levanter/grug/attention/__init__.py
@@ -14,4 +14,5 @@ from levanter.grug.attention._core import (
 )
 from levanter.grug.attention._fa4_cute import fa4_cute_segment_bounds as fa4_cute_segment_bounds
 from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention as gpu_fa4_cute_attention
+from levanter.grug.attention._fa4_cute import gpu_fa4_cute_wide_attention as gpu_fa4_cute_wide_attention
 from levanter.grug.attention._fa4_thd import gpu_fa4_thd_attention as gpu_fa4_thd_attention

--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -33,6 +33,7 @@ GrugAttentionImplementation = Literal[
     "reference",
     "tpu_splash",
     "gpu_fa4_cute",
+    "gpu_fa4_cute_wide",  # 128x64 forward tile; measured faster only at the d6144 EP64 hero shape.
     "gpu_fa4_thd",
 ]
 
@@ -477,6 +478,10 @@ def attention(
         from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
 
         return gpu_fa4_cute_attention(q, k, v, mask)
+    if implementation == "gpu_fa4_cute_wide":
+        from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
+
+        return gpu_fa4_cute_attention(q, k, v, mask, wide_forward_tile=True)
     if implementation == "gpu_fa4_thd":
         from levanter.grug.attention._fa4_thd import gpu_fa4_thd_attention  # noqa: PLC0415
 

--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -474,10 +474,14 @@ def attention(
 ) -> Float[Array, "B Q Hq D"]:
     if implementation == "reference":
         return reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
-    if implementation in ("gpu_fa4_cute", "gpu_fa4_cute_wide"):
+    if implementation == "gpu_fa4_cute":
         from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
 
-        return gpu_fa4_cute_attention(q, k, v, mask, wide_forward_tile=implementation == "gpu_fa4_cute_wide")
+        return gpu_fa4_cute_attention(q, k, v, mask)
+    if implementation == "gpu_fa4_cute_wide":
+        from levanter.grug.attention._fa4_cute import gpu_fa4_cute_wide_attention  # noqa: PLC0415
+
+        return gpu_fa4_cute_wide_attention(q, k, v, mask)
     if implementation == "gpu_fa4_thd":
         from levanter.grug.attention._fa4_thd import gpu_fa4_thd_attention  # noqa: PLC0415
 

--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -474,14 +474,10 @@ def attention(
 ) -> Float[Array, "B Q Hq D"]:
     if implementation == "reference":
         return reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
-    if implementation == "gpu_fa4_cute":
+    if implementation in ("gpu_fa4_cute", "gpu_fa4_cute_wide"):
         from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
 
-        return gpu_fa4_cute_attention(q, k, v, mask)
-    if implementation == "gpu_fa4_cute_wide":
-        from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
-
-        return gpu_fa4_cute_attention(q, k, v, mask, wide_forward_tile=True)
+        return gpu_fa4_cute_attention(q, k, v, mask, wide_forward_tile=implementation == "gpu_fa4_cute_wide")
     if implementation == "gpu_fa4_thd":
         from levanter.grug.attention._fa4_thd import gpu_fa4_thd_attention  # noqa: PLC0415
 

--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -33,6 +33,7 @@ GrugAttentionImplementation = Literal[
     "reference",
     "tpu_splash",
     "gpu_fa4_cute",
+    "gpu_fa4_cute_wide",  # 128x64 forward tile. Measured faster only at the hero shape.
     "gpu_fa4_thd",
 ]
 
@@ -473,10 +474,10 @@ def attention(
 ) -> Float[Array, "B Q Hq D"]:
     if implementation == "reference":
         return reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
-    if implementation == "gpu_fa4_cute":
+    if implementation in ("gpu_fa4_cute", "gpu_fa4_cute_wide"):
         from levanter.grug.attention._fa4_cute import gpu_fa4_cute_attention  # noqa: PLC0415
 
-        return gpu_fa4_cute_attention(q, k, v, mask)
+        return gpu_fa4_cute_attention(q, k, v, mask, wide_forward_tile=implementation == "gpu_fa4_cute_wide")
     if implementation == "gpu_fa4_thd":
         from levanter.grug.attention._fa4_thd import gpu_fa4_thd_attention  # noqa: PLC0415
 

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -283,6 +283,13 @@ def _fa4_cute_attention_forward_sharded(
 
 def _segmented_kernel_config(head_dim: int, *, wide_forward_tile: bool):
     arch = gpu_compute_capability()
+    if wide_forward_tile and not (arch // 10 == 10 and head_dim == 128):
+        # Refusing beats silently running the plain config: a tile A/B on such
+        # hardware would measure a no-op and report a false null.
+        raise ValueError(
+            f"gpu_fa4_cute_wide only engages on sm100 at head_dim=128, not sm{arch} at"
+            f" head_dim={head_dim}; select gpu_fa4_cute instead."
+        )
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
     # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -281,8 +281,16 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _segmented_kernel_config(head_dim: int):
+def _segmented_kernel_config(head_dim: int, *, wide_forward_tile: bool):
     arch = gpu_compute_capability()
+    if wide_forward_tile and not (arch // 10 == 10 and head_dim == 128):
+        # Refusing beats silently running the plain config, which would let a tile A/B
+        # measure a no-op and report a false null.
+        raise ValueError(
+            f"gpu_fa4_cute_wide changes the forward tile only on sm100 at head_dim=128."
+            f" On sm{arch} at head_dim={head_dim} it selects the same kernel configuration"
+            " as gpu_fa4_cute, so use that name."
+        )
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
     # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in
@@ -290,8 +298,13 @@ def _segmented_kernel_config(head_dim: int):
     # kernel: it carries dynamic lower-bound metadata through the SM80/SM120
     # segmented fork. On B200 d5120 Grug shapes, 64x64 fwd/bwd is consistently
     # faster than both the prior 128x64/64x64 config and dense-upstream 128x128.
+    # Some workloads measure faster with a 128x64 forward tile. Tile preference does
+    # not follow from any shape the kernel can see, so the caller selects it through the
+    # "gpu_fa4_cute_wide" implementation name. The backward tile stays at 64x64, because
+    # the SM120 kernel raises on 128.
     if arch // 10 == 10 and head_dim == 128:
-        return replace(kernel_config, forward_tile=(64, 64), backward_tile=(64, 64), num_threads=128)
+        forward_tile = (128, 64) if wide_forward_tile else (64, 64)
+        return replace(kernel_config, forward_tile=forward_tile, backward_tile=(64, 64), num_threads=128)
     return kernel_config
 
 
@@ -300,6 +313,8 @@ def gpu_fa4_cute_attention(
     k: Float[Array, "B K Hkv D"],
     v: Float[Array, "B K Hkv D"],
     mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    wide_forward_tile: bool = False,
 ) -> Float[Array, "B Q Hq D"]:
     """Run causal self-attention through a FlashAttention-4/CuTe JAX FFI backend."""
     if jax.default_backend() != "gpu":
@@ -317,7 +332,7 @@ def gpu_fa4_cute_attention(
             mask,
             backend_name="gpu_fa4_cute_attention",
         )
-    kernel_config = _segmented_kernel_config(q.shape[-1])
+    kernel_config = _segmented_kernel_config(q.shape[-1], wide_forward_tile=wide_forward_tile)
 
     return _fa4_cute_attention_forward_sharded(
         q,

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -281,16 +281,8 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _segmented_kernel_config(head_dim: int, *, wide_forward_tile: bool):
+def _segmented_kernel_config(head_dim: int) -> Flash4CuteKernelConfig:
     arch = gpu_compute_capability()
-    if wide_forward_tile and not (arch // 10 == 10 and head_dim == 128):
-        # Refusing beats silently running the plain config, which would let a tile A/B
-        # measure a no-op and report a false null.
-        raise ValueError(
-            f"gpu_fa4_cute_wide changes the forward tile only on sm100 at head_dim=128."
-            f" On sm{arch} at head_dim={head_dim} it selects the same kernel configuration"
-            " as gpu_fa4_cute, so use that name."
-        )
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
     # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in
@@ -298,28 +290,27 @@ def _segmented_kernel_config(head_dim: int, *, wide_forward_tile: bool):
     # kernel: it carries dynamic lower-bound metadata through the SM80/SM120
     # segmented fork. On B200 d5120 Grug shapes, 64x64 fwd/bwd is consistently
     # faster than both the prior 128x64/64x64 config and dense-upstream 128x128.
-    # Some workloads measure faster with a 128x64 forward tile. Tile preference does
-    # not follow from any shape the kernel can see, so the caller selects it through the
-    # "gpu_fa4_cute_wide" implementation name. The backward tile stays at 64x64, because
-    # the SM120 kernel raises on 128.
     if arch // 10 == 10 and head_dim == 128:
-        forward_tile = (128, 64) if wide_forward_tile else (64, 64)
-        return replace(kernel_config, forward_tile=forward_tile, backward_tile=(64, 64), num_threads=128)
+        return replace(kernel_config, forward_tile=(64, 64), backward_tile=(64, 64), num_threads=128)
     return kernel_config
 
 
-def gpu_fa4_cute_attention(
+def _wide_segmented_kernel_config(head_dim: int) -> Flash4CuteKernelConfig:
+    arch = gpu_compute_capability()
+    if arch // 10 != 10 or head_dim != 128:
+        raise ValueError(f"gpu_fa4_cute_wide requires sm100 and head_dim=128, got sm{arch} and head_dim={head_dim}.")
+    kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
+    return replace(kernel_config, forward_tile=(128, 64), backward_tile=(64, 64), num_threads=128)
+
+
+def _gpu_fa4_cute_attention(
     q: Float[Array, "B Q Hq D"],
     k: Float[Array, "B K Hkv D"],
     v: Float[Array, "B K Hkv D"],
     mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
     *,
-    wide_forward_tile: bool = False,
+    kernel_config: Flash4CuteKernelConfig,
 ) -> Float[Array, "B Q Hq D"]:
-    """Run causal self-attention through a FlashAttention-4/CuTe JAX FFI backend."""
-    if jax.default_backend() != "gpu":
-        raise RuntimeError("gpu_fa4_cute_attention requires the JAX GPU backend.")
-
     _validate_head_layout(q, k, backend_name="gpu_fa4_cute_attention")
     if isinstance(mask, AttentionMask) and mask.fa4_bounds is not None:
         # The caller precomputed and selected the per-token metadata outside any per-layer scan/cond
@@ -332,7 +323,6 @@ def gpu_fa4_cute_attention(
             mask,
             backend_name="gpu_fa4_cute_attention",
         )
-    kernel_config = _segmented_kernel_config(q.shape[-1], wide_forward_tile=wide_forward_tile)
 
     return _fa4_cute_attention_forward_sharded(
         q,
@@ -343,6 +333,30 @@ def gpu_fa4_cute_attention(
         sm_scale=1.0 / math.sqrt(q.shape[-1]),
         kernel_config=kernel_config,
     )
+
+
+def gpu_fa4_cute_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run causal self-attention through the segmented FA4/CuTe kernel."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_fa4_cute_attention requires the JAX GPU backend.")
+    return _gpu_fa4_cute_attention(q, k, v, mask, kernel_config=_segmented_kernel_config(q.shape[-1]))
+
+
+def gpu_fa4_cute_wide_attention(
+    q: Float[Array, "B Q Hq D"],
+    k: Float[Array, "B K Hkv D"],
+    v: Float[Array, "B K Hkv D"],
+    mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+) -> Float[Array, "B Q Hq D"]:
+    """Run segmented FA4/CuTe attention with the SM100 128x64 forward tile."""
+    if jax.default_backend() != "gpu":
+        raise RuntimeError("gpu_fa4_cute_wide_attention requires the JAX GPU backend.")
+    return _gpu_fa4_cute_attention(q, k, v, mask, kernel_config=_wide_segmented_kernel_config(q.shape[-1]))
 
 
 def fa4_cute_segment_bounds(

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -281,7 +281,7 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _segmented_kernel_config(head_dim: int):
+def _segmented_kernel_config(head_dim: int, *, wide_forward_tile: bool):
     arch = gpu_compute_capability()
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
@@ -290,8 +290,15 @@ def _segmented_kernel_config(head_dim: int):
     # kernel: it carries dynamic lower-bound metadata through the SM80/SM120
     # segmented fork. On B200 d5120 Grug shapes, 64x64 fwd/bwd is consistently
     # faster than both the prior 128x64/64x64 config and dense-upstream 128x128.
+    # The d6144 EP64 hero measures the other way: a 128x64 forward tile gains
+    # 0.28 MFU at its 24k-restore operating point. Tile preference does not
+    # follow from any shape the kernel can see (the hero and moe_hero_fsdp
+    # launch identical local shapes with different sliding windows), so the
+    # caller chooses via the "gpu_fa4_cute_wide" implementation name. The
+    # backward tile is hard-locked to 64x64 (the SM120 kernel raises on 128).
     if arch // 10 == 10 and head_dim == 128:
-        return replace(kernel_config, forward_tile=(64, 64), backward_tile=(64, 64), num_threads=128)
+        forward_tile = (128, 64) if wide_forward_tile else (64, 64)
+        return replace(kernel_config, forward_tile=forward_tile, backward_tile=(64, 64), num_threads=128)
     return kernel_config
 
 
@@ -300,6 +307,8 @@ def gpu_fa4_cute_attention(
     k: Float[Array, "B K Hkv D"],
     v: Float[Array, "B K Hkv D"],
     mask: AttentionMask | Bool[Array, "B Q K"] | Float[Array, "B Q K"] | None,
+    *,
+    wide_forward_tile: bool = False,
 ) -> Float[Array, "B Q Hq D"]:
     """Run causal self-attention through a FlashAttention-4/CuTe JAX FFI backend."""
     if jax.default_backend() != "gpu":
@@ -317,7 +326,7 @@ def gpu_fa4_cute_attention(
             mask,
             backend_name="gpu_fa4_cute_attention",
         )
-    kernel_config = _segmented_kernel_config(q.shape[-1])
+    kernel_config = _segmented_kernel_config(q.shape[-1], wide_forward_tile=wide_forward_tile)
 
     return _fa4_cute_attention_forward_sharded(
         q,

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -150,7 +150,7 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
         return q
 
     monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim: object())
+    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim, *, wide_forward_tile: object())
     monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", fake_forward)
     mesh = AbstractMesh(
         axis_sizes=(1, 2, 8, 1),

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -140,6 +140,15 @@ def test_simple_causal_lower_bounds_match_full_causal_semantics():
     np.testing.assert_array_equal(valid, np.ones((2, 4), dtype=np.bool_))
 
 
+def test_the_wide_tile_refuses_hardware_where_it_cannot_engage(monkeypatch):
+    # Silently running the plain config would let a tile A/B measure a no-op
+    # and report a false null.
+    monkeypatch.setattr(fa4_cute, "gpu_compute_capability", lambda: 90)
+
+    with pytest.raises(ValueError, match="gpu_fa4_cute_wide only engages on sm100"):
+        fa4_cute._segmented_kernel_config(128, wide_forward_tile=True)
+
+
 def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     def fake_forward(q, k, v, lower_bounds, valid, *, sm_scale, kernel_config):
         del k, v, sm_scale, kernel_config

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -152,7 +152,7 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
         return q
 
     monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim, *, wide_forward_tile: object())
+    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim: object())
     monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", fake_forward)
     mesh = AbstractMesh(
         axis_sizes=(1, 2, 8, 1),

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -140,6 +140,13 @@ def test_simple_causal_lower_bounds_match_full_causal_semantics():
     np.testing.assert_array_equal(valid, np.ones((2, 4), dtype=np.bool_))
 
 
+def test_the_wide_tile_refuses_hardware_where_it_cannot_engage(monkeypatch):
+    monkeypatch.setattr(fa4_cute, "gpu_compute_capability", lambda: 90)
+
+    with pytest.raises(ValueError, match="gpu_fa4_cute_wide changes the forward tile only on sm100"):
+        fa4_cute._segmented_kernel_config(128, wide_forward_tile=True)
+
+
 def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     def fake_forward(q, k, v, lower_bounds, valid, *, sm_scale, kernel_config):
         del k, v, sm_scale, kernel_config
@@ -150,7 +157,7 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
         return q
 
     monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim: object())
+    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim, *, wide_forward_tile: object())
     monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", fake_forward)
     mesh = AbstractMesh(
         axis_sizes=(1, 2, 8, 1),

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -176,6 +176,18 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     assert out.sharding.spec == qkv_sharding.spec
 
 
+def test_fa4_wide_attention_rejects_unsupported_hardware(monkeypatch):
+    q = jnp.zeros((1, 1, 2, 128), dtype=jnp.bfloat16)
+    k = jnp.zeros((1, 1, 1, 128), dtype=jnp.bfloat16)
+    v = jnp.zeros((1, 1, 1, 128), dtype=jnp.bfloat16)
+    monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(fa4_cute, "gpu_compute_capability", lambda: 90)
+    monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", lambda q, *_args, **_kwargs: q)
+
+    with pytest.raises(ValueError):
+        attention(q, k, v, AttentionMask.causal(), implementation="gpu_fa4_cute_wide")
+
+
 def _assert_real_gpu_fa4_cute_matches_reference(
     q,
     k,

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -12,6 +12,8 @@ import levanter.grug.attention._fa4_cute as fa4_cute
 import levanter.grug.attention._fa4_cute_backend as fa4_cute_backend
 from levanter.grug.attention import (
     AttentionMask,
+    GrugAttentionImplementation,
+    attention,
     gpu_fa4_cute_attention,
     reference_attention,
 )
@@ -140,13 +142,6 @@ def test_simple_causal_lower_bounds_match_full_causal_semantics():
     np.testing.assert_array_equal(valid, np.ones((2, 4), dtype=np.bool_))
 
 
-def test_the_wide_tile_refuses_hardware_where_it_cannot_engage(monkeypatch):
-    monkeypatch.setattr(fa4_cute, "gpu_compute_capability", lambda: 90)
-
-    with pytest.raises(ValueError, match="gpu_fa4_cute_wide changes the forward tile only on sm100"):
-        fa4_cute._segmented_kernel_config(128, wide_forward_tile=True)
-
-
 def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     def fake_forward(q, k, v, lower_bounds, valid, *, sm_scale, kernel_config):
         del k, v, sm_scale, kernel_config
@@ -181,8 +176,20 @@ def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
     assert out.sharding.spec == qkv_sharding.spec
 
 
-def _assert_real_gpu_fa4_cute_matches_reference(q, k, v, mask, cotangent, *, valid_tokens=None):
-    actual = jax.jit(gpu_fa4_cute_attention)(q, k, v, mask)
+def _assert_real_gpu_fa4_cute_matches_reference(
+    q,
+    k,
+    v,
+    mask,
+    cotangent,
+    *,
+    valid_tokens=None,
+    implementation: GrugAttentionImplementation = "gpu_fa4_cute",
+):
+    def fa4(q_arg, k_arg, v_arg):
+        return attention(q_arg, k_arg, v_arg, mask, implementation=implementation)
+
+    actual = jax.jit(fa4)(q, k, v)
     expected = reference_attention(q, k, v, mask, logits_dtype=jnp.float32)
     if valid_tokens is not None:
         actual = jnp.where(valid_tokens[..., None, None], actual, expected)
@@ -194,7 +201,7 @@ def _assert_real_gpu_fa4_cute_matches_reference(q, k, v, mask, cotangent, *, val
         return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
 
     def fa4_loss(q_arg, k_arg, v_arg):
-        out = gpu_fa4_cute_attention(q_arg, k_arg, v_arg, mask)
+        out = attention(q_arg, k_arg, v_arg, mask, implementation=implementation)
         return jnp.sum(out.astype(jnp.float32) * cotangent.astype(jnp.float32))
 
     actual_grads = jax.jit(jax.grad(fa4_loss, argnums=(0, 1, 2)))(q, k, v)
@@ -202,6 +209,31 @@ def _assert_real_gpu_fa4_cute_matches_reference(q, k, v, mask, cotangent, *, val
 
     for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
         np.testing.assert_allclose(actual_grad, expected_grad, atol=7e-2, rtol=7e-2)
+
+
+def test_real_gpu_fa4_cute_wide_attention_matches_reference():
+    if jax.default_backend() != "gpu":
+        pytest.skip("FA4/CuTe correctness requires a GPU backend.")
+    if fa4_cute.gpu_compute_capability() // 10 != 10:
+        pytest.skip("The wide FA4 tile requires SM100.")
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute")
+    pytest.importorskip("flash_attn.cute.flash_bwd_preprocess")
+    key = jax.random.PRNGKey(7)
+    q_key, k_key, v_key, cotangent_key = jax.random.split(key, 4)
+    q = jax.random.normal(q_key, (1, 128, 4, 128), dtype=jnp.bfloat16)
+    k = jax.random.normal(k_key, (1, 128, 1, 128), dtype=jnp.bfloat16)
+    v = jax.random.normal(v_key, (1, 128, 1, 128), dtype=jnp.bfloat16)
+    cotangent = jax.random.normal(cotangent_key, q.shape, dtype=jnp.bfloat16)
+
+    _assert_real_gpu_fa4_cute_matches_reference(
+        q,
+        k,
+        v,
+        AttentionMask.causal(),
+        cotangent,
+        implementation="gpu_fa4_cute_wide",
+    )
 
 
 @pytest.mark.parametrize(("q_heads", "kv_heads", "head_dim"), [(4, 1, 64), (2, 2, 64), (4, 1, 128)])

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -426,14 +426,6 @@ def test_interleave_places_gate_and_up_in_alternating_columns(dtype):
     np.testing.assert_array_equal(np.asarray(interleaved[..., 1::2]), np.asarray(w13[..., moe_dim:]))
 
 
-@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
-def test_a_mismatched_moe_dim_is_rejected_rather_than_broadcast(dtype):
-    # The packed path broadcasts the two halves against each other, so a wrong `moe_dim` would
-    # return a wrong-width array instead of failing the way the stack path does.
-    with pytest.raises(ValueError, match="w13 output last dimension"):
-        _interleave_gate_up(_arange_w13(dtype, moe_dim=4), 3)
-
-
 @pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16])
 def test_the_interleave_transpose_de_interleaves_the_cotangent(dtype):
     # `bitcast_convert_type` has no AD rule, so the pack carries a hand-written VJP. Its

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -19,8 +19,11 @@ from haliax.nn.ragged_dot import ragged_dot
 
 import levanter.grug.grug_moe as grug_moe
 from levanter.grug._moe.common import (
+    _interleave_gate_up,
+    _interleave_halves,
     _prepare_moe_dispatch,
     _prepare_moe_dispatch_indices_with_assignment_ids,
+    _swiglu_gate_up_backward,
     CapacityOverflow,
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
@@ -402,6 +405,70 @@ def test_prepare_moe_dispatch_indices_match_materialized_dispatch():
     flat_dispatch_positions = np.asarray(dispatch_positions).reshape(-1)
     np.testing.assert_array_equal(
         flat_dispatch_positions[np.asarray(sorted_assignment_ids)], expected_sorted_positions
+    )
+
+
+def _interleave_w13(dtype, *, experts: int = 2, hidden: int = 3, moe_dim: int = 4) -> jax.Array:
+    values = jnp.arange(experts * hidden * 2 * moe_dim, dtype=jnp.float32)
+    return values.reshape(experts, hidden, 2 * moe_dim).astype(dtype)
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16, jnp.float32])
+def test_interleave_places_gate_and_up_in_alternating_columns(dtype):
+    moe_dim = 4
+    w13 = _interleave_w13(dtype, moe_dim=moe_dim)
+
+    interleaved = _interleave_gate_up(w13, moe_dim)
+
+    assert interleaved.shape == w13.shape
+    assert interleaved.dtype == w13.dtype
+    np.testing.assert_array_equal(np.asarray(interleaved[..., 0::2]), np.asarray(w13[..., :moe_dim]))
+    np.testing.assert_array_equal(np.asarray(interleaved[..., 1::2]), np.asarray(w13[..., moe_dim:]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
+def test_a_mismatched_moe_dim_is_rejected_rather_than_broadcast(dtype):
+    # The packed path broadcasts the two halves against each other, so a wrong `moe_dim` would
+    # return a wrong-width array instead of failing the way the stack path does.
+    with pytest.raises(ValueError, match="w13 output last dimension"):
+        _interleave_gate_up(_interleave_w13(dtype, moe_dim=4), 3)
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16])
+def test_the_interleave_transpose_de_interleaves_the_cotangent(dtype):
+    # `bitcast_convert_type` has no AD rule, so the pack carries a hand-written VJP. Its
+    # correctness is what keeps `dw13` pointing at the right half of the fused weight.
+    gate = _interleave_w13(dtype, moe_dim=4)[..., :4]
+    up = -gate
+    # The cotangent carries the interleaved layout, one value per output element.
+    cotangent = _interleave_w13(dtype, moe_dim=4)
+
+    _, vjp = jax.vjp(_interleave_halves, gate, up)
+    gate_ct, up_ct = vjp(cotangent)
+
+    np.testing.assert_array_equal(np.asarray(gate_ct), np.asarray(cotangent[..., 0::2]))
+    np.testing.assert_array_equal(np.asarray(up_ct), np.asarray(cotangent[..., 1::2]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
+def test_swiglu_backward_matches_autodiff_of_the_forward(dtype):
+    tokens, moe_dim = 5, 4
+    gu = jnp.linspace(-2.0, 2.0, tokens * 2 * moe_dim, dtype=jnp.float32).reshape(tokens, 2 * moe_dim).astype(dtype)
+    dh = jnp.linspace(1.0, -1.0, tokens * moe_dim, dtype=jnp.float32).reshape(tokens, moe_dim).astype(dtype)
+
+    def swiglu(x):
+        gate, up = x[:, 0::2], x[:, 1::2]
+        return jax.nn.silu(gate.astype(jnp.float32)) * up.astype(jnp.float32)
+
+    expected = jax.vjp(swiglu, gu)[1](dh.astype(jnp.float32))[0]
+
+    actual = _swiglu_gate_up_backward(gu, dh)
+
+    assert actual.dtype == gu.dtype
+    # The reference runs in float32, so the gap is the storage dtype's rounding: one bfloat16
+    # unit in the last place at these magnitudes is about 1e-3.
+    np.testing.assert_allclose(
+        np.asarray(actual, dtype=np.float32), np.asarray(expected, dtype=np.float32), rtol=1e-2, atol=1e-3
     )
 
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -408,7 +408,7 @@ def test_prepare_moe_dispatch_indices_match_materialized_dispatch():
     )
 
 
-def _interleave_w13(dtype, *, experts: int = 2, hidden: int = 3, moe_dim: int = 4) -> jax.Array:
+def _arange_w13(dtype, *, experts: int = 2, hidden: int = 3, moe_dim: int = 4) -> jax.Array:
     values = jnp.arange(experts * hidden * 2 * moe_dim, dtype=jnp.float32)
     return values.reshape(experts, hidden, 2 * moe_dim).astype(dtype)
 
@@ -416,7 +416,7 @@ def _interleave_w13(dtype, *, experts: int = 2, hidden: int = 3, moe_dim: int = 
 @pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16, jnp.float32])
 def test_interleave_places_gate_and_up_in_alternating_columns(dtype):
     moe_dim = 4
-    w13 = _interleave_w13(dtype, moe_dim=moe_dim)
+    w13 = _arange_w13(dtype, moe_dim=moe_dim)
 
     interleaved = _interleave_gate_up(w13, moe_dim)
 
@@ -431,17 +431,17 @@ def test_a_mismatched_moe_dim_is_rejected_rather_than_broadcast(dtype):
     # The packed path broadcasts the two halves against each other, so a wrong `moe_dim` would
     # return a wrong-width array instead of failing the way the stack path does.
     with pytest.raises(ValueError, match="w13 output last dimension"):
-        _interleave_gate_up(_interleave_w13(dtype, moe_dim=4), 3)
+        _interleave_gate_up(_arange_w13(dtype, moe_dim=4), 3)
 
 
 @pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16])
 def test_the_interleave_transpose_de_interleaves_the_cotangent(dtype):
     # `bitcast_convert_type` has no AD rule, so the pack carries a hand-written VJP. Its
     # correctness is what keeps `dw13` pointing at the right half of the fused weight.
-    gate = _interleave_w13(dtype, moe_dim=4)[..., :4]
+    gate = _arange_w13(dtype, moe_dim=4)[..., :4]
     up = -gate
     # The cotangent carries the interleaved layout, one value per output element.
-    cotangent = _interleave_w13(dtype, moe_dim=4)
+    cotangent = _arange_w13(dtype, moe_dim=4)
 
     _, vjp = jax.vjp(_interleave_halves, gate, up)
     gate_ct, up_ct = vjp(cotangent)

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -442,8 +442,11 @@ def test_the_interleave_transpose_de_interleaves_the_cotangent(dtype):
     np.testing.assert_array_equal(np.asarray(up_ct), np.asarray(cotangent[..., 1::2]))
 
 
-@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
-def test_swiglu_backward_matches_autodiff_of_the_forward(dtype):
+@pytest.mark.parametrize(
+    ("dtype", "max_abs_error", "mean_abs_error"),
+    [(jnp.bfloat16, 8e-3, 5e-4), (jnp.float32, 2e-7, 2e-8)],
+)
+def test_swiglu_backward_matches_autodiff_of_the_forward(dtype, max_abs_error, mean_abs_error):
     tokens, moe_dim = 5, 4
     gu = jnp.linspace(-2.0, 2.0, tokens * 2 * moe_dim, dtype=jnp.float32).reshape(tokens, 2 * moe_dim).astype(dtype)
     dh = jnp.linspace(1.0, -1.0, tokens * moe_dim, dtype=jnp.float32).reshape(tokens, moe_dim).astype(dtype)
@@ -457,12 +460,9 @@ def test_swiglu_backward_matches_autodiff_of_the_forward(dtype):
     actual = _swiglu_gate_up_backward(gu, dh)
 
     assert actual.dtype == gu.dtype
-    # The reference rounds once, at the end. `_swiglu_gate_up_backward` rounds after each
-    # operation in the storage dtype. The tolerance covers that difference: one bfloat16 unit
-    # in the last place at these magnitudes is about 1e-3.
-    np.testing.assert_allclose(
-        np.asarray(actual, dtype=np.float32), np.asarray(expected, dtype=np.float32), rtol=1e-2, atol=1e-3
-    )
+    error = np.abs(np.asarray(actual, dtype=np.float32) - np.asarray(expected, dtype=np.float32))
+    assert np.max(error) <= max_abs_error
+    assert np.mean(error) <= mean_abs_error
 
 
 def test_moe_expert_mlp_init_matches_across_backends():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -19,8 +19,11 @@ from haliax.nn.ragged_dot import ragged_dot
 
 import levanter.grug.grug_moe as grug_moe
 from levanter.grug._moe.common import (
+    _interleave_gate_up,
+    _interleave_halves,
     _prepare_moe_dispatch,
     _prepare_moe_dispatch_indices_with_assignment_ids,
+    _swiglu_gate_up_backward,
     CapacityOverflow,
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
@@ -402,6 +405,71 @@ def test_prepare_moe_dispatch_indices_match_materialized_dispatch():
     flat_dispatch_positions = np.asarray(dispatch_positions).reshape(-1)
     np.testing.assert_array_equal(
         flat_dispatch_positions[np.asarray(sorted_assignment_ids)], expected_sorted_positions
+    )
+
+
+def _arange_w13(dtype, *, experts: int = 2, hidden: int = 3, moe_dim: int = 4) -> jax.Array:
+    values = jnp.arange(experts * hidden * 2 * moe_dim, dtype=jnp.float32)
+    return values.reshape(experts, hidden, 2 * moe_dim).astype(dtype)
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16, jnp.float32])
+def test_interleave_places_gate_and_up_in_alternating_columns(dtype):
+    moe_dim = 4
+    w13 = _arange_w13(dtype, moe_dim=moe_dim)
+
+    interleaved = _interleave_gate_up(w13, moe_dim)
+
+    assert interleaved.shape == w13.shape
+    assert interleaved.dtype == w13.dtype
+    np.testing.assert_array_equal(np.asarray(interleaved[..., 0::2]), np.asarray(w13[..., :moe_dim]))
+    np.testing.assert_array_equal(np.asarray(interleaved[..., 1::2]), np.asarray(w13[..., moe_dim:]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
+def test_a_mismatched_moe_dim_is_rejected_rather_than_broadcast(dtype):
+    # The packed path broadcasts the two halves against each other, so a wrong `moe_dim` would
+    # return a wrong-width array instead of failing the way the stack path does.
+    with pytest.raises(ValueError, match="w13 output last dimension"):
+        _interleave_gate_up(_arange_w13(dtype, moe_dim=4), 3)
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16])
+def test_the_interleave_transpose_de_interleaves_the_cotangent(dtype):
+    # `bitcast_convert_type` has no AD rule, so the pack carries a hand-written VJP. Its
+    # correctness is what keeps `dw13` pointing at the right half of the fused weight.
+    gate = _arange_w13(dtype, moe_dim=4)[..., :4]
+    up = -gate
+    # The cotangent carries the interleaved layout, one value per output element.
+    cotangent = _arange_w13(dtype, moe_dim=4)
+
+    _, vjp = jax.vjp(_interleave_halves, gate, up)
+    gate_ct, up_ct = vjp(cotangent)
+
+    np.testing.assert_array_equal(np.asarray(gate_ct), np.asarray(cotangent[..., 0::2]))
+    np.testing.assert_array_equal(np.asarray(up_ct), np.asarray(cotangent[..., 1::2]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float32])
+def test_swiglu_backward_matches_autodiff_of_the_forward(dtype):
+    tokens, moe_dim = 5, 4
+    gu = jnp.linspace(-2.0, 2.0, tokens * 2 * moe_dim, dtype=jnp.float32).reshape(tokens, 2 * moe_dim).astype(dtype)
+    dh = jnp.linspace(1.0, -1.0, tokens * moe_dim, dtype=jnp.float32).reshape(tokens, moe_dim).astype(dtype)
+
+    def swiglu(x):
+        gate, up = x[:, 0::2], x[:, 1::2]
+        return jax.nn.silu(gate.astype(jnp.float32)) * up.astype(jnp.float32)
+
+    expected = jax.vjp(swiglu, gu)[1](dh.astype(jnp.float32))[0]
+
+    actual = _swiglu_gate_up_backward(gu, dh)
+
+    assert actual.dtype == gu.dtype
+    # The reference rounds once, at the end. `_swiglu_gate_up_backward` rounds after each
+    # operation in the storage dtype. The tolerance covers that difference: one bfloat16 unit
+    # in the last place at these magnitudes is about 1e-3.
+    np.testing.assert_allclose(
+        np.asarray(actual, dtype=np.float32), np.asarray(expected, dtype=np.float32), rtol=1e-2, atol=1e-3
     )
 
 

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -214,6 +214,7 @@ def _runtime_env_config(
     watch_mode=train.WatchMode.INLINE,
     watch_interval=1,
     moe_implementation="fixed_pooled_wave_all_to_all",
+    remat_mode="recompute_all",
 ):
     """A stand-in for GrugRunConfig holding only the fields ``run_grug``'s env setup and dispatch read."""
     return SimpleNamespace(
@@ -221,7 +222,7 @@ def _runtime_env_config(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
             watch_mode=watch_mode,
         ),
-        model=SimpleNamespace(moe_implementation=moe_implementation),
+        model=SimpleNamespace(moe_implementation=moe_implementation, remat_mode=remat_mode),
         resources=ResourceConfig.with_gpu("GB200", count=4),
         processes_per_task=processes_per_task,
         max_retries_failure=0,
@@ -431,6 +432,38 @@ def test_a_master_bearing_checkpoint_migrates_in_process_into_a_master_less_rest
     assert all(leaf.dtype == jnp.float32 for leaf in got)
     for want, have in zip(jax.tree.leaves(written.master_params), got, strict=True):
         np.testing.assert_array_equal(np.asarray(want), np.asarray(have))
+
+
+def test_the_carry_offload_overrides_an_inherited_collective_overlap_limit(monkeypatch):
+    """The offload, the scheduler, and an overlap limit above 1 corrupt training together (#8317).
+
+    An overlap limit inherited from another recipe's environment is the way a run reaches that
+    combination without anyone choosing it, and the corruption is silent, so the offload takes the
+    flag away from the caller instead of defaulting it.
+    """
+    inherited = f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT}"
+    monkeypatch.setenv("XLA_FLAGS", inherited)
+    config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION, remat_mode="offload_carry")
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    flags = os.environ["XLA_FLAGS"].split()
+    assert inherited not in flags
+    assert f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}=1" in flags
+    assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
+
+
+def test_a_ragged_run_without_the_offload_keeps_the_scheduler_off(monkeypatch):
+    # The scheduler's longer live ranges do not fit until the carry leaves HBM, so an arm that
+    # skips the offload has to keep the posture it was measured under.
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION)
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert "--xla_gpu_enable_latency_hiding_scheduler=false" in os.environ["XLA_FLAGS"].split()
 
 
 def test_ep_newton_schulz_returns_to_expert_sharding():

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -435,7 +435,6 @@ def test_a_master_bearing_checkpoint_migrates_in_process_into_a_master_less_rest
 
 
 def test_the_carry_offload_overrides_an_inherited_collective_overlap_limit(monkeypatch):
-    """An inherited overlap limit reaches the corrupting combination unchosen (#8317)."""
     inherited = f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT}"
     monkeypatch.setenv("XLA_FLAGS", inherited)
     config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION, remat_mode="offload_carry")

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -466,6 +466,24 @@ def test_a_ragged_run_without_the_offload_keeps_the_scheduler_off(monkeypatch):
     assert "--xla_gpu_enable_latency_hiding_scheduler=false" in os.environ["XLA_FLAGS"].split()
 
 
+@pytest.mark.parametrize(
+    ("moe_implementation", "expected_remat_mode"),
+    [(train.RAGGED_MOE_IMPLEMENTATION, "offload_carry"), ("fixed_pooled_wave_all_to_all", "recompute_all")],
+)
+def test_only_the_ragged_transport_offloads_the_layer_carry(moe_implementation, expected_remat_mode):
+    step = launch.build_diagnostic_run(
+        run_id="carry-offload",
+        dp_racks=1,
+        num_steps=1,
+        version="dev",
+        moe_implementation=moe_implementation,
+        processes_per_task=4,
+    )
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert config.model.remat_mode == expected_remat_mode
+
+
 def test_ep_newton_schulz_returns_to_expert_sharding():
     mesh = AbstractMesh(
         axis_sizes=(1, 1, 64, 1),

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -214,6 +214,7 @@ def _runtime_env_config(
     watch_mode=train.WatchMode.INLINE,
     watch_interval=1,
     moe_implementation="fixed_pooled_wave_all_to_all",
+    remat_mode="recompute_all",
 ):
     """A stand-in for GrugRunConfig holding only the fields ``run_grug``'s env setup and dispatch read."""
     return SimpleNamespace(
@@ -221,7 +222,7 @@ def _runtime_env_config(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
             watch_mode=watch_mode,
         ),
-        model=SimpleNamespace(moe_implementation=moe_implementation),
+        model=SimpleNamespace(moe_implementation=moe_implementation, remat_mode=remat_mode),
         resources=ResourceConfig.with_gpu("GB200", count=4),
         processes_per_task=processes_per_task,
         max_retries_failure=0,
@@ -431,6 +432,33 @@ def test_a_master_bearing_checkpoint_migrates_in_process_into_a_master_less_rest
     assert all(leaf.dtype == jnp.float32 for leaf in got)
     for want, have in zip(jax.tree.leaves(written.master_params), got, strict=True):
         np.testing.assert_array_equal(np.asarray(want), np.asarray(have))
+
+
+def test_the_carry_offload_overrides_an_inherited_collective_overlap_limit(monkeypatch):
+    """An inherited overlap limit reaches the corrupting combination unchosen (#8317)."""
+    inherited = f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT}"
+    monkeypatch.setenv("XLA_FLAGS", inherited)
+    config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION, remat_mode="offload_carry")
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    flags = os.environ["XLA_FLAGS"].split()
+    assert inherited not in flags
+    assert f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}=1" in flags
+    assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
+
+
+def test_a_ragged_run_without_the_offload_keeps_the_scheduler_off(monkeypatch):
+    # The scheduler's longer live ranges do not fit until the carry leaves HBM, so an arm that
+    # skips the offload has to keep the posture it was measured under.
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION)
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert "--xla_gpu_enable_latency_hiding_scheduler=false" in os.environ["XLA_FLAGS"].split()
 
 
 def test_ep_newton_schulz_returns_to_expert_sharding():

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -461,6 +461,24 @@ def test_a_ragged_run_without_the_offload_keeps_the_scheduler_off(monkeypatch):
     assert "--xla_gpu_enable_latency_hiding_scheduler=false" in os.environ["XLA_FLAGS"].split()
 
 
+@pytest.mark.parametrize(
+    ("moe_implementation", "expected_remat_mode"),
+    [(train.RAGGED_MOE_IMPLEMENTATION, "offload_carry"), ("fixed_pooled_wave_all_to_all", "recompute_all")],
+)
+def test_only_the_ragged_transport_offloads_the_layer_carry(moe_implementation, expected_remat_mode):
+    step = launch.build_diagnostic_run(
+        run_id="carry-offload",
+        dp_racks=1,
+        num_steps=1,
+        version="dev",
+        moe_implementation=moe_implementation,
+        processes_per_task=4,
+    )
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert config.model.remat_mode == expected_remat_mode
+
+
 def test_ep_newton_schulz_returns_to_expert_sharding():
     mesh = AbstractMesh(
         axis_sizes=(1, 1, 64, 1),

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -437,7 +437,10 @@ def test_a_master_bearing_checkpoint_migrates_in_process_into_a_master_less_rest
 def test_the_carry_offload_overrides_an_inherited_collective_overlap_limit(monkeypatch):
     inherited = f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT}"
     monkeypatch.setenv("XLA_FLAGS", inherited)
-    config = _runtime_env_config(moe_implementation=train.RAGGED_MOE_IMPLEMENTATION, remat_mode="offload_carry")
+    config = _runtime_env_config(
+        moe_implementation=train.RAGGED_MOE_IMPLEMENTATION,
+        remat_mode=model.OFFLOAD_CARRY_REMAT_MODE,
+    )
 
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)
@@ -462,7 +465,10 @@ def test_a_ragged_run_without_the_offload_keeps_the_scheduler_off(monkeypatch):
 
 @pytest.mark.parametrize(
     ("moe_implementation", "expected_remat_mode"),
-    [(train.RAGGED_MOE_IMPLEMENTATION, "offload_carry"), ("fixed_pooled_wave_all_to_all", "recompute_all")],
+    [
+        (train.RAGGED_MOE_IMPLEMENTATION, model.OFFLOAD_CARRY_REMAT_MODE),
+        ("fixed_pooled_wave_all_to_all", "recompute_all"),
+    ],
 )
 def test_only_the_ragged_transport_offloads_the_layer_carry(moe_implementation, expected_remat_mode):
     step = launch.build_diagnostic_run(


### PR DESCRIPTION
Three changes increase Grug hero training throughput at EP64 without changing the model function.

- The layer carry moves to pinned host under a new `offload_carry` remat mode, and the latency-hiding scheduler turns on only in that mode. Against the no-offload arm, this gives +0.44 MFU and lowers peak HBM from 137.95 to 116.50 GiB.
- The QuACK gate/up interleave packs each gate/up pair of 16-bit values into one `uint32`. The equivalent XLA stack-and-reshape reaches approximately 1.9 TB/s; the packed elementwise form reaches 7.13 TB/s. Against the stack-and-reshape arm, this gives +0.22 MFU. It carries a hand-written VJP because `bitcast_convert_type` has no AD rule.
- The FA4 forward tile becomes 128x64 at the hero shape with `d_model=6144`. Against the 64x64 forward tile, this gives +0.28 MFU. Only the hero EP recipe selects it through `attention_implementation=gpu_fa4_cute_wide`. The backward tile stays 64x64. The wide implementation requires SM100 with head dimension 128 and raises an error for other configurations.

Evidence comes from one GB200 NVL72 rack at EP64. Each one-change ablation restores the production hero checkpoint. The score is the median of `throughput/mfu` over restore steps +5 to +19.

The offload has one known hazard. When the offload, scheduler, and a collective overlap limit above 1 are all enabled, the reloaded residual races its backward consumer and corrupts training. No pair of the three does (#8317). To prevent an inherited `--xla_gpu_experimental_parallel_collective_overlap_limit` from bypassing the safe setting, offload replaces any supplied value with 1.

This branch is based on #8684 for the required checkpoint-restore work. Part of #8317.
