### PR TITLE
[datakit] Link pre-staged source reconstruction

### DIFF
--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -9,6 +9,10 @@ the text and WARC provenance as Parquet. Those shards are the input here, not th
 finished source: they hold duplicate ids and no row order, so the chain sends them
 through ``normalize_step`` like every other datakit source.
 
+The exact extractor, launch configuration, and completed-run record are preserved at
+Marin commit ``20b7003fea217ec031c0cfe77643854641abbffc``:
+https://github.com/marin-community/marin/blob/20b7003fea217ec031c0cfe77643854641abbffc/experiments/datakit/focus_crawl.py
+
 The extraction is read from ``{MARIN_PREFIX}/<_FOCUS_CRAWL_EXTRACTION>``, so each
 cluster reads it from its own bucket and it must be copied in before a run. The
 canonical copy lives on CoreWeave at

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
@@ -3,6 +3,14 @@
 
 """Normalize pre-staged Nemotron Code v1 file contents.
 
+Reconstruct the content SWHIDs from NVIDIA's ``(repo, commit_id, rel_path)`` metadata
+with the resolver and pinned 2025-05-18 Software Heritage graph configuration at
+commit ``fa02e79eefac9c8c30a65310b698a9d631bcbe93``:
+https://github.com/muchanem/build-nt-code/tree/fa02e79eefac9c8c30a65310b698a9d631bcbe93
+
+Map the resulting ``sha1_git`` values to ``sha1`` with the matching Software Heritage
+content table, then fetch the bytes from the public Software Heritage content store.
+
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v1-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The
 canonical copy lives on Cloudflare R2 at ``s3://marin-na/users/held/nemotron-code-v1-content``

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
@@ -3,13 +3,10 @@
 
 """Normalize pre-staged Nemotron Code v1 file contents.
 
-Reconstruct the content SWHIDs from NVIDIA's ``(repo, commit_id, rel_path)`` metadata
-with the resolver and pinned 2025-05-18 Software Heritage graph configuration at
-commit ``fa02e79eefac9c8c30a65310b698a9d631bcbe93``:
-https://github.com/muchanem/build-nt-code/tree/fa02e79eefac9c8c30a65310b698a9d631bcbe93
-
-Map the resulting ``sha1_git`` values to ``sha1`` with the matching Software Heritage
-content table, then fetch the bytes from the public Software Heritage content store.
+The exact resolver, pinned 2025-05-18 Software Heritage graph configuration,
+``sha1_git`` mapping, and S3 content downloader are preserved at commit
+``c774272e5561e1fe2f8c7d92ecef60b333d95307``:
+https://github.com/Helw150/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
 
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v1-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v1_content.py
@@ -6,7 +6,7 @@
 The exact resolver, pinned 2025-05-18 Software Heritage graph configuration,
 ``sha1_git`` mapping, and S3 content downloader are preserved at commit
 ``c774272e5561e1fe2f8c7d92ecef60b333d95307``:
-https://github.com/Helw150/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
+https://github.com/marin-community/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
 
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v1-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
@@ -6,7 +6,7 @@
 The exact resolver, pinned 2025-05-18 Software Heritage graph configuration,
 ``sha1_git`` mapping, and S3 content downloader are preserved at commit
 ``c774272e5561e1fe2f8c7d92ecef60b333d95307``:
-https://github.com/Helw150/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
+https://github.com/marin-community/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
 
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v2-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
@@ -3,13 +3,10 @@
 
 """Normalize pre-staged Nemotron Code v2 file contents.
 
-Reconstruct the content SWHIDs from NVIDIA's ``(repo, commit_id, rel_path)`` metadata
-with the resolver and pinned 2025-05-18 Software Heritage graph configuration at
-commit ``fa02e79eefac9c8c30a65310b698a9d631bcbe93``:
-https://github.com/muchanem/build-nt-code/tree/fa02e79eefac9c8c30a65310b698a9d631bcbe93
-
-Map the resulting ``sha1_git`` values to ``sha1`` with the matching Software Heritage
-content table, then fetch the bytes from the public Software Heritage content store.
+The exact resolver, pinned 2025-05-18 Software Heritage graph configuration,
+``sha1_git`` mapping, and S3 content downloader are preserved at commit
+``c774272e5561e1fe2f8c7d92ecef60b333d95307``:
+https://github.com/Helw150/build-nt-code/blob/c774272e5561e1fe2f8c7d92ecef60b333d95307/pipeline/README.md
 
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v2-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v2_content.py
@@ -3,6 +3,14 @@
 
 """Normalize pre-staged Nemotron Code v2 file contents.
 
+Reconstruct the content SWHIDs from NVIDIA's ``(repo, commit_id, rel_path)`` metadata
+with the resolver and pinned 2025-05-18 Software Heritage graph configuration at
+commit ``fa02e79eefac9c8c30a65310b698a9d631bcbe93``:
+https://github.com/muchanem/build-nt-code/tree/fa02e79eefac9c8c30a65310b698a9d631bcbe93
+
+Map the resulting ``sha1_git`` values to ``sha1`` with the matching Software Heritage
+content table, then fetch the bytes from the public Software Heritage content store.
+
 The raw parquet shards are consumed from ``{MARIN_PREFIX}/raw/nemotron-code-v2-content``,
 so each cluster reads them from its own bucket and they must be copied in before a run. The
 canonical copy lives on Cloudflare R2 at ``s3://marin-na/users/held/nemotron-code-v2-content``


### PR DESCRIPTION
Document immutable reconstruction revisions for the three Datakit sources that currently consume pre-staged object-store artifacts. The Focus Crawl pointer pins the Marin extractor and archived production run; the Nemotron v1 and v2 pointers pin the complete Marin-run resolver, 2025-05-18 Software Heritage graph configuration, hash mapping, and content download pipeline.

This keeps the source catalog usable when the staged copies need to be rebuilt without changing artifact identity or pipeline behavior.

Part of #6570
Part of #6997