### PR TITLE
[levanter] Fail a resume that finds checkpoints it cannot load

### DIFF
--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -1026,26 +1026,49 @@ def load_checkpoint_or_initialize(
         loaded_state = equinox.filter(state_shape, lambda _: False)
 
         if do_load is not False:
-            # now we can load the checkpoint
-            try:
-                if discover_latest:
-                    checkpoint_path = latest_checkpoint_path(checkpoint_search_paths[0], *checkpoint_search_paths[1:])
-                else:
-                    if len(checkpoint_search_paths) != 1:
-                        raise ValueError("discover_latest=False requires exactly one checkpoint search path")
-                    checkpoint_path = checkpoint_search_paths[0]
+            if discover_latest:
+                candidates = discover_checkpoint_candidates(checkpoint_search_paths[0], *checkpoint_search_paths[1:])
+                # Newest first, so a torn or unreadable newest checkpoint falls back to older ones.
+                candidate_paths = [candidate.path for candidate in reversed(candidates)]
+            else:
+                if len(checkpoint_search_paths) != 1:
+                    raise ValueError("discover_latest=False requires exactly one checkpoint search path")
+                candidate_paths = list(checkpoint_search_paths)
 
-                loaded_state = load_checkpoint(
-                    filtered_state_shape,
-                    checkpoint_path,
-                    subpath=subpath,
-                    axis_mapping=axis_mapping,
-                    mesh=mesh,
-                    allow_partial=allow_partial,
-                )
-            except FileNotFoundError:
+            last_error: Optional[FileNotFoundError] = None
+            loaded_any = False
+            for checkpoint_path in candidate_paths:
+                try:
+                    loaded_state = load_checkpoint(
+                        filtered_state_shape,
+                        checkpoint_path,
+                        subpath=subpath,
+                        axis_mapping=axis_mapping,
+                        mesh=mesh,
+                        allow_partial=allow_partial,
+                    )
+                    loaded_any = True
+                    break
+                except FileNotFoundError as error:
+                    last_error = error
+                    logger.warning(
+                        "Checkpoint %s could not be loaded (%s). Trying an older checkpoint.", checkpoint_path, error
+                    )
+
+            if not loaded_any:
+                written = candidate_paths if discover_latest else [p for p in candidate_paths if is_checkpoint_path(p)]
+                if written:
+                    # Checkpoints exist but none loaded. Initializing from scratch would overwrite
+                    # them and report plausible progress from step 0, so fail even when the load
+                    # was optional.
+                    raise FileNotFoundError(
+                        f"{len(written)} checkpoint(s) exist under {checkpoint_search_paths} but none "
+                        f"could be loaded: {', '.join(written)}"
+                    ) from last_error
                 if do_load is True:
-                    raise
+                    raise FileNotFoundError(
+                        f"Could not discover checkpoint under any of: {checkpoint_search_paths}"
+                    ) from last_error
                 logger.info(f"Checkpoint not found in {checkpoint_search_paths}. Initializing from scratch.")
 
         state = init_and_merge(loaded_state, *args, **kwargs)

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -988,7 +988,10 @@ def load_checkpoint_or_initialize(
         is_checkpointed: a FilterSpec that specifies which parameters are checkpointed
         donate_args: a FilterSpec that specifies which arguments to donate to init_fn if we need to initialize
         donate_kwargs: a FilterSpec that specifies which kwargs to donate to init_fn if we need to initialize
-        do_load: if True, always load the checkpoint. If False, always initialize. If None, load if the checkpoint exists, otherwise initialize
+        do_load: if True, always load a checkpoint. If False, always initialize. If None, load when
+            checkpoints exist and initialize from scratch only when none do. Candidates are tried
+            newest first, falling back past one that cannot be read; when candidates exist and none
+            load, this raises rather than initializing over them.
         allow_partial: if True, allow partial loading of the checkpoint. If False, all parameters must be present in the checkpoint.
 
     Returns:

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import os
 import pathlib
+import shutil
 import tempfile
 from datetime import timedelta
 
@@ -1098,3 +1099,62 @@ def test_backward_compatibility_with_ocdbt():
         )
         assert all(np.isclose(restored_state.training_key, initial_state.training_key))
         assert restored_state.step == initial_state.step
+
+
+def _tear_checkpoint(checkpoint_dir: pathlib.Path) -> None:
+    """Delete a checkpoint's array data, keeping metadata.json, as a crashed save would."""
+    for entry in checkpoint_dir.iterdir():
+        if entry.name == "metadata.json":
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+
+
+def test_restore_falls_back_past_an_unreadable_newest_checkpoint(tmp_path):
+    """A torn newest checkpoint must not beat a complete older one."""
+
+    def init_fn(key):
+        return {"w": jax.random.normal(key, (4,))}
+
+    good = eqx.filter_jit(init_fn)(jax.random.PRNGKey(0))
+    save_checkpoint(good, step=1, checkpoint_path=str(tmp_path / "step-1"))
+    save_checkpoint({"w": jnp.zeros(4)}, step=2, checkpoint_path=str(tmp_path / "step-2"))
+    _tear_checkpoint(tmp_path / "step-2")
+
+    with use_test_mesh():
+        loaded = load_checkpoint_or_initialize(init_fn, [str(tmp_path)], donate_args=False)(jax.random.PRNGKey(1))
+
+    assert_trees_all_equal(np.asarray(loaded["w"]), np.asarray(good["w"]))
+
+
+def test_a_resume_that_finds_checkpoints_and_loads_none_fails_instead_of_initializing(tmp_path):
+    """Optional resume, so nothing requested a load -- but a checkpoint is here and unreadable.
+
+    Initializing from scratch would overwrite it and report plausible progress from step 0, which
+    is why a silent fall-through is worse than a crash.
+    """
+
+    def init_fn(key):
+        return {"w": jax.random.normal(key, (4,))}
+
+    save_checkpoint({"w": jnp.zeros(4)}, step=2, checkpoint_path=str(tmp_path / "step-2"))
+    _tear_checkpoint(tmp_path / "step-2")
+
+    with use_test_mesh(), pytest.raises(FileNotFoundError, match="could be loaded"):
+        load_checkpoint_or_initialize(init_fn, [str(tmp_path)], donate_args=False)(jax.random.PRNGKey(1))
+
+
+def test_an_explicit_non_checkpoint_path_still_initializes_from_scratch(tmp_path):
+    """discover_latest=False with a path that holds no checkpoint keeps the optional-load default."""
+
+    def init_fn(key):
+        return {"w": jax.random.normal(key, (4,))}
+
+    with use_test_mesh():
+        loaded = load_checkpoint_or_initialize(
+            init_fn, [str(tmp_path / "absent")], discover_latest=False, donate_args=False
+        )(jax.random.PRNGKey(1))
+
+    assert not any(isinstance(leaf, ShapeDtypeStruct) for leaf in jax.tree_util.tree_leaves(loaded))


### PR DESCRIPTION
An optional resume that discovered a checkpoint but failed to read it logged "Checkpoint not found" and initialized from scratch, overwriting the checkpoints it found and reporting plausible progress from step 0. `load_checkpoint_or_initialize` now tries every complete candidate newest first, so a torn newest checkpoint falls back to an older one, and raises when candidates exist and none load. A first launch with no checkpoints still initializes from scratch, and `discover_latest=False` keeps its optional-load default for a path that holds no checkpoint.

The fallback catches `FileNotFoundError`, which is what a torn OCDBT checkpoint (metadata present, array data missing) raises. This ports the semantics grug's restore adopted in #8684, where unreadable checkpoints had silently restarted development runs at step 0; a follow-up can shrink grug's `restore_grug_state_from_checkpoint` toward this implementation.

https://claude.ai/code/session_01DjKqDyu2VRjkmkR9nzirCE
