### PR TITLE
[iris] Distinguish job and task failure budgets

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -1102,12 +1102,16 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
           </InfoRow>
           <InfoRow label="Failure attempts">
             <span :title="failuresTitle">
-              {{ job.failureCount ?? 0 }}<span class="text-text-muted"> / (job max {{ maxTaskFailures }})</span>
+              {{ job.failureCount ?? 0 }}<span class="text-text-muted">
+                / (job max <span data-testid="job-failure-budget">{{ maxTaskFailures }}</span>)
+              </span>
             </span>
           </InfoRow>
           <InfoRow label="Failure retries">
             <span :title="failuresTitle">
-              <span class="text-text-muted">max {{ maxRetriesFailure }}/task</span>
+              <span class="text-text-muted">
+                max <span data-testid="task-failure-retry-budget">{{ maxRetriesFailure }}</span>/task
+              </span>
             </span>
           </InfoRow>
           <InfoRow label="Preemptions">

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -715,7 +715,7 @@ const maxRetriesPreemption = computed(() => jobRequest.value?.maxRetriesPreempti
 const failuresTitle = computed(() =>
   `${job.value?.failureCount ?? 0} failed task attempts (including retries). `
   + `Each task retries up to ${maxRetriesFailure.value}× on failure; `
-  + `the job fails once more than ${maxTaskFailures.value} tasks fail.`,
+  + `the job fails after more than ${maxTaskFailures.value} failed task attempts.`,
 )
 
 const preemptionsTitle = computed(() =>
@@ -1100,9 +1100,14 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
           <InfoRow label="Duration">
             <span class="font-mono">{{ jobDuration(job) }}</span>
           </InfoRow>
-          <InfoRow label="Failures">
+          <InfoRow label="Failure attempts">
             <span :title="failuresTitle">
-              {{ job.failureCount ?? 0 }}<span class="text-text-muted"> / (max {{ maxTaskFailures }})</span>
+              {{ job.failureCount ?? 0 }}<span class="text-text-muted"> / (job max {{ maxTaskFailures }})</span>
+            </span>
+          </InfoRow>
+          <InfoRow label="Failure retries">
+            <span :title="failuresTitle">
+              <span class="text-text-muted">max {{ maxRetriesFailure }}/task</span>
             </span>
           </InfoRow>
           <InfoRow label="Preemptions">

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -504,16 +504,24 @@ def test_dashboard_job_expand(smoke_cluster, smoke_page, smoke_screenshot):
 
 def test_dashboard_job_detail(smoke_cluster, smoke_page, smoke_screenshot):
     """SUCCEEDED job detail page."""
-    job = smoke_cluster.submit(TestJobs.quick, "smoke-detail")
+    job = smoke_cluster.submit(
+        TestJobs.quick,
+        "smoke-detail",
+        max_retries_failure=2,
+        max_task_failures=5,
+    )
     smoke_cluster.wait(job, timeout=smoke_cluster.job_timeout)
 
     job_id = job.job_id.to_wire()
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job_id}")
     wait_for_dashboard_ready(smoke_page)
     _wait_for_job_detail_screenshot_ready(smoke_page, job_id)
-    assert_visible(smoke_page, "text=Failure retries")
-    assert_visible(smoke_page, "text=job max 0")
-    assert_visible(smoke_page, "text=max 0/task")
+    job_budget = smoke_page.get_by_test_id("job-failure-budget")
+    retry_budget = smoke_page.get_by_test_id("task-failure-retry-budget")
+    assert job_budget.is_visible()
+    assert job_budget.text_content() == "5"
+    assert retry_budget.is_visible()
+    assert retry_budget.text_content() == "2"
     smoke_screenshot(
         "job-detail",
         "Job detail page for succeeded job with explicit per-task retry and job-wide failure budgets, "

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -511,8 +511,13 @@ def test_dashboard_job_detail(smoke_cluster, smoke_page, smoke_screenshot):
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job_id}")
     wait_for_dashboard_ready(smoke_page)
     _wait_for_job_detail_screenshot_ready(smoke_page, job_id)
+    assert_visible(smoke_page, "text=Failure retries")
+    assert_visible(smoke_page, "text=job max 0")
+    assert_visible(smoke_page, "text=max 0/task")
     smoke_screenshot(
-        "job-detail", "Job detail page for succeeded job with state badge, task table, and job-level log viewer"
+        "job-detail",
+        "Job detail page for succeeded job with explicit per-task retry and job-wide failure budgets, "
+        "state badge, task table, and job-level log viewer",
     )
 
 


### PR DESCRIPTION
Show `max_task_failures` as the job-wide failed-attempt budget and
`max_retries_failure` as a separate per-task retry limit on job detail. The
previous card rendered `Failures N / (max M)` and kept the per-task limit in
hover text, so the visible maximum did not identify its scope.

The report came from a `cw-rno2a` child whose Kubernetes attempt exited 250 and
was recorded as `FAILED`. Its request carried both failure limits as 3, while
its parent coordinator carried zero limits. Iris scheduled the retry allowed by
the child request. Separate rows expose both policy scopes without requiring a
tooltip.

Incident: https://echo.oa.dev/wiki/280
