### PR TITLE
[fray] Preserve application errors in operation recovery

### DIFF
--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -410,7 +410,12 @@ class OperationFuture:
     def result(self, timeout: float | None = None) -> Any:
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:
-            op = self._client.poll_operation_status(self._op_id)
+            try:
+                op = self._client.poll_operation_status(self._op_id)
+            except ConnectError as exc:
+                if exc.code is Code.NOT_FOUND:
+                    raise ActorUnavailableError(f"Operation {self._op_id} was lost") from exc
+                raise
 
             if op.state == actor_pb2.Operation.SUCCEEDED:
                 return cloudpickle.loads(op.serialized_result)

--- a/lib/fray/tests/test_operation_future.py
+++ b/lib/fray/tests/test_operation_future.py
@@ -6,6 +6,9 @@
 import time
 
 import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from fray.actor import ActorUnavailableError
 from fray.iris_backend import OperationFuture
 from iris.actor.client import ActorClient
 from iris.actor.resolver import FixedResolver
@@ -27,6 +30,11 @@ class SlowActor:
 def _make_client(port: int, name: str = "actor") -> ActorClient:
     resolver = FixedResolver({name: f"http://127.0.0.1:{port}"})
     return ActorClient(resolver, name)
+
+
+class _MissingOperationClient:
+    def poll_operation_status(self, operation_id: str):
+        raise ConnectError(Code.NOT_FOUND, f"Operation '{operation_id}' not found")
 
 
 def test_operation_future_basic():
@@ -81,3 +89,10 @@ def test_operation_future_propagates_exception():
             future.result()
     finally:
         server.stop()
+
+
+def test_operation_future_converts_missing_operation_to_actor_unavailable():
+    future = OperationFuture(_MissingOperationClient(), "lost")
+
+    with pytest.raises(ActorUnavailableError, match="Operation lost was lost"):
+        future.result()

--- a/lib/zephyr/src/zephyr/memory_store.py
+++ b/lib/zephyr/src/zephyr/memory_store.py
@@ -11,8 +11,6 @@ from collections.abc import Callable, Hashable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar, cast
 
-from connectrpc.code import Code
-from connectrpc.errors import ConnectError
 from fray.actor import ActorFuture, ActorHandle, ActorUnavailableError
 from rigging.timing import ExponentialBackoff
 
@@ -304,9 +302,7 @@ def actor_result_with_recovery(
             raise MemoryStoreUnavailable(
                 f"memory-store actor {actor_index} did not respond within {timeout:g} seconds"
             ) from exc
-        except (ActorUnavailableError, ConnectError) as exc:
-            if isinstance(exc, ConnectError) and exc.code is not Code.NOT_FOUND:
-                raise
+        except ActorUnavailableError as exc:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise MemoryStoreUnavailable(

--- a/lib/zephyr/tests/test_memory_store.py
+++ b/lib/zephyr/tests/test_memory_store.py
@@ -217,15 +217,14 @@ def test_memory_store_retries_actor_unavailability_and_preserves_application_err
         _fake_store(failing_actor).get("key")
 
 
-def test_memory_store_retries_lost_operation_after_actor_recovery():
-    recovering_actor = _SequencedActor(
-        [
-            _TestActorFuture(error=ConnectError(Code.NOT_FOUND, "Operation 'lost' not found")),
-            _TestActorFuture(value=MemoryTableLookup(MemoryTableStatus.READY, [(True, "value")])),
-        ]
-    )
+def test_memory_store_propagates_application_not_found():
+    application_error = ConnectError(Code.NOT_FOUND, "record was not found")
+    failing_actor = _SequencedActor([_TestActorFuture(error=application_error)])
 
-    assert _fake_store(recovering_actor).get("key") == "value"
+    with pytest.raises(ConnectError) as exc_info:
+        _fake_store(failing_actor).get("key")
+
+    assert exc_info.value is application_error
 
 
 def test_memory_store_bounds_actor_call_by_recovery_timeout():


### PR DESCRIPTION
Convert only a missing Iris operation returned while polling into ActorUnavailableError. ConnectError exceptions serialized by the actor remain unchanged, so memory-store recovery does not mask application failures.

Follow-up to #8752.

<!--
See .agents/skills/writing-style/pull-requests.md for the prose rules.

Lead with what changes, then why. Keep the measured results, constraints, and
caveats a future reader needs; length follows useful content rather than a fixed
limit. Do not add Summary/Changes/Testing headings, an implementation inventory,
checkboxes, attribution, or validation narration. If an issue exists, end with
"Fixes #NNNN" or "Part of #NNNN".

Example:

Normalize DAPO loss over all response tokens instead of normalizing each
example separately. Per-example normalization over-weights short responses,
hurting math tasks where correct answers need longer derivations.

Fixes #1234
-->
