### PR TITLE
[grafana] Restore Loom alert triage launches

### DIFF
--- a/infra/grafana/src/loom_alerts.py
+++ b/infra/grafana/src/loom_alerts.py
@@ -376,7 +376,7 @@ class LoomAlertClient:
             loom_token = _required_string(federation.json(), "token", "Loom federation response")
 
             run = await client.post(
-                f"{self._config.url}/api/runs",
+                f"{self._config.url}/api/runs/create",
                 json=request,
                 headers={"Authorization": f"Bearer {loom_token}"},
             )

--- a/infra/grafana/tests/test_loom_alerts.py
+++ b/infra/grafana/tests/test_loom_alerts.py
@@ -100,7 +100,7 @@ def client_for(
         if request.url.path == "/api/auth/federate":
             assert json.loads(request.content) == {"token": "google-id-token"}
             return httpx.Response(200, json={"token": "short-lived-loom-token"})
-        if request.url.path == "/api/runs":
+        if request.url.path == "/api/runs/create":
             assert request.headers["Authorization"] == "Bearer short-lived-loom-token"
             if runs is not None:
                 runs.append(json.loads(request.content))


### PR DESCRIPTION
Send Grafana alert runs to Loom's declared `runs.create` endpoint. Loom removed
the legacy `POST /api/runs` route in
[loom#322](https://github.com/marin-community/loom/pull/322), so critical alerts
reached Slack but failed to open triage sessions with HTTP 405. Posting to
`/api/runs/create` restores triage launches.

Incident record: [Echo #283](https://echo.oa.dev/wiki/283).
