### PR TITLE
Fix empty reducer shard shuffle reads

### DIFF
--- a/experiments/datakit/testbed/neg_control.py
+++ b/experiments/datakit/testbed/neg_control.py
@@ -1,0 +1,290 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Datakit Testbed negative-control duplication arm (#5310 / #8806).
+
+Injects exact-row duplication while keeping per-shard row counts — and therefore
+mixture weights — identical to baseline. For each input shard of ``N`` rows:
+
+    unique_n = ceil(unique_fraction * N)
+    output   = first ``unique_n`` rows, replayed from the start until ``N`` rows
+
+``unique_fraction=0.50`` is the original #5310 recipe (``dup_rate = 0.50``).
+``unique_fraction=1.0`` is a row-level identity. Training HPs are the same
+Grug-MoE / MuonH protocol as :mod:`experiments.datakit.testbed.baseline`.
+
+Submit in the staging region::
+
+    uv run iris --cluster=marin job run --region us-central1 -- \\
+        python experiments/datakit/testbed/neg_control.py --unique-fraction 0.25
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import os
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from typing import TypeVar
+
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from marin.datakit.normalize import NormalizedData
+from marin.execution.artifact import read_artifact
+from marin.execution.remote import remote
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from rigging.filesystem.cluster_config import check_path_in_region, marin_prefix
+from rigging.filesystem.factory import url_to_fs
+from rigging.filesystem.storage_path import StoragePath
+from rigging.log_setup import configure_logging
+
+from experiments.datakit.testbed.mixture import tokenized_bucket_weights_step
+from experiments.datakit.testbed.sampler import build_testbed_steps
+from experiments.datakit.testbed.settings import TESTBED_STAGING_PREFIX, TESTBED_STAGING_REGION, TESTBED_TOKENIZER
+from experiments.datakit.testbed.train import run_testbed_config, testbed_tokenize
+from experiments.datasets.paloma import paloma_datasets
+from experiments.datasets.uncheatable import uncheatable_datasets
+
+logger = logging.getLogger(__name__)
+
+TARGET_TOTAL_TOKENS_B = 1000.0
+MAX_STEP_CONCURRENCY = 20
+
+_SAMPLE_STEP_PREFIX = "data/datakit/normalized/"
+# After #5310 OOMed at 5g / 32 threads, the unique-pool pass uses a small pool
+# and 12g so a mapper-sized shard's prefix can be re-read without materializing
+# the whole file 32 ways at once.
+_DUP_REMOTE_RESOURCES = ResourceConfig(cpu=1, ram="12g")
+_DUP_PARALLELISM = 4
+
+T = TypeVar("T")
+
+
+def _check_unique_fraction(unique_fraction: float) -> None:
+    if not 0.0 < unique_fraction <= 1.0:
+        raise ValueError(f"unique_fraction must be in (0.0, 1.0]; got {unique_fraction}")
+
+
+def unique_row_count(num_rows: int, unique_fraction: float) -> int:
+    """``ceil(unique_fraction * N)`` — the unique-pool size for a shard of ``N`` rows."""
+    _check_unique_fraction(unique_fraction)
+    if num_rows < 0:
+        raise ValueError(f"num_rows must be nonnegative; got {num_rows}")
+    return math.ceil(unique_fraction * num_rows)
+
+
+def first_k_replay(rows: Sequence[T], unique_fraction: float) -> list[T]:
+    """Replay the first ``unique_n`` rows until the output length equals ``len(rows)``.
+
+    ``dup_rate`` is ``1 - unique_fraction``. For ``unique_fraction=0.5`` this is
+    the #5310 per-shard recipe: keep the first half (ceil), drop the tail, then
+    replay the kept prefix until the original length is restored.
+    """
+    n = len(rows)
+    unique_n = unique_row_count(n, unique_fraction)
+    if n == 0:
+        return []
+    if unique_n == 0:
+        raise ValueError(f"unique pool is empty for unique_fraction={unique_fraction} and N={n}")
+    pool = list(rows[:unique_n])
+    out: list[T] = []
+    while len(out) < n:
+        out.extend(pool[: n - len(out)])
+    return out
+
+
+def _append_prefix_rows(src: str, writer: pq.ParquetWriter, num_rows: int) -> None:
+    """Append the first ``num_rows`` rows of ``src`` onto ``writer``."""
+    if num_rows <= 0:
+        return
+    src_fs, src_path = url_to_fs(src)
+    remaining = num_rows
+    with src_fs.open(src_path, "rb") as sf:
+        pf = pq.ParquetFile(sf)
+        for i in range(pf.num_row_groups):
+            if remaining <= 0:
+                break
+            rg = pf.read_row_group(i)
+            if rg.num_rows > remaining:
+                rg = rg.slice(0, remaining)
+            writer.write_table(rg)
+            remaining -= rg.num_rows
+    if remaining != 0:
+        raise ValueError(f"expected {num_rows} prefix rows from {src}, fell short by {remaining}")
+
+
+def duplicate_parquet_shard(src: str, dst: str, unique_fraction: float) -> tuple[int, int]:
+    """Rewrite ``src`` with first-K replay; return ``(rows_in, unique_n)``.
+
+    Output has exactly ``rows_in`` rows. The unique pool is the file prefix of
+    length ``unique_n``; later passes re-read that prefix rather than holding
+    the whole shard.
+    """
+    src_fs, src_path = url_to_fs(src)
+    with src_fs.open(src_path, "rb") as sf:
+        pf = pq.ParquetFile(sf)
+        rows_in = pf.metadata.num_rows
+        schema = pf.schema_arrow
+    unique_n = unique_row_count(rows_in, unique_fraction)
+
+    dst_fs, dst_path = url_to_fs(dst)
+    parent = os.path.dirname(dst_path)
+    if parent:
+        StoragePath(parent).mkdirs(exist_ok=True)
+
+    remaining = rows_in
+    with dst_fs.open(dst_path, "wb") as df, pq.ParquetWriter(df, schema) as writer:
+        while remaining > 0:
+            take = min(unique_n, remaining)
+            _append_prefix_rows(src, writer, take)
+            remaining -= take
+    return rows_in, unique_n
+
+
+def duplicate_normalized_shards(
+    *,
+    source: NormalizedData,
+    output_path: str,
+    unique_fraction: float,
+) -> NormalizedData:
+    """Apply first-K replay to every parquet shard under ``source.main_output_dir``.
+
+    Relative shard names are preserved so tokenize still globs
+    ``{output_path}/outputs/main/*.parquet``. Each output shard has the same
+    row count as its input, so per-bucket token counts stay baseline-shaped.
+    """
+    _check_unique_fraction(unique_fraction)
+    input_base = source.main_output_dir.rstrip("/")
+    shards = sorted(str(m) for m in StoragePath(f"{input_base}/**/*.parquet").glob())
+    if not shards:
+        raise ValueError(f"No parquet shards under {input_base}")
+    main_out = f"{output_path.rstrip('/')}/outputs/main"
+    prefix_len = len(input_base)
+
+    tasks: list[tuple[str, str]] = []
+    for src in shards:
+        rel = src[prefix_len:].lstrip("/")
+        tasks.append((src, f"{main_out}/{rel}"))
+
+    rows_in_total = 0
+    unique_n_total = 0
+    dup_rate = 1.0 - unique_fraction
+    logger.info(
+        "neg_control: unique_fraction=%.4f (dup_rate=%.4f) on %d shards %s → %s",
+        unique_fraction,
+        dup_rate,
+        len(tasks),
+        input_base,
+        main_out,
+    )
+    with ThreadPoolExecutor(max_workers=_DUP_PARALLELISM) as pool:
+        for rows_in, unique_n in pool.map(lambda args: duplicate_parquet_shard(*args, unique_fraction), tasks):
+            rows_in_total += rows_in
+            unique_n_total += unique_n
+
+    return NormalizedData(
+        main_output_dir=main_out,
+        dup_output_dir=source.dup_output_dir,
+        counters={
+            "neg_control/shards": len(tasks),
+            "neg_control/rows_in": rows_in_total,
+            "neg_control/rows_out": rows_in_total,
+            "neg_control/unique_rows": unique_n_total,
+            "neg_control/unique_fraction": unique_fraction,
+        },
+    )
+
+
+def duplicate_normalized_shards_step(
+    *,
+    name: str,
+    sampled: StepSpec,
+    unique_fraction: float,
+) -> StepSpec:
+    """StepSpec: first-K replay over one sampled source."""
+    _check_unique_fraction(unique_fraction)
+    sampled_path = sampled.output_path
+
+    def duplicate(output_path: str) -> NormalizedData:
+        return duplicate_normalized_shards(
+            source=read_artifact(sampled_path, NormalizedData),
+            output_path=output_path,
+            unique_fraction=unique_fraction,
+        )
+
+    return StepSpec(
+        name=name,
+        deps=[sampled],
+        hash_attrs={"unique_fraction": unique_fraction},
+        fn=remote(duplicate, resources=_DUP_REMOTE_RESOURCES),
+    )
+
+
+def neg_control_run_id(unique_fraction: float) -> str:
+    """Stable training-step / wandb name, e.g. ``neg_control_unique50``."""
+    _check_unique_fraction(unique_fraction)
+    return f"neg_control_unique{round(unique_fraction * 100):02d}"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Datakit Testbed first-K duplication arm")
+    parser.add_argument(
+        "--unique-fraction",
+        type=float,
+        required=True,
+        help="Fraction of each shard kept as the unique pool in (0, 1]. "
+        "0.50 reproduces #5310; 0.25/0.10/0.05 are the #8806 follow-ups.",
+    )
+    args = parser.parse_args(argv)
+    unique_fraction: float = args.unique_fraction
+    _check_unique_fraction(unique_fraction)
+
+    os.environ.setdefault("MARIN_PREFIX", TESTBED_STAGING_PREFIX)
+    check_path_in_region("MARIN_PREFIX", marin_prefix(), TESTBED_STAGING_REGION)
+
+    tokenizer = TESTBED_TOKENIZER
+    run_id = neg_control_run_id(unique_fraction)
+    validation = [*paloma_datasets(tokenizer=tokenizer).values(), *uncheatable_datasets(tokenizer=tokenizer).values()]
+
+    testbed_steps = build_testbed_steps(target_total_tokens_b=TARGET_TOTAL_TOKENS_B)
+    sampled_by_source = {
+        s.name.removeprefix(_SAMPLE_STEP_PREFIX): s for s in testbed_steps if s.name.startswith(_SAMPLE_STEP_PREFIX)
+    }
+    if not sampled_by_source:
+        raise ValueError("no sample steps found in the testbed DAG")
+
+    duplicated_by_source = {
+        name: duplicate_normalized_shards_step(
+            name=f"data/datakit/duplicated/{name}",
+            sampled=sampled,
+            unique_fraction=unique_fraction,
+        )
+        for name, sampled in sampled_by_source.items()
+    }
+    tokenized_buckets = {
+        name: testbed_tokenize(name, duplicated, tokenizer) for name, duplicated in duplicated_by_source.items()
+    }
+    weights_step = tokenized_bucket_weights_step(run_id, tokenized_buckets)
+    training_step = run_testbed_config(
+        name=run_id,
+        tokenized_buckets=tokenized_buckets,
+        weights_step=weights_step,
+        validation=validation,
+        tokenizer=tokenizer,
+    )
+
+    logger.info(
+        "Neg-control DAG: unique_fraction=%.4f dup_rate=%.4f, %d sources → duplicate → tokenize → weights → train",
+        unique_fraction,
+        1.0 - unique_fraction,
+        len(sampled_by_source),
+    )
+    StepRunner().run([training_step], max_concurrent=MAX_STEP_CONCURRENCY)
+
+
+if __name__ == "__main__":
+    configure_logging()
+    main()

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -271,13 +271,14 @@ class _Sidecar:
     ``(_SHARD_COL, _SORT_KEY_COL)``.
     ``shard_bytes`` and ``shard_rows`` map target shard index to the exact
     payload bytes and row count written for that shard across all files, used
-    by reducers to size the merge-memory plan. ``path`` is the mapper output
-    directory the sidecar lives under.
+    by reducers to size the merge-memory plan. ``shard_bytes is None`` means
+    the sidecar predates those measurements and must not be treated as zero.
+    ``path`` is the mapper output directory the sidecar lives under.
     """
 
     path: str
     files: list[_ChunkFile]
-    shard_bytes: dict[int, int]
+    shard_bytes: dict[int, int] | None
     shard_rows: dict[int, int]
 
     _encoder: ClassVar[msgspec.msgpack.Encoder] = msgspec.msgpack.Encoder()
@@ -290,7 +291,15 @@ class _Sidecar:
     def meta_path(data_path: str) -> str:
         return f"{data_path}{_SCATTER_METADATA_FILENAME}"
 
-    def target_bytes(self, target_shard: int) -> int:
+    def target_bytes(self, target_shard: int) -> int | None:
+        """Payload bytes this mapper wrote for ``target_shard``.
+
+        ``None`` means the sidecar has no ``shard_bytes`` map, which is not
+        the same as an explicit zero. When the map is present, a missing key
+        is an empty shard (0).
+        """
+        if self.shard_bytes is None:
+            return None
         return self.shard_bytes.get(target_shard, 0)
 
     def target_rows(self, target_shard: int) -> int:
@@ -302,7 +311,7 @@ class _Sidecar:
         payload = self._encoder.encode(
             {
                 self._files_field: [file.to_metadata() for file in self.files],
-                self._shard_bytes_field: {str(k): v for k, v in self.shard_bytes.items()},
+                self._shard_bytes_field: {str(k): v for k, v in (self.shard_bytes or {}).items()},
                 self._shard_rows_field: {str(k): v for k, v in self.shard_rows.items()},
             }
         )
@@ -318,12 +327,13 @@ class _Sidecar:
         files = data.get(cls._files_field, [])
         if not files:
             return None
-        raw_shard_bytes = data.get(cls._shard_bytes_field, {})
+        # Absent map is unmeasured; present map (including {}) is authoritative.
+        raw_shard_bytes = data[cls._shard_bytes_field] if cls._shard_bytes_field in data else None
         raw_shard_rows = data.get(cls._shard_rows_field, {})
         return cls(
             path=data_path,
             files=[_ChunkFile.from_metadata(file) for file in files],
-            shard_bytes={int(k): int(v) for k, v in raw_shard_bytes.items()},
+            shard_bytes=None if raw_shard_bytes is None else {int(k): int(v) for k, v in raw_shard_bytes.items()},
             shard_rows={int(k): int(v) for k, v in raw_shard_rows.items()},
         )
 
@@ -453,9 +463,11 @@ def _merge_sorted_frames(
 class ScatterReader:
     """All scatter chunks for one target shard, across all source shards.
 
-    ``_chunk_files`` lists every combined Parquet file the mappers wrote. Each
-    file holds rows for *all* target shards, so :meth:`get_frames` filters each
-    scan down to ``_target_shard``.
+    ``_chunk_files`` lists combined Parquet files that may contain this
+    target. Mappers that recorded ``shard_bytes[target] == 0`` are omitted
+    before any Parquet scan. Each remaining file still holds rows for *all*
+    target shards, so :meth:`get_frames` filters each scan down to
+    ``_target_shard``.
 
     Construct via :meth:`from_sidecars` for production use, or pass fields
     directly for testing.
@@ -466,7 +478,7 @@ class ScatterReader:
         chunk_files: list[_ChunkFile],
         target_shard: int,
         avg_item_bytes: float,
-        shard_payload_bytes: float = 0.0,
+        shard_payload_bytes: float | None = 0.0,
     ) -> None:
         self._chunk_files = chunk_files
         self._target_shard = target_shard
@@ -483,8 +495,10 @@ class ScatterReader:
         thousands of mappers.
         """
         chunk_files: list[_ChunkFile] = []
-        shard_payload_bytes = 0.0
-        shard_payload_rows = 0
+        measured_payload_bytes = 0
+        measured_payload_rows = 0
+        payload_is_measured = True
+        contributing_sidecars = 0
 
         with log_time(
             f"Building ScatterReader for target shard {target_shard} "
@@ -492,23 +506,37 @@ class ScatterReader:
         ):
             sidecars = _Sidecar.read_all(scatter_paths)
             for sidecar in sidecars:
+                target_bytes = sidecar.target_bytes(target_shard)
+                # Explicit zero: this mapper has no rows for the shard. Skip
+                # its files before scan_parquet / footer reads. Unmeasured
+                # sidecars (target_bytes is None) keep every chunk.
+                if target_bytes == 0:
+                    continue
+                contributing_sidecars += 1
                 chunk_files.extend(sidecar.files)
-                shard_payload_bytes += sidecar.target_bytes(target_shard)
-                shard_payload_rows += sidecar.target_rows(target_shard)
+                if target_bytes is None:
+                    payload_is_measured = False
+                    continue
+                measured_payload_bytes += target_bytes
+                measured_payload_rows += sidecar.target_rows(target_shard)
 
         # Computed from this target's own exact bytes and row count, not a
         # mapper-wide average, so row width that varies by target (e.g. a
         # skewed shuffle key) doesn't bias the merge-memory prediction.
-        avg_item_bytes = shard_payload_bytes / shard_payload_rows if shard_payload_rows > 0 else 0.0
+        if payload_is_measured:
+            shard_payload_bytes: float | None = float(measured_payload_bytes)
+            avg_item_bytes = shard_payload_bytes / measured_payload_rows if measured_payload_rows > 0 else 0.0
+        else:
+            shard_payload_bytes = None
+            avg_item_bytes = 0.0
 
         logger.info(
-            "ScatterReader for shard %d: %d source shards, %d total chunks, "
-            "avg_item_bytes=%.1f, shard_payload_bytes=%.0f",
+            "ScatterReader for shard %d: %d source shards, %d total chunks, avg_item_bytes=%.1f, shard_payload_bytes=%s",
             target_shard,
-            len(sidecars),
+            contributing_sidecars,
             len(chunk_files),
             avg_item_bytes,
-            shard_payload_bytes,
+            "unknown" if shard_payload_bytes is None else f"{shard_payload_bytes:.0f}",
         )
         return cls(
             chunk_files=chunk_files,
@@ -555,28 +583,42 @@ class ScatterReader:
                 return
 
             frames = self.get_frames()
-            memory_bytes = _task_memory_bytes()
             baseline_rss_bytes = _process_rss_bytes()
             polars_threads = pl.thread_pool_size()
-            fan_in = memory_budget.read_merge_fan_in(
-                memory_bytes,
-                baseline_rss_bytes,
-                self.avg_item_bytes,
-                self.total_chunks,
-                self.shard_payload_bytes,
-                polars_threads,
-            )
-            logger.info(
-                "[shard %d] Merging %d chunks with fan_in=%d "
-                "(baseline_rss=%s, shard_payload_bytes=%s, avg_item_bytes=%.1f, polars_threads=%d)",
-                self._target_shard,
-                self.total_chunks,
-                fan_in,
-                humanfriendly.format_size(baseline_rss_bytes, binary=True),
-                humanfriendly.format_size(self.shard_payload_bytes, binary=True),
-                self.avg_item_bytes,
-                polars_threads,
-            )
+            if self.shard_payload_bytes is None:
+                # Unmeasured payload: do not treat as empty, and do not size an
+                # unbounded in-memory merge. Conservative fan-in spills.
+                fan_in = memory_budget.MIN_MERGE_FAN_IN
+                logger.info(
+                    "[shard %d] Merging %d chunks with fan_in=%d "
+                    "(baseline_rss=%s, shard_payload_bytes=unknown, avg_item_bytes=%.1f, polars_threads=%d)",
+                    self._target_shard,
+                    self.total_chunks,
+                    fan_in,
+                    humanfriendly.format_size(baseline_rss_bytes, binary=True),
+                    self.avg_item_bytes,
+                    polars_threads,
+                )
+            else:
+                fan_in = memory_budget.read_merge_fan_in(
+                    _task_memory_bytes(),
+                    baseline_rss_bytes,
+                    self.avg_item_bytes,
+                    self.total_chunks,
+                    self.shard_payload_bytes,
+                    polars_threads,
+                )
+                logger.info(
+                    "[shard %d] Merging %d chunks with fan_in=%d "
+                    "(baseline_rss=%s, shard_payload_bytes=%s, avg_item_bytes=%.1f, polars_threads=%d)",
+                    self._target_shard,
+                    self.total_chunks,
+                    fan_in,
+                    humanfriendly.format_size(baseline_rss_bytes, binary=True),
+                    humanfriendly.format_size(self.shard_payload_bytes, binary=True),
+                    self.avg_item_bytes,
+                    polars_threads,
+                )
 
             batches = _merge_sorted_frames(
                 frames=frames,

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -21,6 +21,7 @@ from fsspec.implementations.local import LocalFileSystem
 from iris.env_resources import TaskResources
 from rigging.filesystem.storage_path import StoragePath
 from zephyr import memory_budget
+from zephyr.parquet_scan import scan_parquet
 from zephyr.runners import _InProcessWorkerContext
 from zephyr.shard_keys import deterministic_hash
 from zephyr.shuffle import (
@@ -78,6 +79,46 @@ def _build_shard(tmp_path, items, num_output_shards=4, source_shard=0):
     )
     scatter_paths = list(list_shard)
     return scatter_paths
+
+
+def _sidecar_meta_path(data_path: str) -> str:
+    if not data_path.endswith("/"):
+        data_path = f"{data_path}/"
+    return _Sidecar.meta_path(data_path)
+
+
+def _load_sidecar_payload(data_path: str) -> dict:
+    return _Sidecar._decoder.decode(StoragePath(_sidecar_meta_path(data_path)).read_bytes())
+
+
+def _store_sidecar_payload(data_path: str, payload: dict) -> None:
+    StoragePath(_sidecar_meta_path(data_path)).write_bytes(_Sidecar._encoder.encode(payload))
+
+
+def _drop_shard_bytes_measurement(data_path: str) -> None:
+    payload = _load_sidecar_payload(data_path)
+    payload.pop(_Sidecar._shard_bytes_field, None)
+    payload.pop(_Sidecar._shard_rows_field, None)
+    _store_sidecar_payload(data_path, payload)
+
+
+def _set_explicit_shard_bytes(data_path: str, shard_bytes: dict[int, int]) -> None:
+    payload = _load_sidecar_payload(data_path)
+    payload[_Sidecar._shard_bytes_field] = {str(k): v for k, v in shard_bytes.items()}
+    _store_sidecar_payload(data_path, payload)
+
+
+def _write_mapper(tmp_path, source_shard: int, items: list, *, flushes: int | None = None) -> str:
+    data_path = f"{tmp_path}/shard-{source_shard:04d}/scatter/"
+    writer = ScatterWriter(data_path=data_path, key_fn=_key, source_shard=source_shard)
+    if flushes is None:
+        writer.write(_items_to_dataframe(items, _key, None, 1))
+    else:
+        writer._flush_threshold_bytes = 0
+        for i in range(flushes):
+            writer.write(_items_to_dataframe([items[i % len(items)]], _key, None, 1))
+    writer.close()
+    return data_path
 
 
 # ---------------------------------------------------------------------------
@@ -351,20 +392,136 @@ def test_merge_sorted_chunks_external_trigger(tmp_path):
     assert list(external_dir.iterdir()) == []
 
 
-def test_merge_sorted_chunks_skips_empty_target_shard(tmp_path):
+def test_merge_sorted_chunks_skips_empty_target_shard(tmp_path, monkeypatch):
     key = "only-key"
     populated_shard = _target(key, 2)
     empty_shard = 1 - populated_shard
     scatter_paths = _build_shard(tmp_path, [{"k": key, "v": 1}], num_output_shards=2)
     reader = ScatterReader.from_sidecars(scatter_paths, empty_shard)
 
-    assert reader.total_chunks > 0
-    assert reader.shard_payload_bytes == 0
+    assert reader.total_chunks == 0
+    assert reader.shard_payload_bytes == 0.0
+
+    scanned = []
+
+    def scan_and_record(path, *, schema=None):
+        scanned.append(path)
+        return scan_parquet(path, schema=schema)
+
+    monkeypatch.setattr("zephyr.shuffle.scan_parquet", scan_and_record)
     with patch(
         "zephyr.shuffle.memory_budget.read_merge_fan_in",
         side_effect=AssertionError("empty target shards do not need memory planning"),
     ):
         assert list(reader.merge_sorted_chunks(external_sort_dir=str(tmp_path / "sort"))) == []
+    assert scanned == []
+
+
+# ---------------------------------------------------------------------------
+# Empty-shard skip vs missing shard_bytes (#8352)
+# ---------------------------------------------------------------------------
+
+
+def test_from_sidecars_skips_explicit_zero_byte_shard_before_parquet_scan(tmp_path, monkeypatch):
+    data_path = _write_mapper(tmp_path, 0, [{"k": "a", "v": 1}])
+    _set_explicit_shard_bytes(data_path, {0: 0})
+
+    scanned = []
+
+    def scan_and_record(path, *, schema=None):
+        scanned.append(path)
+        return scan_parquet(path, schema=schema)
+
+    monkeypatch.setattr("zephyr.shuffle.scan_parquet", scan_and_record)
+
+    reader = ScatterReader.from_sidecars([data_path], target_shard=0)
+    assert reader.total_chunks == 0
+    assert reader.shard_payload_bytes == 0.0
+    assert reader.get_frames() == []
+    assert list(reader.merge_sorted_chunks(external_sort_dir=str(tmp_path / "sort"))) == []
+    assert scanned == []
+
+
+def test_from_sidecars_retains_positive_shard_bytes(tmp_path, monkeypatch):
+    data_path = _write_mapper(tmp_path, 0, [{"k": "a", "v": 1}, {"k": "a", "v": 2}])
+
+    scanned = []
+
+    def scan_and_record(path, *, schema=None):
+        scanned.append(path)
+        return scan_parquet(path, schema=schema)
+
+    monkeypatch.setattr("zephyr.shuffle.scan_parquet", scan_and_record)
+
+    reader = ScatterReader.from_sidecars([data_path], target_shard=0)
+    assert reader.total_chunks == 1
+    assert reader.shard_payload_bytes is not None and reader.shard_payload_bytes > 0
+    recovered = _read_shard(reader)
+    assert sorted(row["v"] for row in recovered) == [1, 2]
+    assert scanned == [f"{data_path}c0000.parquet"]
+
+
+def test_from_sidecars_missing_shard_bytes_keeps_chunks_and_external_sorts(tmp_path, monkeypatch):
+    items = [{"k": i, "v": i} for i in range(5)]
+    data_path = _write_mapper(tmp_path, 0, items, flushes=5)
+    _drop_shard_bytes_measurement(data_path)
+
+    scanned = []
+
+    def scan_and_record(path, *, schema=None):
+        scanned.append(path)
+        return scan_parquet(path, schema=schema)
+
+    monkeypatch.setattr("zephyr.shuffle.scan_parquet", scan_and_record)
+
+    reader = ScatterReader.from_sidecars([data_path], target_shard=0)
+    assert reader.total_chunks == 5
+    assert reader.shard_payload_bytes is None
+
+    captured_fan_in: list[int] = []
+    real_merge = _merge_sorted_frames
+
+    def merge_and_record(*args, **kwargs):
+        captured_fan_in.append(kwargs["fan_in"])
+        return real_merge(*args, **kwargs)
+
+    monkeypatch.setattr("zephyr.shuffle._merge_sorted_frames", merge_and_record)
+    with patch(
+        "zephyr.shuffle.memory_budget.read_merge_fan_in",
+        side_effect=AssertionError("unmeasured payload must not use in-memory fan-in sizing"),
+    ):
+        merged = list(reader.merge_sorted_chunks(external_sort_dir=str(tmp_path / "sort")))
+
+    assert [item["v"] for item in merged] == list(range(5))
+    assert captured_fan_in == [memory_budget.MIN_MERGE_FAN_IN]
+    chunk_paths = {f"{data_path}c{i:04d}.parquet" for i in range(5)}
+    assert chunk_paths <= set(scanned)
+
+
+def test_from_sidecars_mixed_mappers_skip_only_explicit_zeros(tmp_path, monkeypatch):
+    zero_path = _write_mapper(tmp_path, 0, [{"k": "a", "v": 0}])
+    positive_path = _write_mapper(tmp_path, 1, [{"k": "a", "v": 1}])
+    missing_path = _write_mapper(tmp_path, 2, [{"k": "a", "v": 2}])
+    _set_explicit_shard_bytes(zero_path, {0: 0})
+    _drop_shard_bytes_measurement(missing_path)
+
+    scanned = []
+
+    def scan_and_record(path, *, schema=None):
+        scanned.append(path)
+        return scan_parquet(path, schema=schema)
+
+    monkeypatch.setattr("zephyr.shuffle.scan_parquet", scan_and_record)
+
+    reader = ScatterReader.from_sidecars([zero_path, positive_path, missing_path], target_shard=0)
+    assert reader.total_chunks == 2
+    assert reader.shard_payload_bytes is None
+
+    recovered = _read_shard(reader)
+    assert sorted(row["v"] for row in recovered) == [1, 2]
+    assert f"{zero_path}c0000.parquet" not in scanned
+    assert f"{positive_path}c0000.parquet" in scanned
+    assert f"{missing_path}c0000.parquet" in scanned
 
 
 def test_scatter_null_keys(tmp_path):

--- a/tests/datakit/testbed/test_neg_control.py
+++ b/tests/datakit/testbed/test_neg_control.py
@@ -1,0 +1,160 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""First-K replay recipe for the Datakit Testbed duplication arm (#5310)."""
+
+import math
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.normalize import NormalizedData
+
+from experiments.datakit.testbed.neg_control import (
+    duplicate_normalized_shards,
+    first_k_replay,
+    unique_row_count,
+)
+
+
+def _ids(n: int) -> list[str]:
+    return [f"r{i}" for i in range(n)]
+
+
+def _write_shard(path: Path, ids: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.table({"id": ids, "text": [f"t{i}" for i in ids]}), path)
+
+
+def _normalized(tmp_path: Path, shards: dict[str, list[str]]) -> NormalizedData:
+    main_dir = tmp_path / "norm" / "outputs" / "main"
+    dup_dir = tmp_path / "norm" / "outputs" / "dups"
+    dup_dir.mkdir(parents=True, exist_ok=True)
+    for rel, ids in shards.items():
+        _write_shard(main_dir / rel, ids)
+    return NormalizedData(main_output_dir=str(main_dir), dup_output_dir=str(dup_dir), counters={})
+
+
+def _read_ids(path: Path) -> list[str]:
+    return pq.read_table(path).column("id").to_pylist()
+
+
+@pytest.mark.parametrize(
+    ("n", "unique_fraction"),
+    [
+        (10, 0.50),
+        (7, 0.50),
+        (8, 0.25),
+        (10, 0.10),
+        (20, 0.05),
+        (1, 0.05),
+        (2, 0.05),
+        (5, 1.0),
+    ],
+)
+def test_unique_count_is_ceil_fraction_of_n(n: int, unique_fraction: float):
+    assert unique_row_count(n, unique_fraction) == math.ceil(unique_fraction * n)
+
+
+def test_replay_preserves_length_and_first_k_pool():
+    rows = _ids(10)
+    out = first_k_replay(rows, 0.25)
+    unique_n = math.ceil(0.25 * 10)
+    assert len(out) == 10
+    assert unique_n == 3
+    assert out[:unique_n] == rows[:unique_n]
+    assert set(out) <= set(rows[:unique_n])
+
+
+def test_unique_fraction_0_5_is_5310_even_and_odd_shards():
+    """#5310: unique_n = ceil(0.5 * N); replay the prefix until length N."""
+    even = _ids(10)
+    assert first_k_replay(even, 0.50) == even[:5] + even[:5]
+
+    odd = _ids(7)
+    # ceil(0.5 * 7) = 4 → prefix of 4, then 3 more from the start.
+    assert first_k_replay(odd, 0.50) == odd[:4] + odd[:3]
+
+
+def test_replay_is_deterministic():
+    rows = _ids(16)
+    assert first_k_replay(rows, 0.10) == first_k_replay(rows, 0.10)
+
+
+def test_unique_fraction_1_is_identity():
+    rows = _ids(6)
+    assert first_k_replay(rows, 1.0) == rows
+
+
+def test_small_shard_unique_fraction_rounds_up_to_one_row():
+    rows = _ids(1)
+    assert first_k_replay(rows, 0.05) == rows
+    two = _ids(2)
+    assert unique_row_count(2, 0.05) == 1
+    assert first_k_replay(two, 0.05) == [two[0], two[0]]
+
+
+def test_empty_sequence_stays_empty():
+    assert first_k_replay([], 0.50) == []
+    assert unique_row_count(0, 0.50) == 0
+
+
+def test_invalid_unique_fraction_rejected():
+    rows = _ids(4)
+    for bad in (0.0, -0.1, 1.1):
+        with pytest.raises(ValueError, match="unique_fraction"):
+            first_k_replay(rows, bad)
+        with pytest.raises(ValueError, match="unique_fraction"):
+            unique_row_count(4, bad)
+
+
+def test_duplicate_normalized_shards_matches_first_k_replay(tmp_path: Path):
+    source = _normalized(
+        tmp_path,
+        {
+            "part-00000-of-00002.parquet": _ids(10),
+            "part-00001-of-00002.parquet": _ids(7),
+        },
+    )
+    unique_fraction = 0.50
+    out = duplicate_normalized_shards(
+        source=source,
+        output_path=str(tmp_path / "duped"),
+        unique_fraction=unique_fraction,
+    )
+
+    src_shards = sorted(Path(source.main_output_dir).glob("*.parquet"))
+    dst_shards = sorted(Path(out.main_output_dir).glob("*.parquet"))
+    assert [p.name for p in dst_shards] == [p.name for p in src_shards]
+    for src, dst in zip(src_shards, dst_shards, strict=True):
+        src_ids = _read_ids(src)
+        dst_ids = _read_ids(dst)
+        assert len(dst_ids) == len(src_ids)
+        assert dst_ids == first_k_replay(src_ids, unique_fraction)
+    assert out.counters["neg_control/rows_out"] == out.counters["neg_control/rows_in"] == 17
+    assert out.counters["neg_control/unique_rows"] == math.ceil(0.5 * 10) + math.ceil(0.5 * 7)
+
+
+def test_duplicate_identity_and_determinism_on_parquet(tmp_path: Path):
+    source = _normalized(tmp_path, {"part-00000-of-00001.parquet": _ids(8)})
+    identity = duplicate_normalized_shards(source=source, output_path=str(tmp_path / "id"), unique_fraction=1.0)
+    assert _read_ids(next(Path(identity.main_output_dir).glob("*.parquet"))) == _ids(8)
+
+    a = duplicate_normalized_shards(source=source, output_path=str(tmp_path / "a"), unique_fraction=0.25)
+    b = duplicate_normalized_shards(source=source, output_path=str(tmp_path / "b"), unique_fraction=0.25)
+    assert _read_ids(next(Path(a.main_output_dir).glob("*.parquet"))) == _read_ids(
+        next(Path(b.main_output_dir).glob("*.parquet"))
+    )
+
+
+def test_duplicate_rejects_invalid_fraction_and_empty_dir(tmp_path: Path):
+    source = _normalized(tmp_path, {"part-00000-of-00001.parquet": _ids(3)})
+    with pytest.raises(ValueError, match="unique_fraction"):
+        duplicate_normalized_shards(source=source, output_path=str(tmp_path / "bad"), unique_fraction=0.0)
+
+    empty_main = tmp_path / "empty" / "outputs" / "main"
+    empty_main.mkdir(parents=True)
+    empty = NormalizedData(main_output_dir=str(empty_main), dup_output_dir=str(tmp_path / "d"), counters={})
+    with pytest.raises(ValueError, match="No parquet shards"):
+        duplicate_normalized_shards(source=empty, output_path=str(tmp_path / "out"), unique_fraction=0.50)


### PR DESCRIPTION
<!--
See .agents/skills/writing-style/pull-requests.md for the prose rules.

Lead with what changes, then why. Keep the measured results, constraints, and
caveats a future reader needs; length follows useful content rather than a fixed
limit. Do not add Summary/Changes/Testing headings, an implementation inventory,
checkboxes, attribution, or validation narration. If an issue exists, end with
"Fixes #NNNN" or "Part of #NNNN".

Example:

Normalize DAPO loss over all response tokens instead of normalizing each
example separately. Per-example normalization over-weights short responses,
hurting math tasks where correct answers need longer derivations.

Fixes #1234
-->
