### PR TITLE
[finelog] Restart the server after Rust panics

### DIFF
--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -631,6 +631,16 @@ compactions indicate ingest pressure; tune `cpu_request`, `cpu_limit`,
 Kubernetes deployment also has a five-minute startup probe so reopening an
 existing network-backed store does not feed a liveness restart loop.
 
+The standalone `finelog-server` treats every Rust panic as process-fatal. Its
+panic hook reports the first panic and aborts before Tokio can contain it as a
+failed task. Kubernetes then restarts the container over the existing store and
+PVC. Inspect `kubectl logs ... --previous` for the initiating panic and the pod's
+restart count. A repeated deterministic panic becomes `CrashLoopBackOff`.
+Do not recover a poisoned store mutex with `PoisonError::into_inner`; the panic
+may have interrupted a state transition protected by that mutex. The PyO3
+server embedded in Iris does not install this process-wide hook because an
+abort would terminate the controller.
+
 The startup events carry millisecond timings for SQLite open, one-time catalog
 adoption, local directory discovery, catalog reads, Parquet footer reconciliation,
 batched catalog refresh, namespace rehydration, and total store open. The catalog

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -120,15 +120,11 @@ struct Args {
     telemetry_migration_mode: TelemetryMigrationMode,
 }
 
-/// Terminate the standalone server on the first panic after reporting it.
-///
-/// Tokio normally contains task panics as `JoinError`s. That is unsafe for this
-/// process because a panic while a store mutex is held poisons the mutex while
-/// leaving the HTTP server alive; later requests then repeat the poison panic.
-/// Aborting lets the process supervisor restart over the durable store instead.
-/// Keep this binary-only: the `finelog` library is also embedded in Iris through
-/// PyO3, where aborting would terminate the host controller.
+/// Abort the standalone server after reporting any Rust panic.
 fn install_abort_on_panic_hook() {
+    // Tokio contains task panics as JoinErrors, which can leave poisoned store
+    // mutexes in a live process. Keep this hook in the binary so the PyO3 host
+    // does not inherit an abort-on-panic policy.
     let report = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic| {
         report(panic);

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -120,8 +120,25 @@ struct Args {
     telemetry_migration_mode: TelemetryMigrationMode,
 }
 
+/// Terminate the standalone server on the first panic after reporting it.
+///
+/// Tokio normally contains task panics as `JoinError`s. That is unsafe for this
+/// process because a panic while a store mutex is held poisons the mutex while
+/// leaving the HTTP server alive; later requests then repeat the poison panic.
+/// Aborting lets the process supervisor restart over the durable store instead.
+/// Keep this binary-only: the `finelog` library is also embedded in Iris through
+/// PyO3, where aborting would terminate the host controller.
+fn install_abort_on_panic_hook() {
+    let report = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
+        report(panic);
+        std::process::abort();
+    }));
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    install_abort_on_panic_hook();
     let args = Args::parse();
 
     tracing_subscriber::fmt()
@@ -325,7 +342,42 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    #[cfg(unix)]
+    use std::process::Command;
+
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn panic_boundary_aborts_process() {
+        const CHILD_PROCESS: &str = "FINELOG_ABORT_ON_PANIC_TEST_CHILD";
+
+        if std::env::var_os(CHILD_PROCESS).is_some() {
+            install_abort_on_panic_hook();
+            let runtime = tokio::runtime::Runtime::new().expect("test runtime starts");
+            runtime.block_on(async {
+                let _ = tokio::spawn(async {
+                    panic!("exercise the finelog-server panic boundary");
+                })
+                .await;
+            });
+            return;
+        }
+
+        let status = Command::new(std::env::current_exe().expect("test executable exists"))
+            .args([
+                "--exact",
+                "tests::panic_boundary_aborts_process",
+                "--nocapture",
+            ])
+            .env(CHILD_PROCESS, "1")
+            .status()
+            .expect("panic-boundary child process starts");
+
+        assert_eq!(status.signal(), Some(libc::SIGABRT));
+    }
 
     fn args(argv: &[&str]) -> Args {
         let mut full = vec!["finelog-server"];


### PR DESCRIPTION
Abort the standalone `finelog-server` after reporting any Rust panic. A panic
in `cw-us-east-02a` poisoned the namespace mutex; Tokio contained later worker
panics as `JoinError`s, so the process remained alive and emitted repeated
`PoisonError` panics. Kubernetes did not receive a normal process exit, and the
initiating panic was lost from retained logs. The incident record is
[Echo wiki 285](https://echo.oa.dev/wiki/285).

The binary-only hook leaves the embedded PyO3 server unchanged because an
abort there would terminate the Iris controller. A subprocess regression
exercises a Tokio worker panic and verifies SIGABRT, which Kubernetes will
restart. The Finelog runbook now documents previous-container log inspection,
poisoned-lock handling, and deterministic `CrashLoopBackOff` behavior.
