### PR TITLE
[iris] Restart complete coscheduled gangs

### DIFF
--- a/lib/iris/docs/task-states.md
+++ b/lib/iris/docs/task-states.md
@@ -4,9 +4,10 @@ This document describes the `TaskState` enum, the state machine governing task
 lifecycle, retry semantics, and how states appear in the dashboard.
 
 A **task** is the unit of execution in Iris. Each job expands into one or more
-tasks (controlled by `replicas`). Tasks are independently scheduled, retried,
-and tracked. Job state is derived from task state counts -- there is no
-independent job state machine.
+tasks (controlled by `replicas`). Tasks are independently tracked. Iris places
+all tasks in a coscheduled job together. A retriable failure or preemption
+returns the whole gang to `PENDING`. Job state is derived from task state counts
+-- there is no independent job state machine.
 
 ## State Diagram
 
@@ -133,7 +134,10 @@ Reported by the worker via Reconcile after the user command starts executing
 
 Reported by the worker via Reconcile when the task process exits with code 0.
 The controller sets `exit_code=0`, `finished_at`, and marks the task terminal.
-No retry logic applies.
+For a regular job, no retry logic applies. For a coscheduled job, the success is
+provisional until every task succeeds. If a sibling retries after a preemption
+or failure, the controller returns the succeeded task to `PENDING`; its
+successful attempt remains unchanged in the attempt history.
 
 ### FAILED
 
@@ -182,10 +186,12 @@ Retry evaluation uses the preemption budget:
 3. If exhausted: `EXCEEDED_RETRY_LIMIT` -- task stays in `WORKER_FAILED`
    and is terminal.
 
-**Coscheduled jobs**: When a task in a coscheduled (gang-scheduled) job fails
-terminally, `_terminate_coscheduled_siblings` transitions all running siblings
-to `COSCHED_FAILED` (always terminal — see below). This prevents other hosts
-from hanging on collective operations.
+**Coscheduled jobs**: A retriable task failure returns every sibling to
+`PENDING`, including siblings that already exited 0, so the next attempt can
+schedule the complete gang. The succeeded attempt remains `SUCCEEDED`; only the
+Task returns to `PENDING`. A terminal failure transitions running siblings to
+`COSCHED_FAILED` (always terminal — see below). This prevents other hosts from
+hanging on collective operations.
 
 ### PREEMPTED
 
@@ -215,13 +221,10 @@ Retry evaluation uses `_resolve_task_failure_state` with the preemption budget:
      `PREEMPTED` (terminal). Both the attempt and the task are `PREEMPTED`.
 
 `PREEMPTED` is in both `TERMINAL_TASK_STATES` and `FAILURE_TASK_STATES`.
-When a coscheduled task becomes terminally `PREEMPTED`, the job state is
-recomputed. If all tasks in the job are terminal, the batches.py
-`_finalize_terminal_job` orchestrator
-kills any remaining non-terminal tasks and cascades to child jobs. Note that
-unlike `WORKER_FAILED` reported via Reconcile, PREEMPT decisions do not
-directly cascade coscheduled siblings — the cascade only occurs through job
-finalization.
+A retriable preemption returns the triggering task and every coscheduled sibling
+to `PENDING`. A terminal preemption transitions active siblings to
+`COSCHED_FAILED`, recomputes the job state, and cascades to child jobs according
+to the job preemption policy.
 
 ### UNSCHEDULABLE
 
@@ -275,35 +278,40 @@ Iris maintains two independent retry budgets per task:
 ### What counts toward job failure
 
 Only `TASK_STATE_FAILED` counts toward the job's `max_task_failures` threshold.
-Worker failures and preemptions do not count. This means a job can survive
-unlimited preemptions as long as the per-task preemption budget is not
-exhausted. `TASK_STATE_PREEMPTED` and `TASK_STATE_WORKER_FAILED` are grouped
-together for job state derivation: if all tasks are terminal and any are in
-one of these states, the job becomes `JOB_STATE_WORKER_FAILED`.
+Worker failures and preemptions do not count. There is no additional job-wide
+preemption limit; each task is governed by its own preemption budget.
+`TASK_STATE_PREEMPTED` and `TASK_STATE_WORKER_FAILED` are grouped together for
+job state derivation: if all tasks are terminal and any are in one of these
+states, the job becomes `JOB_STATE_WORKER_FAILED`.
 
-### States that are never retried
+### When retries stop
 
-- `SUCCEEDED`: task completed successfully
+- `SUCCEEDED`: never retried because of its own result; a coscheduled sibling's retry can return the task to `PENDING`
 - `KILLED`: explicit termination by user or cascade
 - `UNSCHEDULABLE`: scheduling timeout expired
-- `PREEMPTED`: only when preemption budget is exhausted (otherwise retried as `PENDING`)
+- `COSCHED_FAILED`: a sibling reached a terminal failure
+- `FAILED`: failure budget exhausted
+- `WORKER_FAILED` or `PREEMPTED`: preemption budget exhausted
 
 ## Terminal State Summary
 
-A task is considered finished (`is_finished() == True`) when:
+The controller's task-finished predicate returns true when:
 
 | State | Condition |
 |---|---|
-| `SUCCEEDED` | Always finished |
+| `SUCCEEDED` | Always finished in the current state |
 | `KILLED` | Always finished |
 | `UNSCHEDULABLE` | Always finished |
 | `FAILED` | Finished when `failure_count > max_retries_failure` |
 | `WORKER_FAILED` | Finished when `preemption_count > max_retries_preemption` |
 | `PREEMPTED` | Finished when `preemption_count > max_retries_preemption` |
+| `COSCHED_FAILED` | Always finished |
 
 The distinction matters: a task in `FAILED` state with retry budget remaining
-is in a terminal state at the attempt level but is not finished at the task
-level. `can_be_scheduled()` returns `True` for such tasks.
+is terminal at the attempt level but is not finished at the task level. Iris
+returns the Task to `PENDING`, which makes it eligible for scheduling.
+A later coscheduled sibling retry can similarly transition a finished
+`SUCCEEDED` Task back to `PENDING`.
 
 ## Dashboard Display
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/batches.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/batches.py
@@ -188,10 +188,11 @@ def _cascade_to_peers(overlay: Overlay, outcome: task.TransitionOutcome, now_ms:
     """Coscheduled-sibling cascade for one transition. No job recompute."""
     if not outcome.cascade_to_peers:
         return
-    siblings = peers.find_coscheduled_siblings(overlay, outcome.job_id, outcome.task_id)
     if outcome.new_task_state in FAILURE_TASK_STATES:
+        siblings = peers.find_coscheduled_siblings(overlay, outcome.job_id, outcome.task_id)
         peers.terminate_coscheduled_siblings(overlay, siblings, outcome.task_id, now_ms)
     else:
+        siblings = peers.find_coscheduled_requeue_siblings(overlay, outcome.job_id, outcome.task_id)
         peers.requeue_coscheduled_siblings(overlay, siblings, outcome.task_id, now_ms)
 
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/loader.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/loader.py
@@ -34,6 +34,7 @@ from iris.cluster.types import (
     JobName,
     WorkerId,
 )
+from iris.rpc import job_pb2
 
 
 class TransitionReader(Protocol):
@@ -264,7 +265,8 @@ def load_closed_snapshot(
 
     * ``tasks`` covers every seed task, every task resolved from an
       observation UID, every active task on a seeded worker, and every task
-      of every job in the seeded-job subtrees.
+      of every job in the seeded-job subtrees. It also covers succeeded tasks
+      in coscheduled jobs, because a peer retry may return them to PENDING.
     * ``attempts`` covers each task's current attempt plus ``extra_attempt_keys``
       and the attempts resolved from ``observation_uids``.
     * ``job_descendants``, ``job_state_basis``, ``all_tasks_by_job``,
@@ -322,6 +324,18 @@ def load_closed_snapshot(
     job_descendants = _load_descendants_multi(cur, job_set)
     job_configs = _build_job_configs(cur, job_set)
     all_tasks_by_job = _load_all_tasks_for_jobs(cur, job_set)
+    succeeded_coscheduled_task_ids = {
+        row.task_id
+        for job_id, rows in all_tasks_by_job.items()
+        if job_configs[job_id].has_coscheduling
+        for row in rows
+        if row.state == job_pb2.TASK_STATE_SUCCEEDED
+    }
+    missing_succeeded_task_ids = succeeded_coscheduled_task_ids - tasks.keys()
+    succeeded_tasks = reads.bulk_get_task_detail(cur, list(missing_succeeded_task_ids))
+    tasks.update(succeeded_tasks)
+    succeeded_attempt_keys = [(task_id, task.current_attempt_id) for task_id, task in succeeded_tasks.items()]
+    attempts.update(reads.bulk_get_attempts(cur, succeeded_attempt_keys))
     job_state_basis = _bulk_load_job_state_basis(cur, job_set, all_tasks_by_job)
     active_tasks_by_job = reads.list_active_tasks_for_jobs(cur, job_set, states=NON_TERMINAL_TASK_STATES)
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/loader.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/loader.py
@@ -27,14 +27,13 @@ from iris.cluster.controller.schema import (
     jobs_table,
     local_tasks,
 )
-from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
+from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, COSCHEDULED_REQUEUE_TASK_STATES
 from iris.cluster.types import (
     TERMINAL_JOB_STATES,
     AttemptUid,
     JobName,
     WorkerId,
 )
-from iris.rpc import job_pb2
 
 
 class TransitionReader(Protocol):
@@ -324,18 +323,18 @@ def load_closed_snapshot(
     job_descendants = _load_descendants_multi(cur, job_set)
     job_configs = _build_job_configs(cur, job_set)
     all_tasks_by_job = _load_all_tasks_for_jobs(cur, job_set)
-    succeeded_coscheduled_task_ids = {
+    requeueable_coscheduled_task_ids = {
         row.task_id
         for job_id, rows in all_tasks_by_job.items()
         if job_configs[job_id].has_coscheduling
         for row in rows
-        if row.state == job_pb2.TASK_STATE_SUCCEEDED
+        if row.state in COSCHEDULED_REQUEUE_TASK_STATES
     }
-    missing_succeeded_task_ids = succeeded_coscheduled_task_ids - tasks.keys()
-    succeeded_tasks = reads.bulk_get_task_detail(cur, list(missing_succeeded_task_ids))
-    tasks.update(succeeded_tasks)
-    succeeded_attempt_keys = [(task_id, task.current_attempt_id) for task_id, task in succeeded_tasks.items()]
-    attempts.update(reads.bulk_get_attempts(cur, succeeded_attempt_keys))
+    missing_requeueable_task_ids = requeueable_coscheduled_task_ids - tasks.keys()
+    requeueable_tasks = reads.bulk_get_task_detail(cur, list(missing_requeueable_task_ids))
+    tasks.update(requeueable_tasks)
+    requeueable_attempt_keys = [(task_id, task.current_attempt_id) for task_id, task in requeueable_tasks.items()]
+    attempts.update(reads.bulk_get_attempts(cur, requeueable_attempt_keys))
     job_state_basis = _bulk_load_job_state_basis(cur, job_set, all_tasks_by_job)
     active_tasks_by_job = reads.list_active_tasks_for_jobs(cur, job_set, states=NON_TERMINAL_TASK_STATES)
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/overlay.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/overlay.py
@@ -7,6 +7,7 @@ A narrow record-bag threaded through the per-update kernel.
 """
 
 from collections.abc import Iterable
+from dataclasses import replace
 from typing import TypeVar
 
 from rigging.timing import Timestamp
@@ -26,7 +27,7 @@ from iris.cluster.controller.reconcile.snapshot import (
     TransitionSnapshot,
     pick_earliest_task_error,
 )
-from iris.cluster.controller.task_state import ActiveTaskRow
+from iris.cluster.controller.task_state import ActiveTaskRow, TaskDetailRow
 from iris.cluster.types import TERMINAL_JOB_STATES, JobName, WorkerId
 from iris.rpc import job_pb2
 
@@ -212,6 +213,28 @@ class Overlay:
                 )
             out.append(row)
         return out
+
+    def task_details_for_job(
+        self,
+        job_id: JobName,
+        *,
+        exclude: JobName | None = None,
+        states: Iterable[int],
+    ) -> list[TaskDetailRow]:
+        """Return task details for ``job_id`` filtered through the prospective overlay."""
+        state_set = frozenset(int(state) for state in states)
+        rows: list[TaskDetailRow] = []
+        for histogram_row in self._snapshot.all_tasks_by_job.get(job_id, ()):
+            if exclude is not None and histogram_row.task_id == exclude:
+                continue
+            row = self._snapshot.tasks.get(histogram_row.task_id)
+            if row is None:
+                continue
+            effective_state = self.task_state(row.task_id)
+            if effective_state not in state_set:
+                continue
+            rows.append(row if effective_state == row.state else replace(row, state=effective_state))
+        return rows
 
     def job_descendants(self, job_id: JobName) -> list[JobName]:
         desc = self._snapshot.job_descendants.get(job_id)

--- a/lib/iris/src/iris/cluster/controller/reconcile/peers.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/peers.py
@@ -13,6 +13,7 @@ from iris.cluster.controller.reconcile.overlay import Overlay
 from iris.cluster.controller.reconcile.task import merge_task_termination
 from iris.cluster.controller.task_state import (
     ACTIVE_TASK_STATES,
+    COSCHEDULED_REQUEUE_TASK_STATES,
     ActiveTaskRow,
 )
 from iris.cluster.stats.tables import TaskEventSeverity
@@ -60,12 +61,12 @@ def find_coscheduled_requeue_siblings(
     their tasks without rewriting the succeeded attempt.
     """
     active_siblings = find_coscheduled_siblings(state, job_id, exclude_task_id)
-    succeeded_siblings = state.task_details_for_job(
+    requeueable_terminal_siblings = state.task_details_for_job(
         job_id,
-        states={job_pb2.TASK_STATE_SUCCEEDED},
+        states=COSCHEDULED_REQUEUE_TASK_STATES,
         exclude=exclude_task_id,
     )
-    return (*active_siblings, *succeeded_siblings)
+    return (*active_siblings, *requeueable_terminal_siblings)
 
 
 def terminate_coscheduled_siblings(

--- a/lib/iris/src/iris/cluster/controller/reconcile/peers.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/peers.py
@@ -59,11 +59,7 @@ def find_coscheduled_requeue_siblings(
     completes. Include those siblings so a retriable peer failure can revive
     their tasks without rewriting the succeeded attempt.
     """
-    active_siblings = state.active_tasks_for_job(
-        job_id,
-        states=ACTIVE_TASK_STATES,
-        exclude=exclude_task_id,
-    )
+    active_siblings = find_coscheduled_siblings(state, job_id, exclude_task_id)
     succeeded_siblings = state.task_details_for_job(
         job_id,
         states={job_pb2.TASK_STATE_SUCCEEDED},

--- a/lib/iris/src/iris/cluster/controller/reconcile/peers.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/peers.py
@@ -4,6 +4,7 @@
 """Cross-aggregate rules for coscheduled task peers."""
 
 from collections.abc import Sequence
+from typing import Protocol
 
 from rigging.timing import Timestamp
 
@@ -17,6 +18,16 @@ from iris.cluster.controller.task_state import (
 from iris.cluster.stats.tables import TaskEventSeverity
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
+
+
+class CoscheduledSibling(Protocol):
+    """Task fields required by a coscheduled peer cascade."""
+
+    @property
+    def task_id(self) -> JobName: ...
+
+    @property
+    def current_attempt_id(self) -> int: ...
 
 
 def find_coscheduled_siblings(
@@ -34,6 +45,31 @@ def find_coscheduled_siblings(
         states=ACTIVE_TASK_STATES,
         exclude=exclude_task_id,
     )
+
+
+def find_coscheduled_requeue_siblings(
+    state: Overlay,
+    job_id: JobName,
+    exclude_task_id: JobName,
+) -> Sequence[CoscheduledSibling]:
+    """Find siblings that must return to PENDING for an atomic gang restart.
+
+    A succeeded sibling may have exited because another gang member vanished.
+    Its task result is therefore provisional until the whole coscheduled job
+    completes. Include those siblings so a retriable peer failure can revive
+    their tasks without rewriting the succeeded attempt.
+    """
+    active_siblings = state.active_tasks_for_job(
+        job_id,
+        states=ACTIVE_TASK_STATES,
+        exclude=exclude_task_id,
+    )
+    succeeded_siblings = state.task_details_for_job(
+        job_id,
+        states={job_pb2.TASK_STATE_SUCCEEDED},
+        exclude=exclude_task_id,
+    )
+    return (*active_siblings, *succeeded_siblings)
 
 
 def terminate_coscheduled_siblings(
@@ -78,18 +114,16 @@ def terminate_coscheduled_siblings(
 
 def requeue_coscheduled_siblings(
     state: Overlay,
-    siblings: Sequence[ActiveTaskRow],
+    siblings: Sequence[CoscheduledSibling],
     failed_task_id: JobName,
     now_ms: int,
 ) -> None:
     """Bounce coscheduled siblings to PENDING so the job re-coschedules atomically.
 
-    The bounced attempt is stamped ``COSCHED_FAILED``, not ``PREEMPTED``: an
-    atomic gang restart is not the sibling's own preemption, so its budget must
-    stay honest. Since the retry counters are derived from attempt state, a
-    ``PREEMPTED`` stamp here would spuriously charge the sibling; ``COSCHED_FAILED``
-    (terminal, excluded from the preemption states) both records the true cause
-    and keeps the derived ``preemption_count`` at zero.
+    An active sibling's attempt is stamped ``COSCHED_FAILED``, not ``PREEMPTED``:
+    an atomic gang restart is not the sibling's own preemption, so its budget
+    stays unchanged. A succeeded attempt is already terminal and remains
+    ``SUCCEEDED`` in the attempt history while its task returns to ``PENDING``.
     """
     error = f"Coscheduled sibling {failed_task_id.to_wire()} bounced for atomic re-scheduling"
 

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -19,6 +19,11 @@ ACTIVE_TASK_STATES: frozenset[int] = frozenset(
     }
 )
 
+# Terminal task states that become provisional when a coscheduled peer retries.
+# Snapshot loading and peer selection must share this predicate so the closed
+# reconciliation snapshot contains every task the cascade can requeue.
+COSCHEDULED_REQUEUE_TASK_STATES: frozenset[int] = frozenset({job_pb2.TASK_STATE_SUCCEEDED})
+
 # Subset of ACTIVE that excludes ASSIGNED — i.e. tasks already on a worker.
 EXECUTING_TASK_STATES: frozenset[int] = frozenset(
     {

--- a/lib/iris/src/iris/testing/journeys/world.py
+++ b/lib/iris/src/iris/testing/journeys/world.py
@@ -87,7 +87,7 @@ class JourneyWorld:
         self._jobs: dict[str, JobRef] = {}
         self._checkpoint_jobs: dict[str, frozenset[str]] = {}
         self._task_history: dict[str, tuple[tuple[int, int], ...]] = {}
-        self._terminal_tasks: set[str] = set()
+        self._terminal_tasks: dict[str, int] = {}
         self._prior_backend_events: list[BackendEvent] = []
         self._prior_backend_calls: list[tuple[str, str]] = []
         self.trace: list[str] = []
@@ -167,7 +167,9 @@ class JourneyWorld:
             if any(task_id.startswith(f"{job_id}/") for job_id in retained)
         }
         self._terminal_tasks = {
-            task_id for task_id in self._terminal_tasks if any(task_id.startswith(f"{job_id}/") for job_id in retained)
+            task_id: state
+            for task_id, state in self._terminal_tasks.items()
+            if any(task_id.startswith(f"{job_id}/") for job_id in retained)
         }
         db = ControllerDB(db_dir=self._db_dir)
         self.controller, self.backend = self._build_controller(db)
@@ -542,10 +544,18 @@ class JourneyWorld:
                     raise AssertionError(f"multiple live Attempts for {task.task_id}: {self.timeline}")
                 if task.state in terminal_states and any(attempt.state in active_states for attempt in detail.attempts):
                     raise AssertionError(f"terminal Task retained a live Attempt: {task.task_id}: {self.timeline}")
-                if task.task_id in self._terminal_tasks and task.state not in terminal_states:
+                previous_terminal_state = self._terminal_tasks.get(task.task_id)
+                succeeded_coscheduled_task_restarted = (
+                    job.coscheduled and previous_terminal_state == job_pb2.TASK_STATE_SUCCEEDED
+                )
+                if (
+                    previous_terminal_state is not None
+                    and task.state not in terminal_states
+                    and not succeeded_coscheduled_task_restarted
+                ):
                     raise AssertionError(f"terminal Task revived: {task.task_id}: {self.timeline}")
                 if task.state in terminal_states:
-                    self._terminal_tasks.add(task.task_id)
+                    self._terminal_tasks[task.task_id] = task.state
                 state_name = job_pb2.TaskState.Name(task.state).removeprefix("TASK_STATE_").lower()
                 counts[state_name] = counts.get(state_name, 0) + 1
             if dict(status.task_state_counts) != counts:

--- a/lib/iris/tests/journeys/README.md
+++ b/lib/iris/tests/journeys/README.md
@@ -2,9 +2,11 @@
 
 Iris journeys cover chronological behavior across the real controller, service,
 SQLite persistence, scheduling, reconciliation, federation, and checkpoint code.
-Only execution processes, provider transports, peer transport, and time are
-faked. `JourneyWorld` checks Attempt history, terminal-state monotonicity, live
-Attempt uniqueness, Job counts, and duplicate launches after every control tick.
+`ScriptedTaskBackend` replaces external task execution and provider transport;
+the peer client and clock are also fakes. `JourneyWorld` checks terminal Attempt
+history, live Attempt uniqueness, Job counts, and duplicate launches after every
+control tick. A succeeded Task in a coscheduled job may return to pending when a
+sibling retries; its succeeded Attempt remains terminal.
 
 The source catalog evaluated all 2,496 pytest families at
 `1373230331f63a0a388a7b9944b48672ad844cdc`. The full catalog and rationale are

--- a/lib/iris/tests/journeys/test_coscheduling.py
+++ b/lib/iris/tests/journeys/test_coscheduling.py
@@ -39,7 +39,7 @@ def test_coscheduled_job_when_one_task_retries_restarts_the_whole_gang(journey):
     assert journey.job(job).state == job_pb2.JOB_STATE_SUCCEEDED
 
 
-def test_coscheduled_job_when_workers_succeed_before_head_preemption_restarts_the_whole_gang(journey):
+def test_coscheduled_job_when_siblings_succeed_before_task_preemption_restarts_the_whole_gang(journey):
     job = journey.submit(
         "coscheduled-preempted-head",
         tasks=4,

--- a/lib/iris/tests/journeys/test_coscheduling.py
+++ b/lib/iris/tests/journeys/test_coscheduling.py
@@ -37,3 +37,27 @@ def test_coscheduled_job_when_one_task_retries_restarts_the_whole_gang(journey):
     journey.succeed_all(job)
     journey.settle()
     assert journey.job(job).state == job_pb2.JOB_STATE_SUCCEEDED
+
+
+def test_coscheduled_job_when_workers_succeed_before_head_preemption_restarts_the_whole_gang(journey):
+    job = journey.submit(
+        "coscheduled-preempted-head",
+        tasks=4,
+        preemption_retries=1,
+        coscheduled=True,
+    )
+    journey.settle()
+
+    journey.succeed(job[1])
+    journey.succeed(job[2])
+    journey.settle()
+    journey.preempt(job[0])
+    journey.settle()
+
+    tasks = journey.tasks(job)
+    assert [task.state for task in tasks] == [job_pb2.TASK_STATE_RUNNING] * 4
+    assert all(len(journey.task(job[index]).attempts) == 2 for index in range(4))
+    assert [attempt.state for attempt in journey.task(job[1]).attempts] == [
+        job_pb2.TASK_STATE_SUCCEEDED,
+        job_pb2.TASK_STATE_RUNNING,
+    ]

--- a/lib/marin/src/marin/external_dependencies.py
+++ b/lib/marin/src/marin/external_dependencies.py
@@ -75,7 +75,7 @@ MARIN_SKYRL = ExternalDependency(
     distribution="marinskyrl",
     repository="https://github.com/marin-community/MarinSkyRL.git",
     version="0.1.0",
-    commit="c6ec7e2de67fb2cf28a6310d8ad863782cae85d4",
+    commit="7e8159e75f5257625589307ea8c00853dfc8eef2",
     runtime_requirements=(),
 )
 


### PR DESCRIPTION
Return every coscheduled task to pending when any member has a retriable failure or preemption, including tasks whose prior attempt exited successfully. A restarted Ray head can then schedule against a complete worker gang instead of waiting on terminal worker tasks.

Keep successful Attempts immutable when their Tasks return to pending, and leave retry counters unchanged. The reconciliation snapshot includes succeeded coscheduled Tasks so committed and same-batch results follow the same gang transition.

Pin MarinSkyRL #467, whose multi-node launcher opts into Iris coscheduling and now exits worker tasks successfully only after an attempt-scoped head success result. Signal termination before that result remains nonzero.

Fixes #8774
