### PR TITLE
[iris] Grant OpenAthena principals full CoreWeave budgets

### DIFF
--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -233,6 +233,7 @@ user_budgets:
     budget_limit: 342016
     max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
+      - ben.feuer@openathena.ai
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai
       - matt.wittmann@openathena.ai

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -163,7 +163,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 1000
+  budget_limit: 10688
   max_band: interactive
 
 scale_groups:
@@ -232,7 +232,6 @@ user_budgets:
   - user_ids: [benjaminfeuer]
     budget_limit: 342016
     max_band: PRIORITY_BAND_INTERACTIVE
-  # Core Marin developers may use the full cluster at INTERACTIVE priority.
   - user_ids:
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -163,7 +163,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 400000
+  budget_limit: 1000
   max_band: interactive
 
 scale_groups:
@@ -231,4 +231,15 @@ user_budgets:
   # 342016 is 32 h100-8x nodes: half of this cluster's 64-node fleet.
   - user_ids: [benjaminfeuer]
     budget_limit: 342016
+    max_band: PRIORITY_BAND_INTERACTIVE
+  # Core Marin developers may use the full cluster at INTERACTIVE priority.
+  - user_ids:
+      - david.hall@openathena.ai
+      - mark.muchane@openathena.ai
+      - matt.wittmann@openathena.ai
+      - rafal.wojdyla@openathena.ai
+      - romain.yon@openathena.ai
+      - russell.power@openathena.ai
+      - will.held@openathena.ai
+    budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -212,34 +212,30 @@ scale_groups:
 # 42752 is 4 h100-8x nodes (32 GPUs) at full node resources.
 user_budgets:
   - user_ids:
-      - benjaminfeuer
       - betsy
-      - dlwh
       - eczech
-      - held
       - larry
       - marin
-      - muchanem
-      - mwittmann
-      - power
-      - rav
-      - romain
       - wmoss
       - zack
     budget_limit: 42752
     max_band: PRIORITY_BAND_INTERACTIVE
-  # 342016 is 32 h100-8x nodes: half of this cluster's 64-node fleet.
-  - user_ids: [benjaminfeuer]
-    budget_limit: 342016
-    max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
       - ben.feuer@openathena.ai
+      - benjaminfeuer
       - david.hall@openathena.ai
+      - dlwh
       - mark.muchane@openathena.ai
+      - muchanem
       - matt.wittmann@openathena.ai
+      - mwittmann
       - rafal.wojdyla@openathena.ai
+      - rav
       - romain.yon@openathena.ai
+      - romain
       - russell.power@openathena.ai
+      - power
       - will.held@openathena.ai
+      - held
     budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -163,7 +163,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 400000
+  budget_limit: 1000
   max_band: interactive
 
 scale_groups:
@@ -231,4 +231,15 @@ user_budgets:
   # 171008 is 16 h100-8x nodes: half of this cluster's 32-node fleet.
   - user_ids: [benjaminfeuer]
     budget_limit: 171008
+    max_band: PRIORITY_BAND_INTERACTIVE
+  # Core Marin developers may use the full cluster at INTERACTIVE priority.
+  - user_ids:
+      - david.hall@openathena.ai
+      - mark.muchane@openathena.ai
+      - matt.wittmann@openathena.ai
+      - rafal.wojdyla@openathena.ai
+      - romain.yon@openathena.ai
+      - russell.power@openathena.ai
+      - will.held@openathena.ai
+    budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -212,34 +212,30 @@ scale_groups:
 # 42752 is 4 h100-8x nodes (32 GPUs) at full node resources.
 user_budgets:
   - user_ids:
-      - benjaminfeuer
       - betsy
-      - dlwh
       - eczech
-      - held
       - larry
       - marin
-      - muchanem
-      - mwittmann
-      - power
-      - rav
-      - romain
       - wmoss
       - zack
     budget_limit: 42752
     max_band: PRIORITY_BAND_INTERACTIVE
-  # 171008 is 16 h100-8x nodes: half of this cluster's 32-node fleet.
-  - user_ids: [benjaminfeuer]
-    budget_limit: 171008
-    max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
       - ben.feuer@openathena.ai
+      - benjaminfeuer
       - david.hall@openathena.ai
+      - dlwh
       - mark.muchane@openathena.ai
+      - muchanem
       - matt.wittmann@openathena.ai
+      - mwittmann
       - rafal.wojdyla@openathena.ai
+      - rav
       - romain.yon@openathena.ai
+      - romain
       - russell.power@openathena.ai
+      - power
       - will.held@openathena.ai
+      - held
     budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -163,7 +163,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 1000
+  budget_limit: 10688
   max_band: interactive
 
 scale_groups:
@@ -232,7 +232,6 @@ user_budgets:
   - user_ids: [benjaminfeuer]
     budget_limit: 171008
     max_band: PRIORITY_BAND_INTERACTIVE
-  # Core Marin developers may use the full cluster at INTERACTIVE priority.
   - user_ids:
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -233,6 +233,7 @@ user_budgets:
     budget_limit: 171008
     max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
+      - ben.feuer@openathena.ai
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai
       - matt.wittmann@openathena.ai

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -254,6 +254,7 @@ user_budgets:
     budget_limit: 128000
     max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
+      - ben.feuer@openathena.ai
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai
       - matt.wittmann@openathena.ai

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -186,7 +186,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 1000
+  budget_limit: 5680
   max_band: interactive
 
 scale_groups:
@@ -253,7 +253,6 @@ user_budgets:
       - zack
     budget_limit: 128000
     max_band: PRIORITY_BAND_INTERACTIVE
-  # Core Marin developers may use the full cluster at INTERACTIVE priority.
   - user_ids:
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -186,7 +186,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 400000
+  budget_limit: 1000
   max_band: interactive
 
 scale_groups:
@@ -252,4 +252,15 @@ user_budgets:
       - wmoss
       - zack
     budget_limit: 128000
+    max_band: PRIORITY_BAND_INTERACTIVE
+  # Core Marin developers may use the full cluster at INTERACTIVE priority.
+  - user_ids:
+      - david.hall@openathena.ai
+      - mark.muchane@openathena.ai
+      - matt.wittmann@openathena.ai
+      - rafal.wojdyla@openathena.ai
+      - romain.yon@openathena.ai
+      - russell.power@openathena.ai
+      - will.held@openathena.ai
+    budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -237,30 +237,30 @@ scale_groups:
 # 128000 is about one NVL72 rack: 18 gb200-4x nodes cost ~102,000.
 user_budgets:
   - user_ids:
-      - benjaminfeuer
       - betsy
-      - dlwh
       - eczech
-      - held
       - larry
       - marin
-      - muchanem
-      - mwittmann
-      - power
-      - rav
-      - romain
       - wmoss
       - zack
     budget_limit: 128000
     max_band: PRIORITY_BAND_INTERACTIVE
   - user_ids:
       - ben.feuer@openathena.ai
+      - benjaminfeuer
       - david.hall@openathena.ai
+      - dlwh
       - mark.muchane@openathena.ai
+      - muchanem
       - matt.wittmann@openathena.ai
+      - mwittmann
       - rafal.wojdyla@openathena.ai
+      - rav
       - romain.yon@openathena.ai
+      - romain
       - russell.power@openathena.ai
+      - power
       - will.held@openathena.ai
+      - held
     budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -115,7 +115,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 1000
+  budget_limit: 10688
   max_band: interactive
 
 scale_groups:
@@ -161,7 +161,6 @@ scale_groups:
         region: US-WEST-04A
         instance_type: gd-8xh100ib-i128
 
-# Core Marin developers may use the full cluster at INTERACTIVE priority.
 user_budgets:
   - user_ids:
       - david.hall@openathena.ai

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -164,12 +164,20 @@ scale_groups:
 user_budgets:
   - user_ids:
       - ben.feuer@openathena.ai
+      - benjaminfeuer
       - david.hall@openathena.ai
+      - dlwh
       - mark.muchane@openathena.ai
+      - muchanem
       - matt.wittmann@openathena.ai
+      - mwittmann
       - rafal.wojdyla@openathena.ai
+      - rav
       - romain.yon@openathena.ai
+      - romain
       - russell.power@openathena.ai
+      - power
       - will.held@openathena.ai
+      - held
     budget_limit: 0
     max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -163,6 +163,7 @@ scale_groups:
 
 user_budgets:
   - user_ids:
+      - ben.feuer@openathena.ai
       - david.hall@openathena.ai
       - mark.muchane@openathena.ai
       - matt.wittmann@openathena.ai

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -115,7 +115,7 @@ defaults:
     default_task_image: ghcr.io/marin-community/iris-task:latest
 
 user_budget_defaults:
-  budget_limit: 400000
+  budget_limit: 1000
   max_band: interactive
 
 scale_groups:
@@ -160,3 +160,16 @@ scale_groups:
       coreweave:
         region: US-WEST-04A
         instance_type: gd-8xh100ib-i128
+
+# Core Marin developers may use the full cluster at INTERACTIVE priority.
+user_budgets:
+  - user_ids:
+      - david.hall@openathena.ai
+      - mark.muchane@openathena.ai
+      - matt.wittmann@openathena.ai
+      - rafal.wojdyla@openathena.ai
+      - romain.yon@openathena.ai
+      - russell.power@openathena.ai
+      - will.held@openathena.ai
+    budget_limit: 0
+    max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/docs/priority-bands.md
+++ b/lib/iris/docs/priority-bands.md
@@ -105,8 +105,8 @@ service-account identity. The friendly owner in a job path remains independent:
 an admin may submit `/power/train` while Iris accounts the job to
 `russell.power@openathena.ai`. Child jobs inherit the root submitter, and a
 federated handoff carries the same principal to the receiving cluster. Trusted
-local submissions (`local_admin`) and rows created before submitter tracking use
-the job-path owner as a fallback budget key.
+local submissions (`local_admin`) and rows with an empty `submitting_user` use the
+job-path owner as a fallback budget key.
 
 If a higher-band submission is rejected:
 

--- a/lib/iris/docs/priority-bands.md
+++ b/lib/iris/docs/priority-bands.md
@@ -99,15 +99,23 @@ config at startup are:
   default budget; jobs run INTERACTIVE while within budget and degrade to
   BATCH once exceeded. SYSTEM and PRODUCTION submissions are rejected.
 
+Budget rows are keyed by the authenticated principal stored in
+`jobs.submitting_user`. IAP and JWT submissions use the verified email or
+service-account identity. The friendly owner in a job path remains independent:
+an admin may submit `/power/train` while Iris accounts the job to
+`russell.power@openathena.ai`. Child jobs inherit the root submitter, and a
+federated handoff carries the same principal to the receiving cluster. Trusted
+local submissions (`local_admin`) and rows created before submitter tracking use
+the job-path owner as a fallback budget key.
+
 If a higher-band submission is rejected:
 
 1. **Use the appropriate lower band.** Ordinary research should run at
    INTERACTIVE or BATCH.
-2. **Check your username.** The `max_band` cap is keyed on the verified
-   identity the controller sees. If the username in the error message isn't
-   what you expect — e.g. it's an email local-part or an SSO id rather than
-   your GitHub handle — your identity probably doesn't match the `user_id`
-   listed in the cluster config, and you'll land on the default tier.
+2. **Check your budget identity.** The error reports the authenticated email or
+   service account used for budget lookup. Confirm that exact value appears in
+   the cluster config. Trusted local submissions instead use the nickname at
+   the start of the job path.
 3. **Request an uplift.** If your work needs INTERACTIVE budget headroom or an
    admin-only band, ping [@Helw150](https://github.com/Helw150).
 

--- a/lib/iris/src/iris/cluster/controller/budget.py
+++ b/lib/iris/src/iris/cluster/controller/budget.py
@@ -34,8 +34,9 @@ def budget_user_id(job_id: JobName, submitting_user: str) -> str:
     """Return the principal used for budget accounting.
 
     Authenticated submissions use the verified email or service-account identity
-    stored on the job. Trusted local submissions and pre-migration rows have no
-    distinct principal, so their friendly job owner remains the budget key.
+    stored on the job. Trusted local submissions and rows with an empty
+    ``submitting_user`` have no distinct principal, so their friendly job owner
+    remains the budget key.
     """
     if submitting_user and submitting_user != LOCAL_ADMIN_SUBMITTER:
         return submitting_user

--- a/lib/iris/src/iris/cluster/controller/budget.py
+++ b/lib/iris/src/iris/cluster/controller/budget.py
@@ -31,13 +31,7 @@ class UserTask(Generic[T]):
 
 
 def budget_user_id(job_id: JobName, submitting_user: str) -> str:
-    """Return the principal used for budget accounting.
-
-    Authenticated submissions use the verified email or service-account identity
-    stored on the job. Trusted local submissions and rows with an empty
-    ``submitting_user`` have no distinct principal, so their friendly job owner
-    remains the budget key.
-    """
+    """Use the authenticated submitter, with job-owner fallback for local or empty identities."""
     if submitting_user and submitting_user != LOCAL_ADMIN_SUBMITTER:
         return submitting_user
     return job_id.user

--- a/lib/iris/src/iris/cluster/controller/budget.py
+++ b/lib/iris/src/iris/cluster/controller/budget.py
@@ -15,7 +15,7 @@ from iris.cluster.config import UserBudgetTier
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.codec import device_counts_from_json
 from iris.cluster.controller.db import ControllerDB, Tx
-from iris.cluster.types import UserBudgetDefaults
+from iris.cluster.types import LOCAL_ADMIN_SUBMITTER, JobName, UserBudgetDefaults
 from iris.rpc import job_pb2
 from iris.rpc.proto_display import ADMIN_PRIORITY_BAND_VALUES, PRIORITY_BAND_VALUES
 
@@ -28,6 +28,18 @@ T = TypeVar("T")
 class UserTask(Generic[T]):
     user_id: str
     task: T
+
+
+def budget_user_id(job_id: JobName, submitting_user: str) -> str:
+    """Return the principal used for budget accounting.
+
+    Authenticated submissions use the verified email or service-account identity
+    stored on the job. Trusted local submissions and pre-migration rows have no
+    distinct principal, so their friendly job owner remains the budget key.
+    """
+    if submitting_user and submitting_user != LOCAL_ADMIN_SUBMITTER:
+        return submitting_user
+    return job_id.user
 
 
 def resource_value(cpu_millicores: int, memory_bytes: int, accelerator_count: int) -> int:
@@ -47,14 +59,13 @@ def compute_user_spend(tx: Tx) -> dict[str, int]:
     Sums ``resource_value * task_count`` per user over the active, non-BATCH
     task rows returned by :func:`reads.user_spend_rows`.
 
-    Returns ``{user_id: total_resource_value}`` for users with active tasks.
+    Returns ``{budget_user_id: total_resource_value}`` for principals with active tasks.
     """
     rows = reads.user_spend_rows(tx)
 
     spend: dict[str, int] = defaultdict(int)
     for row in rows:
-        # job_id is decoded by JobNameType to JobName
-        user_id = row.job_id.user
+        user_id = budget_user_id(row.job_id, str(row.submitting_user))
         cpu = row.res_cpu_millicores
         mem = row.res_memory_bytes
         counts = device_counts_from_json(row.res_device_json)

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -70,6 +70,7 @@ from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.federation.store import FederationDirection, HandoffState
 from iris.cluster.runtime.env import TASK_OUTPUT_FINALIZING_STATUS
 from iris.cluster.types import (
+    LOCAL_ADMIN_SUBMITTER,
     LOCAL_CLUSTER,
     TERMINAL_JOB_STATES,
     AttemptUid,
@@ -552,6 +553,15 @@ def get_job_state(tx: Tx, job_id: JobName) -> int | None:
     return int(row.state) if row is not None else None
 
 
+def get_job_submitting_user(tx: Tx, job_id: JobName) -> str | None:
+    """Return the authenticated submitter stored for ``job_id``, or None if absent."""
+    row = tx.execute(
+        select(jobs_table.c.submitting_user).where(jobs_table.c.job_id == bindparam("job_id")),
+        {"job_id": job_id},
+    ).first()
+    return str(row.submitting_user) if row is not None else None
+
+
 def find_prunable_job(tx: Tx, terminal_states: Iterable[int], before_ts: Timestamp) -> JobName | None:
     """Return one terminal *local* job finished before ``before_ts``, or None.
 
@@ -858,6 +868,7 @@ def _row_to_pending_task(row: Row) -> PendingTask:
     return PendingTask(
         task_id=row.task_id,
         job_id=row.job_id,
+        submitting_user=str(row.submitting_user),
         backend_id=str(row.backend_id),
         state=int(row.state),
         current_attempt_id=int(row.current_attempt_id),
@@ -886,6 +897,7 @@ _PENDING_TASKS_STMT = (
         *PENDING_TASK_COLS,
         # job columns (label job_state to avoid clash with tasks.state)
         jobs_table.c.state.label("job_state"),
+        jobs_table.c.submitting_user,
         jobs_table.c.scheduling_deadline_epoch_ms,
         # job_config columns
         job_config_table.c.scheduling_timeout_ms,
@@ -954,24 +966,29 @@ def running_task_band_rows(tx: Tx) -> Sequence[Row]:
 _USER_SPEND_STMT = (
     select(
         local_tasks.c.job_id,
+        jobs_table.c.submitting_user,
         job_config_table.c.res_cpu_millicores,
         job_config_table.c.res_memory_bytes,
         job_config_table.c.res_device_json,
         func.count().label("task_count"),
     )
-    .select_from(local_tasks.join(job_config_table, job_config_table.c.job_id == local_tasks.c.job_id))
+    .select_from(
+        local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
+            job_config_table, job_config_table.c.job_id == local_tasks.c.job_id
+        )
+    )
     .where(hint_rare_state(local_tasks.c.state.in_(bindparam("states", expanding=True))))
     .where(job_config_table.c.priority_band != job_pb2.PRIORITY_BAND_BATCH)
-    .group_by(local_tasks.c.job_id)
+    .group_by(local_tasks.c.job_id, jobs_table.c.submitting_user)
 )
 
 
 def user_spend_rows(tx: Tx) -> Sequence[Row]:
     """Return per-job resource rows for active, non-BATCH tasks (budget spend basis).
 
-    Each row carries ``(job_id, res_cpu_millicores, res_memory_bytes,
-    res_device_json, task_count)``. ``job_config.priority_band`` (the user's
-    requested band) drives the BATCH exclusion, not the stamped
+    Each row carries ``(job_id, submitting_user, res_cpu_millicores,
+    res_memory_bytes, res_device_json, task_count)``. ``job_config.priority_band``
+    (the user's requested band) drives the BATCH exclusion, not the stamped
     ``tasks.priority_band``, so scheduler-downgraded jobs still count.
     """
     return tx.execute(_USER_SPEND_STMT, {"states": list(ACTIVE_TASK_STATES)}).all()
@@ -1435,13 +1452,20 @@ def list_active_tasks_for_jobs(
     return result
 
 
-def count_active_tasks_for_user(tx: Tx, user_id: str) -> int:
-    """Return the number of non-terminal tasks across all jobs owned by ``user_id``."""
+def count_active_tasks_for_budget_user(tx: Tx, user_id: str) -> int:
+    """Return non-terminal local tasks attributed to the budget identity ``user_id``."""
+    budget_user = case(
+        (
+            jobs_table.c.submitting_user.in_(("", LOCAL_ADMIN_SUBMITTER)),
+            jobs_table.c.user_id,
+        ),
+        else_=jobs_table.c.submitting_user,
+    )
     return int(
         tx.execute(
             select(func.count())
             .select_from(local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id))
-            .where(jobs_table.c.user_id == bindparam("user_id"))
+            .where(budget_user == bindparam("user_id"))
             .where(local_tasks.c.state.in_(bindparam("states", expanding=True))),
             {"user_id": user_id, "states": list(NON_TERMINAL_TASK_STATES)},
         ).scalar()

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.budget import (
     UserTask,
+    budget_user_id,
     compute_effective_band,
     compute_user_spend,
     interleave_by_user,
@@ -140,6 +141,7 @@ class _RankRow:
 
     task_id: JobName
     job_id: JobName
+    budget_user: str
     num_tasks: int
     has_coscheduling: bool
     sort_key: _PriorityKey
@@ -154,6 +156,7 @@ def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
         select(
             local_tasks.c.task_id,
             local_tasks.c.job_id,
+            jobs_table.c.submitting_user,
             jobs_table.c.num_tasks,
             job_config_table.c.has_coscheduling,
             local_tasks.c.priority_neg_depth,
@@ -168,6 +171,7 @@ def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
         _RankRow(
             task_id=r.task_id,
             job_id=r.job_id,
+            budget_user=budget_user_id(r.job_id, str(r.submitting_user)),
             num_tasks=int(r.num_tasks),
             has_coscheduling=bool(r.has_coscheduling),
             sort_key=_PriorityKey(
@@ -221,7 +225,7 @@ def _rank_promotion_units(
     ranked: list[list[_RankRow]] = []
     for band in sorted(by_band, key=priority_band_rank):
         band_units = sorted(by_band[band], key=lambda unit: min(row.sort_key for row in unit))
-        user_units = [UserTask(user_id=unit[0].task_id.user, task=unit) for unit in band_units]
+        user_units = [UserTask(user_id=unit[0].budget_user, task=unit) for unit in band_units]
         ranked.extend(interleave_by_user(user_units, user_spend))
     return ranked
 
@@ -315,9 +319,10 @@ def drain_for_dispatch(
             resolved_bands = reads.get_priority_bands(cur, job_ids)
             user_spend = compute_user_spend(cur)
             user_budget_limits = reads.get_all_user_budget_limits(cur)
+            budget_users = {row.job_id: row.budget_user for row in candidates}
             effective_bands = {
                 job_id: compute_effective_band(
-                    resolved_bands[job_id], job_id.user, user_spend, user_budget_limits, defaults
+                    resolved_bands[job_id], budget_users[job_id], user_spend, user_budget_limits, defaults
                 )
                 for job_id in job_ids
             }

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -32,6 +32,7 @@ from iris.cluster.controller import reads
 from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.budget import (
     UserTask,
+    budget_user_id,
     compute_effective_band,
     compute_user_spend,
     interleave_by_user,
@@ -890,10 +891,13 @@ def compute_scheduling_order(
     requested_bands = ctx.requested_bands
     user_budget_limits = ctx.user_budget_limits
     defaults = ctx.user_budget_defaults
+    task_budget_users = {
+        task.task_id: budget_user_id(task.job_id, task.submitting_user) for task in ctx.pending_task_rows
+    }
     task_band_map: dict[JobName, int] = {
         task.task_id: compute_effective_band(
             requested_bands.get(task.job_id, task.priority_band),
-            task.task_id.user,
+            task_budget_users[task.task_id],
             user_spend,
             user_budget_limits,
             defaults,
@@ -908,7 +912,7 @@ def compute_scheduling_order(
     interleaved: list[JobName] = []
     for band_key in sorted(tasks_by_band, key=priority_band_rank):
         band_tasks = tasks_by_band[band_key]
-        user_tasks = [UserTask(user_id=tid.user, task=tid) for tid in band_tasks]
+        user_tasks = [UserTask(user_id=task_budget_users[tid], task=tid) for tid in band_tasks]
         interleaved.extend(interleave_by_user(user_tasks, user_spend))
 
     if trace:

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -250,8 +250,8 @@ jobs_table = Table(
     # The authenticated principal that submitted this job, distinct from the
     # friendly ``user_id`` owner: an IAP/JWT email, or ``local_admin`` for a
     # CIDR/loopback (null-auth) submission. Drives per-cluster federation
-    # authorization; a child inherits its root's value and a federated handoff
-    # carries it as a signed claim the receiving peer re-checks.
+    # authorization and budget accounting; a child inherits its root's value and
+    # a federated handoff carries it as a signed claim the receiving peer re-checks.
     Column("submitting_user", String, nullable=False, server_default=""),
     Column("parent_job_id", JobNameType, ForeignKey("jobs.job_id", ondelete="CASCADE")),
     Column("root_job_id", String, nullable=False),

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -50,6 +50,7 @@ from iris.cluster.controller.backend import (
     dashboard_backend_descriptor,
 )
 from iris.cluster.controller.budget import (
+    budget_user_id,
     compute_effective_band,
     compute_user_spend,
 )
@@ -73,7 +74,6 @@ from iris.cluster.controller.schema import (
     federation_sync_state_table,
     job_config_table,
     jobs_table,
-    local_tasks,
     meta_table,
     task_attempts_table,
     tasks_table,
@@ -1599,14 +1599,21 @@ class ControllerServiceImpl:
         # the verified identity (or, for a received handoff, the parent's signed
         # claim); a child inherits its root's value at insert time.
         submitting_user = submitting_user_for_root(identity, request)
+        if job_id.parent is not None:
+            with self._db.read_snapshot() as _snap:
+                root_submitting_user = reads.get_job_submitting_user(_snap, job_id.root_job)
+            if root_submitting_user is not None:
+                submitting_user = root_submitting_user
+        budget_user = budget_user_id(job_id, submitting_user)
 
         # Priority band validation.
         #
         # - SYSTEM and PRODUCTION additionally require MANAGE_BUDGETS when auth
         #   is on; admins pass here and skip the max_band cap below.
-        # - The max_band cap fires regardless of auth mode, keyed on the
-        #   claimed job_id.user. In anonymous mode this doesn't guarantee the
-        #   user is who they claim to be, but it ensures the cluster's
+        # - The max_band cap fires regardless of auth mode, keyed on the verified
+        #   submitter for authenticated jobs and the job owner for trusted local
+        #   or legacy jobs. In anonymous mode this doesn't guarantee the owner
+        #   is who they claim to be, but it ensures the cluster's
         #   configured tiers and UserBudgetDefaults still bite — an unlisted
         #   submitter hits the INTERACTIVE default cap and can't punch up to
         #   SYSTEM or PRODUCTION just by skipping auth.
@@ -1646,18 +1653,16 @@ class ControllerServiceImpl:
                 authorize(AuthzAction.MANAGE_BUDGETS)
             else:
                 with self._db.read_snapshot() as _snap:
-                    user_budget = reads.get_user_budget(_snap, job_id.user)
+                    user_budget = reads.get_user_budget(_snap, budget_user)
                 max_band = user_budget.max_band if user_budget is not None else self._user_budget_defaults.max_band
                 if priority_band_rank(band) < priority_band_rank(max_band):
                     raise ConnectError(
                         Code.PERMISSION_DENIED,
-                        f"User {job_id.user} cannot submit {priority_band_name(band)} jobs "
+                        f"Budget identity {budget_user} cannot submit {priority_band_name(band)} jobs "
                         f"(max band: {priority_band_name(max_band)}). "
                         f"Resubmit with `--priority {priority_band_name(max_band).lower()}` "
                         f"(e.g. `--priority batch`) to launch opportunistically, or ping @Helw150 "
-                        f"if you believe your username ({job_id.user}) should have a higher band — "
-                        f"either to be added to the researcher list or to confirm your username is "
-                        f"registered correctly.",
+                        f"to request a higher band for {budget_user}.",
                     )
 
         # Elevated profiles (DOCKER_ACCESS, PRIVILEGED) are host-root-equivalent
@@ -1703,19 +1708,18 @@ class ControllerServiceImpl:
                 "accelerator tasks.",
             )
 
-        # Cap the number of non-terminal tasks a single user may hold at once.
+        # Cap the number of non-terminal tasks a single budget principal may hold.
         # A burst of eval submissions once materialized enough tasks to OOM the
-        # controller (#6411); reject up front any submission that would push the
-        # user past the cap. Keyed on job_id.user, so a launcher that admits
-        # tasks gradually stays under the cap as earlier tasks finish.
+        # controller (#6411). A launcher that admits tasks gradually stays under
+        # the cap as earlier tasks finish.
         incoming_tasks = int(request.replicas)
         if incoming_tasks > 0:
             with self._db.read_snapshot() as _snap:
-                active_tasks = reads.count_active_tasks_for_user(_snap, job_id.user)
+                active_tasks = reads.count_active_tasks_for_budget_user(_snap, budget_user)
             if active_tasks + incoming_tasks > MAX_ACTIVE_TASKS_PER_USER:
                 raise ConnectError(
                     Code.RESOURCE_EXHAUSTED,
-                    f"User {job_id.user} has {active_tasks} active task(s); submitting "
+                    f"Budget identity {budget_user} has {active_tasks} active task(s); submitting "
                     f"{incoming_tasks} more would exceed the per-user cap of "
                     f"{MAX_ACTIVE_TASKS_PER_USER}. Wait for running tasks to finish, or "
                     f"structure the work as a launcher job that admits tasks gradually.",
@@ -3249,23 +3253,23 @@ class ControllerServiceImpl:
             budget_limits: dict[str, int] = {b.user_id: b.budget_limit for b in budgets}
             user_spend = compute_user_spend(snap)
 
-            # Pending tasks: the scheduler's pending-task projection, reused here for
-            # task_row_can_be_scheduled + band aggregation. No ORDER BY — we aggregate, not display.
-            pending_raw = snap.execute(
-                select(*reads.PENDING_TASK_COLS).where(local_tasks.c.state == job_pb2.TASK_STATE_PENDING)
-            ).all()
-            pending_rows = pending_raw
+            # Reuse the scheduler's filtered pending-task projection so dashboard
+            # aggregation and scheduling apply the same admission gates.
+            pending_rows = reads.pending_tasks_with_jobs(snap)
             pending_requested_bands = reads.get_priority_bands(snap, {row.job_id for row in pending_rows})
 
-            # Running tasks: only task_id, priority_band, worker, and backend_id — no
-            # job_config join is needed for the rolled-up counts below.
+            # The jobs join supplies the budget principal; no job_config fields are
+            # needed for running tasks because assignment stamps the effective band.
             running_raw = snap.execute(
                 select(
                     tasks_table.c.task_id,
+                    jobs_table.c.submitting_user,
                     tasks_table.c.priority_band,
                     tasks_table.c.current_worker_id.label("worker_id"),
                     tasks_table.c.backend_id,
-                ).where(
+                )
+                .select_from(tasks_table.join(jobs_table, jobs_table.c.job_id == tasks_table.c.job_id))
+                .where(
                     tasks_table.c.state == job_pb2.TASK_STATE_RUNNING,
                     tasks_table.c.current_worker_id.is_not(None),
                 )
@@ -3277,9 +3281,7 @@ class ControllerServiceImpl:
         pending_counts: dict[tuple[int, str, str, str], int] = {}
         total_pending = 0
         for row in pending_rows:
-            if not task_row_can_be_scheduled(row):
-                continue
-            user_id = row.task_id.user
+            user_id = budget_user_id(row.job_id, row.submitting_user)
             eff_band = compute_effective_band(
                 pending_requested_bands.get(row.job_id, row.priority_band),
                 user_id,
@@ -3300,7 +3302,7 @@ class ControllerServiceImpl:
         running_counts: dict[tuple[int, str, str, str, str], int] = {}
         total_running = 0
         for row in running_rows:
-            user_id = row.task_id.user
+            user_id = budget_user_id(row.task_id, str(row.submitting_user))
             job_id = (row.task_id.parent or row.task_id).to_wire()
             backend_id = str(row.backend_id or "")
             key = (row.priority_band, user_id, str(row.worker_id), job_id, backend_id)

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1710,8 +1710,8 @@ class ControllerServiceImpl:
 
         # Cap the number of non-terminal tasks a single budget principal may hold.
         # A burst of eval submissions once materialized enough tasks to OOM the
-        # controller (#6411). A launcher that admits tasks gradually stays under
-        # the cap as earlier tasks finish.
+        # controller. A launcher that admits tasks gradually stays under the cap
+        # as earlier tasks finish.
         incoming_tasks = int(request.replicas)
         if incoming_tasks > 0:
             with self._db.read_snapshot() as _snap:

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -440,6 +440,7 @@ class PendingTask:
 
     task_id: JobName
     job_id: JobName
+    submitting_user: str
     backend_id: str
     state: int
     current_attempt_id: int

--- a/lib/iris/tests/cluster/controller/test_availability_enrichment.py
+++ b/lib/iris/tests/cluster/controller/test_availability_enrichment.py
@@ -50,6 +50,7 @@ def _pending(constraints_json: str | None) -> PendingTask:
     return PendingTask(
         task_id=job_id.task(0),
         job_id=job_id,
+        submitting_user="local_admin",
         backend_id="default",
         state=0,
         current_attempt_id=0,

--- a/lib/iris/tests/cluster/controller/test_availability_enrichment.py
+++ b/lib/iris/tests/cluster/controller/test_availability_enrichment.py
@@ -22,7 +22,7 @@ from iris.cluster.controller.scheduling.policy import (
     enrich_workers_with_availability,
 )
 from iris.cluster.controller.scheduling.scheduler import WorkerSnapshot
-from iris.cluster.types import JobName, PendingTask, WorkerId
+from iris.cluster.types import LOCAL_ADMIN_SUBMITTER, JobName, PendingTask, WorkerId
 from rigging.timing import Timestamp
 
 
@@ -50,7 +50,7 @@ def _pending(constraints_json: str | None) -> PendingTask:
     return PendingTask(
         task_id=job_id.task(0),
         job_id=job_id,
-        submitting_user="local_admin",
+        submitting_user=LOCAL_ADMIN_SUBMITTER,
         backend_id="default",
         state=0,
         current_attempt_id=0,

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -340,14 +340,43 @@ def test_drain_deferred_gang_still_fills_same_band(state):
     assert all(query_task(state, t).state == job_pb2.TASK_STATE_PENDING for t in gang)
 
 
-def _submit_job_for_user(state, user: str, name: str, *, priority_band: int = 0) -> JobName:
+def _submit_job_for_user(
+    state, user: str, name: str, *, priority_band: int = 0, submitting_user: str | None = None
+) -> JobName:
     """Submit a single-task direct job owned by ``user`` and return its task id."""
     jid = JobName.root(user, name)
     req = make_direct_job_request(name, priority_band=priority_band)
     req.name = jid.to_wire()  # make_direct_job_request roots names at test-user
     with state._db.transaction() as cur:
-        submit_job_in_tx(cur, job_id=jid, request=req, ts=Timestamp.now())
+        submit_job_in_tx(cur, job_id=jid, request=req, ts=Timestamp.now(), submitting_user=submitting_user)
     return jid.task(0)
+
+
+def test_drain_uses_authenticated_email_for_nickname_job_budget(state):
+    email = "russell.power@openathena.ai"
+    _submit_job_for_user(
+        state,
+        "power",
+        "spend",
+        priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE,
+        submitting_user=email,
+    )
+    with state._db.transaction() as cur:
+        dispatch.drain_for_dispatch(cur)
+        set_user_budget(cur, email, 1, job_pb2.PRIORITY_BAND_INTERACTIVE, Timestamp.now())
+
+    pending = _submit_job_for_user(
+        state,
+        "power",
+        "pending",
+        priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE,
+        submitting_user=email,
+    )
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+
+    [request] = [request for request in batch.tasks_to_run if request.task_id == pending.to_wire()]
+    assert request.priority == job_pb2.PRIORITY_BAND_BATCH
 
 
 def test_drain_interleaves_users_within_band(state):

--- a/lib/iris/tests/cluster/controller/test_federation_fold_exclusion.py
+++ b/lib/iris/tests/cluster/controller/test_federation_fold_exclusion.py
@@ -116,7 +116,7 @@ def test_federated_tasks_excluded_from_budget_and_admission(state):
 
     with state._db.read_snapshot() as tx:
         spend_jobs = {row.job_id for row in reads.user_spend_rows(tx)}
-        active_count = reads.count_active_tasks_for_user(tx, "test-user")
+        active_count = reads.count_active_tasks_for_budget_user(tx, "test-user")
         active_by_job = reads.list_active_tasks_for_jobs(tx, [local_job, fed_job], states=NON_TERMINAL_TASK_STATES)
 
     # Budget spend and the admission cap count only the two local tasks.

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -3,14 +3,17 @@
 
 """Integration tests for priority bands, per-user fairness, and scheduling caps."""
 
-from iris.cluster.controller import reads
+from iris.cluster.controller import reads, writes
 from iris.cluster.controller.budget import (
     compute_user_spend,
 )
 from iris.cluster.controller.scheduling.policy import (
     _sort_pending_tasks_by_resolved_band,
+    apply_scheduling_gates,
+    build_scheduling_context,
+    compute_scheduling_order,
 )
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import controller_pb2, job_pb2
 from iris.testing.controller import (
     make_controller_state,
@@ -192,3 +195,36 @@ def test_batch_childs_spend_does_not_count_against_the_budget():
 
         with state._db.read_snapshot() as snap:
             assert compute_user_spend(snap).keys() == {"bob"}
+
+
+def test_spend_and_worker_scheduler_use_authenticated_email():
+    email = "russell.power@openathena.ai"
+    with make_controller_state() as state:
+        spend_id = JobName.root("power", "spend")
+        spend_request = make_job_request(
+            name=spend_id.to_wire(), cpu=1, replicas=1, priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE
+        )
+        with state._db.transaction() as cur:
+            submit_job_in_tx(cur, job_id=spend_id, request=spend_request, submitting_user=email)
+        _activate_job(state, spend_id)
+
+        pending_id = JobName.root("power", "pending")
+        pending_request = make_job_request(
+            name=pending_id.to_wire(), cpu=1, replicas=1, priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE
+        )
+        with state._db.transaction() as cur:
+            submit_job_in_tx(cur, job_id=pending_id, request=pending_request, submitting_user=email)
+            writes.set_user_budget(cur, email, 1, job_pb2.PRIORITY_BAND_INTERACTIVE, Timestamp.now())
+
+        with state._db.read_snapshot() as snap:
+            context = build_scheduling_context(
+                snap,
+                health=None,
+                worker_attrs=state._worker_attrs,
+                defaults=UserBudgetDefaults(budget_limit=0),
+            )
+        gated = apply_scheduling_gates(context, max_tasks_per_job_per_cycle=100)
+        order = compute_scheduling_order(context, gated)
+
+        assert context.user_spend == {email: 6}
+        assert order.task_band_map[pending_id.task(0)] == job_pb2.PRIORITY_BAND_BATCH

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1366,6 +1366,7 @@ def test_register_allows_worker_role(state, mock_controller, tmp_path, log_clien
 
 def test_get_scheduler_state_with_running_task(controller_service, state):
     """get_scheduler_state aggregates a running task into a (band, user, worker, job) bucket."""
+    email = "alice@example.com"
     # Submit a job and move a task to RUNNING
     job_id = JobName.root("alice", "sched-test")
     request = controller_pb2.Controller.LaunchJobRequest(
@@ -1381,7 +1382,7 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
             job_id=job_id,
             request=request,
             ts=Timestamp.now(),
-            submitting_user="alice@example.com",
+            submitting_user=email,
         )
 
     w1 = WorkerId("w1")
@@ -1413,12 +1414,12 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
         assert len(resp.running_buckets) == 1
         bucket = resp.running_buckets[0]
         assert bucket.job_id == job_id.to_wire()
-        assert bucket.user_id == "alice@example.com"
+        assert bucket.user_id == email
         assert bucket.worker_id == "w1"
         assert bucket.count == 1
         # The email has no explicit user_budgets row but has an active task. The
         # scheduler state must apply UserBudgetDefaults to that principal.
-        alice_budget = next((b for b in resp.user_budgets if b.user_id == "alice@example.com"), None)
+        alice_budget = next((b for b in resp.user_budgets if b.user_id == email), None)
         assert alice_budget is not None
         assert alice_budget.budget_spent > 0
         assert alice_budget.budget_limit == UserBudgetDefaults().budget_limit

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1376,7 +1376,13 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
         replicas=1,
     )
     with state._db.transaction() as cur:
-        submit_job_in_tx(cur, job_id=job_id, request=request, ts=Timestamp.now())
+        submit_job_in_tx(
+            cur,
+            job_id=job_id,
+            request=request,
+            ts=Timestamp.now(),
+            submitting_user="alice@example.com",
+        )
 
     w1 = WorkerId("w1")
     with state._db.transaction() as cur:
@@ -1407,13 +1413,12 @@ def test_get_scheduler_state_with_running_task(controller_service, state):
         assert len(resp.running_buckets) == 1
         bucket = resp.running_buckets[0]
         assert bucket.job_id == job_id.to_wire()
-        assert bucket.user_id == "alice"
+        assert bucket.user_id == "alice@example.com"
         assert bucket.worker_id == "w1"
         assert bucket.count == 1
-        # alice has no explicit user_budgets row but has an active task — the
-        # scheduler state must report her spend using UserBudgetDefaults so the
-        # dashboard renders Spent/Limit/Utilization instead of '-'.
-        alice_budget = next((b for b in resp.user_budgets if b.user_id == "alice"), None)
+        # The email has no explicit user_budgets row but has an active task. The
+        # scheduler state must apply UserBudgetDefaults to that principal.
+        alice_budget = next((b for b in resp.user_budgets if b.user_id == "alice@example.com"), None)
         assert alice_budget is not None
         assert alice_budget.budget_spent > 0
         assert alice_budget.budget_limit == UserBudgetDefaults().budget_limit

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -305,7 +305,6 @@ def test_admin_nickname_job_uses_email_budget(service):
             service.launch_job(_launch("/power/email-budget", band=INTERACTIVE), None)
 
     assert exc.value.code == Code.PERMISSION_DENIED
-    assert email in exc.value.message
 
 
 def test_child_job_inherits_root_email_budget(service):
@@ -320,7 +319,6 @@ def test_child_job_inherits_root_email_budget(service):
             service.launch_job(_launch("/power/parent/child", band=job_pb2.PRIORITY_BAND_INHERIT), None)
 
     assert exc.value.code == Code.PERMISSION_DENIED
-    assert email in exc.value.message
 
 
 def test_active_task_cap_uses_email_across_nicknames(service, monkeypatch):
@@ -338,7 +336,6 @@ def test_active_task_cap_uses_email_across_nicknames(service, monkeypatch):
             service.launch_job(second, None)
 
     assert exc.value.code == Code.RESOURCE_EXHAUSTED
-    assert email in exc.value.message
 
 
 def test_launch_job_unspecified_band_accepted(service):

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -8,16 +8,18 @@ import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from iris.cluster.bundle import BundleStore
+from iris.cluster.controller import service as service_module
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.budget import (
     UserTask,
+    budget_user_id,
     compute_effective_band,
     interleave_by_user,
     resource_value,
 )
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.service import ControllerServiceImpl
-from iris.cluster.types import UserBudgetDefaults
+from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import controller_pb2, job_pb2
 from iris.testing.controller import (
     MockController,
@@ -57,6 +59,18 @@ def state():
 )
 def test_resource_value(cpu_millicores, memory_bytes, accelerator_count, expected):
     assert resource_value(cpu_millicores, memory_bytes, accelerator_count) == expected
+
+
+@pytest.mark.parametrize(
+    "submitting_user,expected",
+    [
+        ("russell.power@openathena.ai", "russell.power@openathena.ai"),
+        ("local_admin", "power"),
+        ("", "power"),
+    ],
+)
+def test_budget_user_id_uses_authenticated_principal_with_nickname_fallback(submitting_user, expected):
+    assert budget_user_id(JobName.root("power", "job"), submitting_user) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +293,52 @@ def test_launch_job_rejects_band_above_user_max(service):
         )
     assert exc.value.code == Code.PERMISSION_DENIED
     assert "cannot submit" in str(exc.value.message).lower()
+
+
+def test_admin_nickname_job_uses_email_budget(service):
+    email = "russell.power@openathena.ai"
+    _as_admin(service.set_user_budget, _set_budget("power", 0, INTERACTIVE), None)
+    _as_admin(service.set_user_budget, _set_budget(email, 0, BATCH), None)
+
+    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+        with pytest.raises(ConnectError) as exc:
+            service.launch_job(_launch("/power/email-budget", band=INTERACTIVE), None)
+
+    assert exc.value.code == Code.PERMISSION_DENIED
+    assert email in exc.value.message
+
+
+def test_child_job_inherits_root_email_budget(service):
+    email = "russell.power@openathena.ai"
+    _as_admin(service.set_user_budget, _set_budget(email, 0, INTERACTIVE), None)
+    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+        service.launch_job(_launch("/power/parent", band=INTERACTIVE), None)
+
+    _as_admin(service.set_user_budget, _set_budget(email, 0, BATCH), None)
+    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+        with pytest.raises(ConnectError) as exc:
+            service.launch_job(_launch("/power/parent/child", band=job_pb2.PRIORITY_BAND_INHERIT), None)
+
+    assert exc.value.code == Code.PERMISSION_DENIED
+    assert email in exc.value.message
+
+
+def test_active_task_cap_uses_email_across_nicknames(service, monkeypatch):
+    email = "russell.power@openathena.ai"
+    monkeypatch.setattr(service_module, "MAX_ACTIVE_TASKS_PER_USER", 5)
+
+    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+        first = _launch("/power/first")
+        first.replicas = 3
+        service.launch_job(first, None)
+
+        second = _launch("/held/second")
+        second.replicas = 3
+        with pytest.raises(ConnectError) as exc:
+            service.launch_job(second, None)
+
+    assert exc.value.code == Code.RESOURCE_EXHAUSTED
+    assert email in exc.value.message
 
 
 def test_launch_job_unspecified_band_accepted(service):

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -19,7 +19,7 @@ from iris.cluster.controller.budget import (
 )
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.service import ControllerServiceImpl
-from iris.cluster.types import JobName, UserBudgetDefaults
+from iris.cluster.types import LOCAL_ADMIN_SUBMITTER, JobName, UserBudgetDefaults
 from iris.rpc import controller_pb2, job_pb2
 from iris.testing.controller import (
     MockController,
@@ -32,6 +32,7 @@ SYSTEM = job_pb2.PRIORITY_BAND_SYSTEM
 PRODUCTION = job_pb2.PRIORITY_BAND_PRODUCTION
 INTERACTIVE = job_pb2.PRIORITY_BAND_INTERACTIVE
 BATCH = job_pb2.PRIORITY_BAND_BATCH
+OPENATHENA_USER = "russell.power@openathena.ai"
 
 GiB = 1024**3
 
@@ -64,8 +65,8 @@ def test_resource_value(cpu_millicores, memory_bytes, accelerator_count, expecte
 @pytest.mark.parametrize(
     "submitting_user,expected",
     [
-        ("russell.power@openathena.ai", "russell.power@openathena.ai"),
-        ("local_admin", "power"),
+        (OPENATHENA_USER, OPENATHENA_USER),
+        (LOCAL_ADMIN_SUBMITTER, "power"),
         ("", "power"),
     ],
 )
@@ -296,11 +297,10 @@ def test_launch_job_rejects_band_above_user_max(service):
 
 
 def test_admin_nickname_job_uses_email_budget(service):
-    email = "russell.power@openathena.ai"
     _as_admin(service.set_user_budget, _set_budget("power", 0, INTERACTIVE), None)
-    _as_admin(service.set_user_budget, _set_budget(email, 0, BATCH), None)
+    _as_admin(service.set_user_budget, _set_budget(OPENATHENA_USER, 0, BATCH), None)
 
-    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+    with identity_scope(VerifiedIdentity(user_id=OPENATHENA_USER, role="admin")):
         with pytest.raises(ConnectError) as exc:
             service.launch_job(_launch("/power/email-budget", band=INTERACTIVE), None)
 
@@ -308,13 +308,12 @@ def test_admin_nickname_job_uses_email_budget(service):
 
 
 def test_child_job_inherits_root_email_budget(service):
-    email = "russell.power@openathena.ai"
-    _as_admin(service.set_user_budget, _set_budget(email, 0, INTERACTIVE), None)
-    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+    _as_admin(service.set_user_budget, _set_budget(OPENATHENA_USER, 0, INTERACTIVE), None)
+    with identity_scope(VerifiedIdentity(user_id=OPENATHENA_USER, role="admin")):
         service.launch_job(_launch("/power/parent", band=INTERACTIVE), None)
 
-    _as_admin(service.set_user_budget, _set_budget(email, 0, BATCH), None)
-    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+    _as_admin(service.set_user_budget, _set_budget(OPENATHENA_USER, 0, BATCH), None)
+    with identity_scope(VerifiedIdentity(user_id=OPENATHENA_USER, role="admin")):
         with pytest.raises(ConnectError) as exc:
             service.launch_job(_launch("/power/parent/child", band=job_pb2.PRIORITY_BAND_INHERIT), None)
 
@@ -322,10 +321,9 @@ def test_child_job_inherits_root_email_budget(service):
 
 
 def test_active_task_cap_uses_email_across_nicknames(service, monkeypatch):
-    email = "russell.power@openathena.ai"
     monkeypatch.setattr(service_module, "MAX_ACTIVE_TASKS_PER_USER", 5)
 
-    with identity_scope(VerifiedIdentity(user_id=email, role="admin")):
+    with identity_scope(VerifiedIdentity(user_id=OPENATHENA_USER, role="admin")):
         first = _launch("/power/first")
         first.replicas = 3
         service.launch_job(first, None)


### PR DESCRIPTION
Grant both the authenticated email and established job-path alias for each of eight OpenAthena principals an unlimited INTERACTIVE budget on all four CoreWeave clusters. A zero limit keeps their work from degrading to BATCH, so each principal can claim the full cluster after other users exceed the guest allowance.

Live Marin rows paired nickname job paths such as `/power/...` with authenticated emails in `jobs.submitting_user`, while budget consumers still used the nickname. Iris now uses the authenticated principal for max-band admission, active-task caps, spend, scheduling fairness and demotion, Kubernetes dispatch, and scheduler dashboard buckets. Friendly job paths remain unchanged. Trusted local jobs and rows with an empty `submitting_user` continue to use the job-path owner.

Set the unlisted-user limit to one GPU node: 10688 on the H100 clusters and 5680 on the GB200 cluster. Additional unlisted work becomes BATCH and can be preempted by the core tier. Non-core aliases remain in their bounded researcher tier. The prior Benjamin Feuer override is superseded by the unlimited core tier. The roster is explicit in each cluster config because Iris has no cross-file config include.

The budget tiers apply when each controller next starts, and authenticated-principal accounting applies after the updated controller is deployed. No cluster was restarted. The investigation record is https://echo.oa.dev/wiki/288.
