### PR TITLE
[echo] Resolve file grading keys in echo get

### DIFF
--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -29,11 +29,14 @@ Discord is excluded by default because messages may be noisy or untrusted. Add
 `--domain discord` only when discussion history is relevant, and open the
 canonical URL when surrounding thread context matters.
 
-Fetch a result's full detail with its printed ID:
+Fetch a result's full detail with the value in the `SOURCE ID` column:
 
 ```bash
-uv run infra/echo/cli.py get <domain:id>
+uv run infra/echo/cli.py get <source-id>
 ```
+
+The `GRADE KEY` column is for `feedback`. `get` also accepts file grading keys
+with numeric suffixes, such as `file:20849`.
 
 Grade evaluated results with the exact query and printed keys:
 

--- a/.agents/skills/write-ops-log/SKILL.md
+++ b/.agents/skills/write-ops-log/SKILL.md
@@ -15,7 +15,7 @@ consume limited model context whenever they are retrieved.
 
 Invoke `consult-echo` and run its complete search-before-write sequence. Edit
 the existing entry when it covers the same incident. Start with a natural-language
-`infra/echo/cli.py search`, fetch likely matches with `get <domain:id>`, and use
+`infra/echo/cli.py search`, fetch likely matches with `get <source-id>`, and use
 `grep` for the exact error or run identifier. Create a new entry for a different
 incident even when the symptom resembles an older one; link related incidents
 and create or extend a separate synthesis only when they establish a reusable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ indexed repository documentation could inform a task:
 ```bash
 uv run infra/echo/cli.py search "how do I deploy Iris"
 uv run infra/echo/cli.py search "compare cache implementations" --repository all
-uv run infra/echo/cli.py get <domain:id>
+uv run infra/echo/cli.py get <source-id>
 ```
 
 Search covers wiki, repository files, pull requests, and issues by default.

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -119,14 +119,17 @@ styles, and fonts into the HTML response so an uncached page load does not consu
 single-request capacity with parallel static assets. Startup CPU boost reduces model
 initialization time for burst instances without allocating CPU to idle instances continuously.
 
-CLI search prints one result block with an execution-specific grading key, title,
-source ID, and one primary source excerpt of at most 240 characters. File results use
-their highest-ranked `path:line` reference, wiki results use `use_when`, and activity
-results use the matching source excerpt. The detail line is independent of terminal
+CLI search prints one block per result with a grading key tied to the stored search
+result, title, source ID, and one primary source excerpt of at most 240 characters. Pass
+the source ID to `get`; the grading key is for `feedback`. `get` also accepts a file
+grading key with a numeric suffix, such as `file:20849`, and looks up the retained source
+ID. File results use the `path:line` reference ranked highest by search, wiki results use
+the contents of their `use_when` field, and activity results use the matching source
+excerpt. The detail line is independent of terminal
 width, so long source IDs do not consume its display budget. Grading keys use
 `<domain>:<numeric-key>` and remain attached
 to the stored row even when a later corpus sync replaces an activity chunk ID.
-Run `uv run infra/echo/cli.py get <domain:id>` to fetch the full indexed wiki body,
+Run `uv run infra/echo/cli.py get <source-id>` to fetch the full indexed wiki body,
 repository file, pull request or issue chunk, or Discord message and its canonical URL.
 File IDs have the form `file:<owner>/<repository>@main:<path>`; the repository is part
 of the identity, so `file:marin-community/marin@main:README.md` and

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -203,6 +203,12 @@ class RepositoryFileDetail(BaseModel):
     text: str
 
 
+class SearchResultIdentity(BaseModel):
+    key: str
+    source_id: str
+    domain: search_config.SearchDomain
+
+
 class SearchDomainOption(BaseModel):
     value: search_config.SearchDomain
     label: str
@@ -1349,6 +1355,25 @@ def chunk(chunk_id: int, engine: Engine) -> Chunk:
         if field not in ("score", "distance", "lexical_score", "snippet")
     }
     return Chunk(score=0.0, distance=None, lexical_score=None, snippet=snippet(row), **fields)
+
+
+@api.get("/search-results/{search_result_id}", response_model=SearchResultIdentity)
+def search_result_identity(search_result_id: int, engine: Engine) -> SearchResultIdentity:
+    with engine.connect() as conn:
+        row = conn.execute(
+            sqlalchemy.select(
+                schema.search_execution_results.c.id,
+                schema.search_execution_results.c.result_id,
+                schema.search_execution_results.c.domain,
+            ).where(schema.search_execution_results.c.id == search_result_id)
+        ).first()
+    if row is None:
+        raise HTTPException(404, f"no search result {search_result_id}")
+    return SearchResultIdentity(
+        key=f"{row.domain}:{row.id}",
+        source_id=row.result_id,
+        domain=row.domain,
+    )
 
 
 @api.get("/repository-files/{reference_value:path}", response_model=RepositoryFileDetail)

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -1360,19 +1360,13 @@ def chunk(chunk_id: int, engine: Engine) -> Chunk:
 @api.get("/search-results/{search_result_id}", response_model=SearchResultIdentity)
 def search_result_identity(search_result_id: int, engine: Engine) -> SearchResultIdentity:
     with engine.connect() as conn:
-        row = conn.execute(
-            sqlalchemy.select(
-                schema.search_execution_results.c.id,
-                schema.search_execution_results.c.result_id,
-                schema.search_execution_results.c.domain,
-            ).where(schema.search_execution_results.c.id == search_result_id)
-        ).first()
-    if row is None:
+        result = stored_feedback_results(conn, {search_result_id}).get(search_result_id)
+    if result is None:
         raise HTTPException(404, f"no search result {search_result_id}")
     return SearchResultIdentity(
-        key=f"{row.domain}:{row.id}",
-        source_id=row.result_id,
-        domain=row.domain,
+        key=f"{result.domain}:{result.id}",
+        source_id=result.source_id,
+        domain=result.domain,
     )
 
 

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -1382,8 +1382,11 @@ def test_same_path_file_detail_uses_qualified_repository_and_commit(client_with,
 def test_search_result_key_resolves_to_exact_source_id(client_with):
     row = make_row(
         id=20849,
+        execution_id=991,
         result_id="file:marin-community/marin@main:infra/echo/README.md",
         domain="file",
+        title="Echo",
+        url="https://github.com/marin-community/marin/blob/abc123/infra/echo/README.md",
     )
     response = client_with([row]).client.get("/api/search-results/20849")
 
@@ -1399,7 +1402,6 @@ def test_search_result_key_reports_missing_row(client_with):
     response = client_with([]).client.get("/api/search-results/20849")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "no search result 20849"}
 
 
 def test_repository_index_reports_searchable_partial_build(client_with):

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -1379,6 +1379,29 @@ def test_same_path_file_detail_uses_qualified_repository_and_commit(client_with,
     }
 
 
+def test_search_result_key_resolves_to_exact_source_id(client_with):
+    row = make_row(
+        id=20849,
+        result_id="file:marin-community/marin@main:infra/echo/README.md",
+        domain="file",
+    )
+    response = client_with([row]).client.get("/api/search-results/20849")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "key": "file:20849",
+        "source_id": "file:marin-community/marin@main:infra/echo/README.md",
+        "domain": "file",
+    }
+
+
+def test_search_result_key_reports_missing_row(client_with):
+    response = client_with([]).client.get("/api/search-results/20849")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "no search result 20849"}
+
+
 def test_repository_index_reports_searchable_partial_build(client_with):
     state = make_row(
         repository="marin-community/vllm",

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -65,7 +65,7 @@ SOURCES = ("github", "discord")
 KINDS = ("issue", "pr", "comment", "message")
 DOMAINS = search_config.SEARCH_DOMAINS
 DEFAULT_DOMAINS = search_config.DEFAULT_SEARCH_DOMAINS
-SEARCH_DETAIL_INSTRUCTION = "Detail: uv run infra/echo/cli.py get <domain:id>"
+SEARCH_DETAIL_INSTRUCTION = "Detail: uv run infra/echo/cli.py get <source-id> (copy the SOURCE ID column)"
 SEARCH_DETAIL_MAX_CHARACTERS = 240
 MISSING_EMAIL_SCOPE_WARNING = "Not all requested scopes were granted by the authorization server, missing scopes email."
 DEFAULT_REQUEST_TIMEOUT = 30
@@ -173,7 +173,7 @@ def print_search_results(results: list[SearchResult]) -> None:
         print("No results.")
         return
 
-    print("KEY  TITLE  ID")
+    print("GRADE KEY  TITLE  SOURCE ID")
     for result in results:
         key = result.key or "unavailable"
         if result.references:
@@ -337,7 +337,8 @@ def cmd_grep(args: argparse.Namespace) -> None:
 
 
 def cmd_get(args: argparse.Namespace) -> None:
-    domain, _, value = args.id.partition(":")
+    source_id = detail_source_id(args.id)
+    domain, _, value = source_id.partition(":")
     if domain == "wiki":
         entry = response_object(request("GET", f"/wiki/{value}"))
         title = entry["title"]
@@ -345,14 +346,14 @@ def cmd_get(args: argparse.Namespace) -> None:
         url = wiki_link(int(value))
         text = entry["body"]
     elif domain == "file":
-        reference = repository_identity.parse_repository_file_id(args.id)
+        reference = repository_identity.parse_repository_file_id(source_id)
         file = response_object(request("GET", f"/repository-files/{quote(reference.route_value, safe='/@:')}"))
         title, subtitle, url, text = file["title"], file["subtitle"], file["url"], file["text"]
     else:
         chunk = response_object(request("GET", f"/chunks/{value}"))
         actual_domain = chunk_domain(chunk)
         if actual_domain != domain:
-            raise SystemExit(f"{args.id} identifies a {actual_domain} result")
+            raise SystemExit(f"{source_id} identifies a {actual_domain} result")
         title = chunk.get("title") or chunk.get("snippet") or chunk["url"]
         details = [domain]
         if chunk.get("author"):
@@ -361,11 +362,25 @@ def cmd_get(args: argparse.Namespace) -> None:
             details.append(str(chunk["date"]))
         subtitle = " · ".join(details)
         url, text = chunk["url"], chunk.get("text") or ""
-    print(f"[{args.id}] {title}")
+    print(f"[{source_id}] {title}")
     if subtitle:
         print(subtitle)
     print(f"{url}\n")
     print(text)
+
+
+def detail_source_id(value: str) -> str:
+    """Resolve an unambiguous numeric file grading key to its stored source ID."""
+    domain, _, detail = value.partition(":")
+    if domain != "file" or not detail.isdecimal():
+        return value
+    result = response_object(request("GET", f"/search-results/{detail}"))
+    actual_domain = str(result["domain"])
+    if actual_domain != domain:
+        raise SystemExit(f"{value} identifies a {actual_domain} result")
+    source_id = artifact_id(str(result["source_id"]))
+    repository_identity.parse_repository_file_id(source_id)
+    return source_id
 
 
 def cmd_history_export(args: argparse.Namespace) -> None:
@@ -462,6 +477,8 @@ def artifact_id(value: str) -> str:
 def detail_artifact_id(value: str) -> str:
     checked = artifact_id(value)
     if checked.startswith("file:"):
+        if checked.removeprefix("file:").isdecimal():
+            return checked
         try:
             repository_identity.parse_repository_file_id(checked)
         except ValueError as error:

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -86,7 +86,10 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     output = capsys.readouterr().out
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
+    assert "GRADE KEY  TITLE  SOURCE ID" in output
+    assert "copy the SOURCE ID column" in output
     assert "file:731" in output
+    assert "file:marin-community/marin@main:lib/iris/src/iris/scheduler.py" in output
     assert f"L42 {reference_text}" in output
     assert output.count("File scope: marin-community/marin") == 1
 
@@ -229,6 +232,33 @@ def test_get_fetches_full_detail_by_search_result_id(monkeypatch):
     args.func(args)
 
     assert calls == [("GET", "/repository-files/marin-community/marin@main:lib/iris/OPS.md", {})]
+
+
+def test_get_resolves_numeric_file_search_key_to_source_id(monkeypatch, capsys):
+    calls = []
+    source_id = "file:marin-community/marin@main:infra/echo/README.md"
+
+    def fake_request(method, path, **options):
+        calls.append((method, path, options))
+        if path == "/search-results/20849":
+            return {"key": "file:20849", "source_id": source_id, "domain": "file"}
+        return {
+            "id": source_id,
+            "title": "Echo",
+            "subtitle": "marin-community/marin · infra/echo/README.md · main@abc123",
+            "url": "https://github.com/marin-community/marin/blob/abc123/infra/echo/README.md",
+            "text": "# Echo",
+        }
+
+    monkeypatch.setattr(cli, "request", fake_request)
+    args = cli.build_parser().parse_args(["get", "file:20849"])
+    args.func(args)
+
+    assert calls == [
+        ("GET", "/search-results/20849", {}),
+        ("GET", "/repository-files/marin-community/marin@main:infra/echo/README.md", {}),
+    ]
+    assert capsys.readouterr().out.startswith(f"[{source_id}] Echo\n")
 
 
 def test_get_rejects_legacy_path_only_file_id():

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -86,8 +86,6 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     output = capsys.readouterr().out
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
-    assert "GRADE KEY  TITLE  SOURCE ID" in output
-    assert "copy the SOURCE ID column" in output
     assert "file:731" in output
     assert "file:marin-community/marin@main:lib/iris/src/iris/scheduler.py" in output
     assert f"L42 {reference_text}" in output


### PR DESCRIPTION
Federated search prints numeric grading keys for file results, while
`echo/cli.py get` required repository-qualified source IDs. Accept numeric file
grading keys by resolving the persisted search-history row to its qualified
source ID before fetching the file, preserving repository and branch identity.

Label search output as `GRADE KEY` and `SOURCE ID`, and update agent guidance
to identify the fetchable value. Unknown keys return `no search result
<number>`.

The Echo Python suite passes with 99 tests. The incident record is
https://echo.oa.dev/wiki/287.
