### PR TITLE
[finelog] Accept migrated summaries without nonzero counts

### DIFF
--- a/lib/finelog/rust/src/levanter_metrics_policy.rs
+++ b/lib/finelog/rust/src/levanter_metrics_policy.rs
@@ -155,11 +155,10 @@ fn validate_metric_batch(
             )));
         }
 
-        let summary_values: [&dyn Array; 9] = [
+        let required_summary_values: [&dyn Array; 8] = [
             minima,
             maxima,
             counts,
-            nonzero_counts,
             sums,
             sum_squares,
             means,
@@ -169,17 +168,20 @@ fn validate_metric_batch(
         match kinds.value(row) {
             "scalar" => {
                 require_non_null(values, VALUE_COLUMN, row)?;
-                require_all_null(&summary_values, "summary", row)?;
+                require_all_null(&required_summary_values, "summary", row)?;
+                require_null(nonzero_counts, NONZERO_COUNT_COLUMN, row)?;
                 require_null(bucket_limits, BUCKET_LIMITS_COLUMN, row)?;
                 require_null(bucket_counts, BUCKET_COUNTS_COLUMN, row)?;
             }
             "summary" | "histogram" => {
                 require_null(values, VALUE_COLUMN, row)?;
-                require_all_non_null(&summary_values, "summary", row)?;
+                // Legacy seven-stat summaries have no nonzero count to reconstruct.
+                require_all_non_null(&required_summary_values, "summary", row)?;
                 if kinds.value(row) == "summary" {
                     require_null(bucket_limits, BUCKET_LIMITS_COLUMN, row)?;
                     require_null(bucket_counts, BUCKET_COUNTS_COLUMN, row)?;
                 } else {
+                    require_non_null(nonzero_counts, NONZERO_COUNT_COLUMN, row)?;
                     require_non_null(bucket_limits, BUCKET_LIMITS_COLUMN, row)?;
                     require_non_null(bucket_counts, BUCKET_COUNTS_COLUMN, row)?;
                     if bucket_limits.value_length(row) != bucket_counts.value_length(row) + 1 {

--- a/lib/finelog/rust/src/telemetry_policy.rs
+++ b/lib/finelog/rust/src/telemetry_policy.rs
@@ -871,6 +871,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
+    use crate::levanter_metrics_policy::LEVANTER_METRICS_POLICY;
     use crate::server::telemetry::telemetry_schema;
 
     fn telemetry_batch(services: &[&str], kinds: &[&str], names: &[&str]) -> RecordBatch {
@@ -1201,5 +1202,12 @@ mod tests {
                 .value(0),
             72.0
         );
+        LEVANTER_METRICS_POLICY
+            .route_batch(
+                IngestionBatchSource::Stored(LEVANTER_METRICS_NAMESPACE),
+                metrics,
+                &mut IngestionState::default(),
+            )
+            .expect("migrated metrics must satisfy live typed ingestion");
     }
 }


### PR DESCRIPTION
Legacy telemetry migration reconstructs `min`, `max`, `count`, `sum`,
`sum_squares`, `mean`, `variance`, and `rms`, but its source stream has no
nonzero count. The hub's typed Levanter policy rejected those migrated rows.
Regional forwarders preserve their cursor after `invalid_argument` responses,
so one such row blocked later rows in that namespace.

Allow a null `nonzero_count` only for summary rows. Scalars still require it to
be null; histograms still require it to be present. A cross-policy regression
passes a migrated seven-stat summary through the typed ingestion validator.

Incident: https://echo.oa.dev/wiki/285
