### PR TITLE
[iris] Restore Kueue TAS priority preemption

### DIFF
--- a/infra/pulumi/src/iac/coreweave/kueue.py
+++ b/infra/pulumi/src/iac/coreweave/kueue.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 
 import pulumi
 import pulumi_kubernetes as k8s
+from iris.cluster.config import IrisClusterConfig
+from iris.cluster.platforms.k8s.constants import NVIDIA_GPU_RESOURCE, RDMA_RESOURCE
 from iris.cluster.platforms.k8s.kueue_manifests import (
     CW_REPO_URL,
     OPERATOR_NS,
@@ -19,6 +21,7 @@ from iris.cluster.platforms.k8s.kueue_manifests import (
     build_topology_cr,
 )
 from iris.cluster.platforms.k8s.types import IRIS_PRIORITY_CLASS_SYSTEM, iris_priority_class_manifest
+from iris.cluster.types import AcceleratorType
 
 from iac.config import KueueProvisioningSpec
 from iac.imports import NO_IMPORTS, ImportRegistrar
@@ -26,9 +29,9 @@ from iac.imports import NO_IMPORTS, ImportRegistrar
 # cks-kueue chart coordinates. The installer resolves `latest`; IaC pins the version so the
 # release is reproducible. Bump this in lockstep with a chart upgrade.
 CKS_KUEUE_CHART = "cks-kueue"
-CKS_KUEUE_VERSION = "1.4.0"
+CKS_KUEUE_VERSION = "1.5.0"
 # The Topology CRD's served apiVersion (install_kueue.py reads it from the live CRD; it is
-# v1beta1 for cks-kueue 1.4.0).
+# v1beta1 for cks-kueue 1.5.0).
 TOPOLOGY_API_VERSION = "kueue.x-k8s.io/v1beta1"
 MANAGER_DEPLOYMENT = "kueue-controller-manager"
 
@@ -38,6 +41,22 @@ class KueueAddonArgs:
     namespace: str  # webhook scope + LocalQueue namespace, from kubernetes_provider.namespace
     cluster_queue: str  # from kubernetes_provider.kueue.cluster_queue
     spec: KueueProvisioningSpec
+    nominal_quotas: dict[str, str]
+
+
+def accelerator_nominal_quotas(config: IrisClusterConfig) -> dict[str, str]:
+    """Return binding GPU and RDMA quotas from CoreWeave scale-group maxima."""
+    accelerator_count = 0
+    for scale_group in config.scale_groups.values():
+        resources = scale_group.resources
+        template = scale_group.slice_template
+        if resources is None or resources.device_type != AcceleratorType.GPU or template is None:
+            continue
+        accelerator_count += scale_group.max_slices * max(1, template.num_vms) * resources.device_count
+    if accelerator_count <= 0:
+        raise ValueError("CoreWeave Kueue requires positive accelerator capacity")
+    quota = str(accelerator_count)
+    return {NVIDIA_GPU_RESOURCE: quota, RDMA_RESOURCE: quota}
 
 
 class KueueAddon(pulumi.ComponentResource):
@@ -117,7 +136,7 @@ class KueueAddon(pulumi.ComponentResource):
         )
         imports.register(resource_flavor, parent=self, provider_id=RESOURCE_FLAVOR_NAME)
 
-        queue_manifest = build_cluster_queue(args.cluster_queue)
+        queue_manifest = build_cluster_queue(args.cluster_queue, nominal_quotas=args.nominal_quotas)
         cluster_queue = k8s.apiextensions.CustomResource(
             "cluster-queue",
             api_version=queue_manifest["apiVersion"],

--- a/infra/pulumi/src/iac/program.py
+++ b/infra/pulumi/src/iac/program.py
@@ -38,7 +38,7 @@ from iac.config import (
 )
 from iac.coreweave.cluster import CoreweaveCluster, CoreweaveClusterArgs
 from iac.coreweave.dns import FederationDns, FederationDnsArgs
-from iac.coreweave.kueue import KueueAddon, KueueAddonArgs
+from iac.coreweave.kueue import KueueAddon, KueueAddonArgs, accelerator_nominal_quotas
 from iac.coreweave.rbac import GrafanaObserverRbac, GrafanaObserverRbacArgs, IrisRbac, IrisRbacArgs
 from iac.coreweave.traefik import TraefikAddon, TraefikAddonArgs
 from iac.gcp.addresses import GcpStaticAddresses, GcpStaticAddressesArgs
@@ -166,6 +166,7 @@ def _build_coreweave(cluster: str, *, imports: ImportRegistrar) -> None:
             namespace=namespace,
             cluster_queue=kueue_config.cluster_queue,
             spec=coreweave_provisioning.kueue,
+            nominal_quotas=accelerator_nominal_quotas(iris_config),
         ),
         k8s_provider=k8s_provider,
         imports=imports,

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -148,14 +148,22 @@ namespace scope in
 [`KueueAddon`](../../../infra/pulumi/src/iac/coreweave/kueue.py); do not replace
 that release with an ad hoc cluster-wide install.
 
+Pulumi pins `cks-kueue` 1.5.0, which contains Kueue 0.18.3. Iris explicitly
+enables `TASRecomputeAssignmentWithinSchedulingCycle`, added in Kueue 0.18.2,
+so a workload's hostname assignment is recomputed when an earlier admission in
+the same scheduling cycle consumes that domain.
+
 #### TAS preemption and CPU spillover
 
 All Iris Pods use the topology-aware `cw-tas` ResourceFlavor. Its
 `iris.kueue=true` selector covers every Iris-managed NodePool. Accelerator-free
 Pods request unconstrained TAS, so Kueue records their per-node CPU reservations
-in the same flavor as GPU gangs. `preemption.withinClusterQueue: LowerPriority`
-can then remove a lower-priority CPU Workload from the topology snapshot before
-retrying a blocked GPU gang's fit.
+in the same flavor as GPU gangs. The ClusterQueue's binding GPU and RDMA quotas
+are derived from the configured maximum GPU node count and per-node device
+count; CPU, memory, disk, and Pods retain non-binding sentinels. Accelerator
+quota pressure activates `preemption.withinClusterQueue: LowerPriority`, and TAS
+then checks whether removing lower-priority candidates creates a compatible
+topology before admitting the waiting Workload.
 
 Each Iris band has three Kueue admission tiers. The controller reconciles the
 twelve `WorkloadPriorityClass` objects at startup.
@@ -199,10 +207,12 @@ flowchart TD
     native --> queue[Kueue LocalQueue and shared ClusterQueue]
     gpu --> queue
     cpu --> queue
-    queue --> fit{TAS topology fit?}
+    queue --> quota{Accelerator quota available?}
+    quota -- No --> preempt[withinClusterQueue: LowerPriority<br/>select compatible victims]
+    preempt --> fit{Quota and TAS fit after victims?}
+    quota -- Yes --> fit
     fit -- Yes --> admit[Admit workload and release scheduling gate]
-    fit -- No --> preempt[withinClusterQueue: LowerPriority<br/>select compatible victims]
-    preempt --> fit
+    fit -- No --> wait[Remain SchedulingGated]
     admit --> schedule[Kubernetes schedules Pods]
 ```
 
@@ -225,6 +235,12 @@ tracked by
 When migrating from the split flavors, apply the NodePool labels before
 switching the ClusterQueue to `cw-tas`, then verify CPU nodes appear in Kueue's
 topology cache.
+
+TAS admission pins each Pod to a hostname from Kueue's capacity snapshot. The
+same-cycle recomputation gate prevents two newly admitted Workloads from keeping
+the same hostname when only one has capacity. If capacity becomes unavailable
+after admission for another reason, kube-scheduler reports an affinity plus
+resource failure and Iris returns the attempt to `PENDING` for fresh admission.
 
 ## Resource ownership
 

--- a/lib/iris/docs/priority-bands.md
+++ b/lib/iris/docs/priority-bands.md
@@ -53,9 +53,10 @@ on every pod. How that band turns into actual preemption depends on the backend:
 - **K8s GPU clusters (CoreWeave).** Every pod is admitted through Kueue. Kueue reads
   the pod's PriorityClass as the Workload priority and, with the ClusterQueue's
   `preemption.withinClusterQueue: LowerPriority` policy, evicts lower-priority
-  Workloads to admit a higher-priority one — including when Topology-Aware
-  Scheduling can't otherwise place it on full nodes. This is what lets a
-  higher-priority multi-host gang reclaim capacity from running `batch` gangs.
+  Workloads when binding GPU or RDMA quota is exhausted. Topology-Aware
+  Scheduling checks that those victims make a compatible placement available.
+  This is what lets a higher-priority multi-host gang reclaim full nodes from
+  running `batch` gangs instead of waiting behind non-binding quota.
   Preemption is whole-Workload (gang-aware): Kueue evicts a full lower-priority gang,
   not a stray pod out of it.
 - **VM/TPU clusters.** There is no Kueue; the Iris controller's own scheduler ranks

--- a/lib/iris/scripts/install_kueue.py
+++ b/lib/iris/scripts/install_kueue.py
@@ -17,12 +17,10 @@ Two variants share one code path (``--variant``):
     clusters. TAS is enabled via ``controllerManager`` feature gates. The smoke
     harness (tests/e2e/gpu_gang_smoke.py) drives this variant on kind.
 
-Neither variant uses cks-kueue's ``topologies:`` values templating: the chart
-(1.3.0) renders Topology CRs at ``kueue.x-k8s.io/v1alpha1`` while the CRD it
-itself installs serves only v1beta1+, so any helm pass carrying ``topologies``
-fails with 'no matches for kind "Topology"'. Instead both variants apply the
-Topology CRs with kubectl after install, at the apiVersion the installed CRD
-actually serves.
+Neither variant uses cks-kueue's ``topologies:`` values templating. Both apply
+the same Topology manifests with kubectl after install, at an apiVersion the
+installed CRD actually serves. This keeps the CoreWeave and upstream smoke paths
+on one manifest implementation across Kueue API-version changes.
 
 Both variants:
   1. Install the operator into ``kueue-system`` (``helm upgrade --install``).
@@ -42,16 +40,20 @@ Both variants:
      ResourceFlavor + ClusterQueue. The flavor selects ``iris.kueue=true`` and every
      Iris Pod requests TAS, so lower-priority CPU reservations are reclaimable during
      GPU topology fit. The ClusterQueue enables priority preemption within the queue
-     (``preemption.withinClusterQueue: LowerPriority``). Quota stays non-binding, so
-     the pressure signal is TAS, not quota. The namespaced LocalQueue is NOT created here:
-     Iris reconciles its own (``{label_prefix}-lq``) at controller start
+     (``preemption.withinClusterQueue: LowerPriority``). Production supplies binding
+     GPU and RDMA quotas from the configured fleet maximum; other resources retain a
+     non-binding sentinel. Quota pressure starts preemption, then TAS verifies that
+     the selected victims make a compatible topology available. The namespaced
+     LocalQueue is NOT created here: Iris reconciles its own
+     (``{label_prefix}-lq``) at controller start
      (``K8sControllerProvider.ensure_kueue_queues``), binding it to this ClusterQueue
      via ``kubernetes_provider.kueue.cluster_queue``.
 
-NB on Kueue version: TAS-aware preemption is version-sensitive. On too-old a Kueue
-a ClusterQueue that combines a topology-bound flavor with a ``preemption`` stanza
-can be marked Inactive, which breaks all gang admission. Validate on the target
-version (kind smoke first) before applying to a shared cluster.
+NB on Kueue version: TAS-aware preemption is version-sensitive. Kueue 0.18.2
+introduced same-scheduling-cycle TAS assignment recomputation, which prevents a
+later workload from retaining a hostname assignment consumed by an earlier
+admission in that cycle. Validate the pinned version and binding-quota preemption
+on the kind smoke before applying to a shared cluster.
 
 NB on the topology levels / flavor node-labels: to Kueue these are just node-label
 *keys* and a node selector. The ``upstream`` variant reuses the CoreWeave level
@@ -112,8 +114,10 @@ _WEBHOOK_WARMUP_DELAY = 5.0
 # Upstream Kueue OCI helm chart (kind / generic clusters). Pinned >= 0.13 for the PodSet-slice
 # TAS feature (multi-rack GB200 nvlink.domain.sliced placement); 0.18 also carries the
 # IsTAS()-recognition fix for slice-only pod groups (upstream #10282, patched in 0.16/0.17).
+# 0.18.2 fixes conflicting same-cycle TAS nominations:
+# https://github.com/kubernetes-sigs/kueue/pull/12521
 UPSTREAM_CHART = "oci://registry.k8s.io/kueue/charts/kueue"
-UPSTREAM_DEFAULT_VERSION = "0.18.0"
+UPSTREAM_DEFAULT_VERSION = "0.18.3"
 
 
 # --------------------------------------------------------------------------
@@ -225,6 +229,7 @@ def run_install(
     release: str = RELEASE_DEFAULT,
     with_queues: bool = False,
     cluster_queue: str = "iris-cq",
+    nominal_quotas: dict[str, str] | None = None,
     flavor_topology: str = INFINIBAND_TOPOLOGY_NAME,
     pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES,
     apply: bool = False,
@@ -235,6 +240,7 @@ def run_install(
     ``apply`` is set. ``flavor_topology`` selects the Topology the ResourceFlavor
     binds (default InfiniBand; the kind smoke passes multinode-nvlink-ib).
     ``--with-queues`` provisions one ``cw-tas`` ResourceFlavor for all nodes.
+    ``nominal_quotas`` makes selected resources binding for quota-driven preemption.
     ``pod_namespaces`` scopes the plain-Pod admission webhook (default: the ``iris``
     namespace) — never widen this to system namespaces on a shared cluster.
     """
@@ -246,7 +252,7 @@ def run_install(
     if with_queues:
         queue_docs = [
             build_resource_flavor(flavor_topology),
-            build_cluster_queue(cluster_queue),
+            build_cluster_queue(cluster_queue, nominal_quotas=nominal_quotas),
         ]
     else:
         queue_docs = []
@@ -421,6 +427,13 @@ def _apply(
 )
 @click.option("--cluster-queue", default="iris-cq", help="ClusterQueue name for --with-queues (default: iris-cq).")
 @click.option(
+    "--nominal-quota",
+    "nominal_quota_items",
+    multiple=True,
+    metavar="RESOURCE=QUANTITY",
+    help="Binding nominal quota for a covered resource. Repeatable; omitted resources stay non-binding.",
+)
+@click.option(
     "--flavor-topology",
     type=click.Choice([INFINIBAND_TOPOLOGY_NAME, MULTINODE_TOPOLOGY_NAME]),
     default=INFINIBAND_TOPOLOGY_NAME,
@@ -443,11 +456,18 @@ def main(
     release: str,
     with_queues: bool,
     cluster_queue: str,
+    nominal_quota_items: tuple[str, ...],
     flavor_topology: str,
     pod_namespaces: tuple[str, ...],
     apply: bool,
 ) -> None:
     """Install + configure Kueue (coreweave or upstream) for Iris gang admission."""
+    nominal_quotas: dict[str, str] = {}
+    for item in nominal_quota_items:
+        resource, separator, quantity = item.partition("=")
+        if not separator or not resource or not quantity:
+            raise click.BadParameter(f"expected RESOURCE=QUANTITY, got {item!r}", param_hint="--nominal-quota")
+        nominal_quotas[resource] = quantity
     run_install(
         variant=variant,
         kubeconfig=kubeconfig,
@@ -456,6 +476,7 @@ def main(
         release=release,
         with_queues=with_queues,
         cluster_queue=cluster_queue,
+        nominal_quotas=nominal_quotas,
         flavor_topology=flavor_topology,
         pod_namespaces=pod_namespaces,
         apply=apply,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -57,7 +57,9 @@ from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.platforms.k8s.constants import (
     COREWEAVE_INTERRUPTABLE_TOLERATION,
     DEFAULT_TASK_CACHE_DIR,
+    NVIDIA_GPU_RESOURCE,
     NVIDIA_GPU_TOLERATION,
+    RDMA_RESOURCE,
 )
 from iris.cluster.platforms.k8s.coreweave_topology import (
     COSCHEDULE_LEAFGROUP,
@@ -158,15 +160,14 @@ _LABEL_JOB_ID = "iris.job_id"
 # Runtime identifier for pods created by K8sTaskProvider.
 _RUNTIME_LABEL_VALUE = IRIS_KUBERNETES_RUNTIME
 
-# Extended resource name for NVIDIA GPUs in pod requests/limits.
-_GPU_RESOURCE = "nvidia.com/gpu"
-
 # Native log-shipping sidecar (initContainer + restartPolicy: Always). It reads
 # the task container's CRI log file from the node and pushes to finelog, so the
 # controller never pulls pod logs through the apiserver.
 _LOGSHIP_CONTAINER_NAME = "log-shipper"
 _LOGSHIP_VOLUME_NAME = "varlogpods"
 _NODE_POD_LOG_DIR = "/var/log/pods"
+LOGSHIP_CPU_REQUEST = "50m"
+OUTPUT_UPLOADER_CPU_REQUEST = "100m"
 
 # Max pod name length is 253 chars in k8s. We stay well under it.
 _MAX_POD_NAME_LEN = 63
@@ -657,7 +658,7 @@ def _build_logship_sidecar(
         "command": [".venv/bin/python", "-m", "iris.cluster.backends.k8s.logship"],
         "env": env,
         "volumeMounts": [{"name": _LOGSHIP_VOLUME_NAME, "mountPath": _NODE_POD_LOG_DIR, "readOnly": True}],
-        "resources": {"requests": {"cpu": "50m", "memory": "64Mi"}},
+        "resources": {"requests": {"cpu": LOGSHIP_CPU_REQUEST, "memory": "64Mi"}},
     }
 
 
@@ -679,7 +680,7 @@ def _build_output_uploader(
             {"name": OUTPUT_MOUNT.name, "mountPath": OUTPUT_MOUNT.container_path},
             {"name": OUTPUT_CONTROL_VOLUME_NAME, "mountPath": OUTPUT_CONTROL_PATH},
         ],
-        "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}},
+        "resources": {"requests": {"cpu": OUTPUT_UPLOADER_CPU_REQUEST, "memory": "128Mi"}},
         "terminationMessagePolicy": "File",
     }
     if env_secret_name:
@@ -883,10 +884,10 @@ def _build_pod_manifest(
             has_tpu = res.device.HasField("tpu")
             if gpu_count > 0:
                 # K8s treats accelerator limits as implicit requests.
-                limits[_GPU_RESOURCE] = str(gpu_count)
+                limits[NVIDIA_GPU_RESOURCE] = str(gpu_count)
                 if host_network:
                     # Request RDMA/IB devices for multi-host NCCL over InfiniBand.
-                    limits["rdma/ib"] = str(gpu_count)
+                    limits[RDMA_RESOURCE] = str(gpu_count)
         if limits:
             resources["limits"] = limits
         if requests:
@@ -1435,7 +1436,9 @@ def _pod_gpu_request(pod: dict) -> int:
     total = 0
     for container in pod.get("spec", {}).get("containers", []):
         resources = container.get("resources", {})
-        value = resources.get("requests", {}).get(_GPU_RESOURCE) or resources.get("limits", {}).get(_GPU_RESOURCE)
+        value = resources.get("requests", {}).get(NVIDIA_GPU_RESOURCE) or resources.get("limits", {}).get(
+            NVIDIA_GPU_RESOURCE
+        )
         if value:
             total += parse_k8s_quantity(str(value))
     return total
@@ -1869,7 +1872,7 @@ def _node_disk_bytes(node: dict) -> int:
 
 
 def _node_gpu_count(node: dict) -> int:
-    gpu = node.get("status", {}).get("allocatable", {}).get(_GPU_RESOURCE)
+    gpu = node.get("status", {}).get("allocatable", {}).get(NVIDIA_GPU_RESOURCE)
     return int(parse_k8s_quantity(str(gpu))) if gpu else 0
 
 
@@ -1973,7 +1976,7 @@ class ClusterState:
             pods = self._pods[:]
         allocatable = 0
         for node in nodes:
-            gpu = node.get("status", {}).get("allocatable", {}).get(_GPU_RESOURCE)
+            gpu = node.get("status", {}).get("allocatable", {}).get(NVIDIA_GPU_RESOURCE)
             if gpu:
                 allocatable += int(parse_k8s_quantity(str(gpu)))
         held = 0

--- a/lib/iris/src/iris/cluster/platforms/k8s/constants.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/constants.py
@@ -4,11 +4,13 @@
 """Shared Kubernetes constants for Iris cluster components."""
 
 DEFAULT_TASK_CACHE_DIR = "/cache"
+NVIDIA_GPU_RESOURCE = "nvidia.com/gpu"
+RDMA_RESOURCE = "rdma/ib"
 
 # NVIDIA GPU nodes commonly carry this taint. Pods requesting GPUs must
 # tolerate it or they will remain Pending.
 NVIDIA_GPU_TOLERATION: dict = {
-    "key": "nvidia.com/gpu",
+    "key": NVIDIA_GPU_RESOURCE,
     "operator": "Exists",
     "effect": "NoSchedule",
 }

--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -9,12 +9,13 @@ builders so they render byte-identical manifests. Everything here is pure — th
 functions return plain dicts and do no I/O.
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 
 import yaml
 
+from iris.cluster.platforms.k8s.constants import NVIDIA_GPU_RESOURCE, RDMA_RESOURCE
 from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_INFINIBAND_TOPOLOGY_LABELS,
     CW_MULTINODE_TOPOLOGY_LABELS,
@@ -39,6 +40,7 @@ CW_CHART = f"{CW_REPO_NAME}/cks-kueue"
 
 RELEASE_DEFAULT = "kueue"
 OPERATOR_NS = "kueue-system"
+TAS_RECOMPUTE_ASSIGNMENT_FEATURE = "TASRecomputeAssignmentWithinSchedulingCycle"
 
 # Controller-manager feature gates for the cks-kueue chart. Helm replaces list values
 # wholesale, so this enumerates the full set the chart ships with, changing one entry:
@@ -56,6 +58,7 @@ CKS_KUEUE_FEATURE_GATES = [
     {"name": "TopologyAwareScheduling", "enabled": True},
     {"name": "TASBalancedPlacement", "enabled": False},
     {"name": "TASMultiLayerTopology", "enabled": True},
+    {"name": TAS_RECOMPUTE_ASSIGNMENT_FEATURE, "enabled": True},
 ]
 
 # Namespace(s) Iris submits gang pods into (the k8s provider namespace, default
@@ -101,24 +104,20 @@ RESOURCE_FLAVOR_NODE_LABELS = {KUEUE_NODE_LABEL: "true"}
 # request cpu/memory/nvidia.com/gpu plus ephemeral-storage (from the disk request)
 # and rdma/ib (the InfiniBand devices), so all five must be covered.
 #
-# Iris does NOT use Kueue for capacity *enforcement*: the Iris autoscaler bounds
-# capacity via scale-group max_slices, so every resource's nominalQuota is a
-# sentinel large enough never to bind — Kueue never rejects on quota, and the real
-# capacity authority stays the scheduler/autoscaler.
-#
-# It DOES use Kueue for preemption (see build_cluster_queue's preemption stanza).
-# The pressure signal is Topology-Aware Scheduling, not quota. Every Iris Pod
-# uses the same TAS flavor so simulated victim removal can reclaim lower-priority
-# CPU reservations before retrying a GPU gang's topology fit. Quota stays
-# non-binding so it does not fight the autoscaler.
+# Iris uses binding accelerator quota to enter Kueue's preemption path. Pulumi
+# derives that quota from scale-group max_slices, so it agrees with the Iris
+# autoscaler's configured upper bound. Other resources keep sentinel quotas and
+# do not become independent capacity limits. Every Iris Pod uses the same TAS
+# flavor so Kueue can check whether removing lower-priority victims creates a
+# compatible accelerator placement.
 NON_BINDING_QUOTA = {
     # Use "1G" not "1000000000" because the Kubernetes API server canonicalizes to 1G
     # and always returns that, which causes a perpetual, cosmetic `pulumi preview` diff
     "cpu": "1G",  # cores
     "memory": "1Pi",
     "ephemeral-storage": "1Pi",
-    "nvidia.com/gpu": "1G",
-    "rdma/ib": "1G",
+    NVIDIA_GPU_RESOURCE: "1G",
+    RDMA_RESOURCE: "1G",
 }
 COVERED_RESOURCES = list(NON_BINDING_QUOTA)
 
@@ -296,7 +295,10 @@ def build_upstream_values(pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES
     return {
         "enableKueueViz": False,
         "controllerManager": {
-            "featureGates": [{"name": "TopologyAwareScheduling", "enabled": True}],
+            "featureGates": [
+                {"name": "TopologyAwareScheduling", "enabled": True},
+                {"name": TAS_RECOMPUTE_ASSIGNMENT_FEATURE, "enabled": True},
+            ],
         },
         "managerConfig": {"controllerManagerConfigYaml": config_yaml},
     }
@@ -343,21 +345,24 @@ def build_workload_priority_class(name: str, value: int) -> dict:
     }
 
 
-def build_cluster_queue(name: str) -> dict:
+def build_cluster_queue(name: str, *, nominal_quotas: Mapping[str, str] | None = None) -> dict:
     """Return the cluster-scoped, admin-owned ClusterQueue.
 
-    Covers every resource Iris pods request (COVERED_RESOURCES) with a non-binding
-    nominalQuota (NON_BINDING_QUOTA) — Kueue does not enforce capacity here (the Iris
-    autoscaler does). It DOES enforce priority: ``preemption.withinClusterQueue:
-    LowerPriority`` lets a higher-priority pending Workload evict compatible
-    lower-priority admitted Workloads when it cannot otherwise be admitted. One
-    flavor covers all resources and nodes so CPU reservations on accelerator
-    nodes are compatible preemption candidates for GPU gangs.
+    Covers every resource Iris pods request (COVERED_RESOURCES). Resources omitted
+    from ``nominal_quotas`` keep their non-binding sentinel. Production supplies
+    accelerator quota from the configured scale-group maxima so accelerator pressure
+    enters Kueue's quota-driven priority preemption path. One flavor covers all
+    resources and nodes so TAS can simulate removal of compatible victims.
     """
+    nominal_quotas = nominal_quotas or {}
+    unknown_resources = nominal_quotas.keys() - NON_BINDING_QUOTA.keys()
+    if unknown_resources:
+        raise ValueError(f"nominal quota provided for uncovered resources: {sorted(unknown_resources)}")
+    quotas = {**NON_BINDING_QUOTA, **nominal_quotas}
     flavors = [
         {
             "name": RESOURCE_FLAVOR_NAME,
-            "resources": [{"name": r, "nominalQuota": NON_BINDING_QUOTA[r]} for r in COVERED_RESOURCES],
+            "resources": [{"name": resource, "nominalQuota": quotas[resource]} for resource in COVERED_RESOURCES],
         },
     ]
     return {

--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -346,13 +346,11 @@ def build_workload_priority_class(name: str, value: int) -> dict:
 
 
 def build_cluster_queue(name: str, *, nominal_quotas: Mapping[str, str] | None = None) -> dict:
-    """Return the cluster-scoped, admin-owned ClusterQueue.
+    """Return a cluster-scoped ClusterQueue with covered-resource quota overrides.
 
-    Covers every resource Iris pods request (COVERED_RESOURCES). Resources omitted
-    from ``nominal_quotas`` keep their non-binding sentinel. Production supplies
-    accelerator quota from the configured scale-group maxima so accelerator pressure
-    enters Kueue's quota-driven priority preemption path. One flavor covers all
-    resources and nodes so TAS can simulate removal of compatible victims.
+    Every resource in ``COVERED_RESOURCES`` appears once. Resources omitted from
+    ``nominal_quotas`` use their ``NON_BINDING_QUOTA`` value. Unknown resources
+    are rejected.
     """
     nominal_quotas = nominal_quotas or {}
     unknown_resources = nominal_quotas.keys() - NON_BINDING_QUOTA.keys()

--- a/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
@@ -30,6 +30,7 @@ def test_cks_values_disable_tas_balanced_placement():
     # stay ON.
     assert _gate(gates, "TopologyAwareScheduling") is True
     assert _gate(gates, "TASMultiLayerTopology") is True
+    assert _gate(gates, "TASRecomputeAssignmentWithinSchedulingCycle") is True
 
 
 def test_upstream_values_never_enable_tas_balanced_placement():
@@ -38,13 +39,23 @@ def test_upstream_values_never_enable_tas_balanced_placement():
     gates = build_upstream_values(["iris"])["controllerManager"]["featureGates"]
     assert _gate(gates, "TASBalancedPlacement") in (None, False)
     assert _gate(gates, "TopologyAwareScheduling") is True
+    assert _gate(gates, "TASRecomputeAssignmentWithinSchedulingCycle") is True
 
 
 def test_resource_flavor_and_cluster_queue_use_one_all_node_tas_flavor():
     flavor = build_resource_flavor()
-    queue = build_cluster_queue("iris-cq")
+    queue = build_cluster_queue(
+        "iris-cq",
+        nominal_quotas={"nvidia.com/gpu": "512", "rdma/ib": "512"},
+    )
 
     assert flavor["metadata"]["name"] == "cw-tas"
     assert flavor["spec"]["nodeLabels"] == {"iris.kueue": "true"}
     assert [entry["name"] for entry in queue["spec"]["resourceGroups"][0]["flavors"]] == ["cw-tas"]
     assert queue["spec"]["preemption"] == {"withinClusterQueue": "LowerPriority"}
+    resources = {
+        resource["name"]: resource["nominalQuota"]
+        for resource in queue["spec"]["resourceGroups"][0]["flavors"][0]["resources"]
+    }
+    assert resources["nvidia.com/gpu"] == "512"
+    assert resources["rdma/ib"] == "512"

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -85,6 +85,7 @@ from iris.cluster.platforms.types import Labels, find_free_port
 from iris.cluster.types import AcceleratorType, CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device
 from iris.resources.state import JobState
 from iris.rpc import job_pb2
+from rigging.timing import Duration, ExponentialBackoff
 
 # install_kueue is a sibling ops script under lib/iris/scripts/ (not part of the
 # iris package), so add that dir to the path before importing it.
@@ -613,12 +614,10 @@ def validate_priority_preemption(controller_url: str, target: ControllerTarget, 
         priority_band=job_pb2.PRIORITY_BAND_BATCH,
     )
     try:
-        deadline = time.monotonic() + args.timeout
-        while time.monotonic() < deadline:
-            if batch.status().state is JobState.RUNNING:
-                break
-            time.sleep(1)
-        else:
+        if not ExponentialBackoff(initial=0.1, maximum=1.0).wait_until(
+            lambda: batch.status().state is JobState.RUNNING,
+            timeout=Duration.from_seconds(args.timeout),
+        ):
             logger.error("batch quota filler did not reach RUNNING")
             return False
 
@@ -642,16 +641,23 @@ def validate_priority_preemption(controller_url: str, target: ControllerTarget, 
             logger.error("interactive preemption probe finished in %s", interactive_status.state)
             return False
 
-        preemption_deadline = time.monotonic() + args.timeout
-        while time.monotonic() < preemption_deadline:
+        preempted_workload: str | None = None
+
+        def preemption_observed() -> bool:
+            nonlocal preempted_workload
             current_preemptions = kueue_preemption_events(target)
             new_preemptions = current_preemptions.keys() - existing_preemptions.keys()
             if new_preemptions:
                 event_uid = next(iter(new_preemptions))
-                workload_name = current_preemptions[event_uid]
-                logger.info("interactive workload triggered Kueue preemption of Workload %s", workload_name)
-                return True
-            time.sleep(1)
+                preempted_workload = current_preemptions[event_uid]
+            return preempted_workload is not None
+
+        if ExponentialBackoff(initial=0.1, maximum=1.0).wait_until(
+            preemption_observed,
+            timeout=Duration.from_seconds(args.timeout),
+        ):
+            logger.info("interactive workload triggered Kueue preemption of Workload %s", preempted_workload)
+            return True
         logger.error("interactive workload ran without a Kueue Workload preemption event")
         return False
     finally:

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -51,8 +51,13 @@ from pathlib import Path
 
 import click
 from iris.client.client import IrisClient
+from iris.cluster.backends.k8s.tasks import LOGSHIP_CPU_REQUEST, OUTPUT_UPLOADER_CPU_REQUEST
 from iris.cluster.config import CoreweavePlatformConfig, IrisClusterConfig, load_config
-from iris.cluster.platforms.k8s.controller import K8sControllerProvider, _build_controller_deployment
+from iris.cluster.platforms.k8s.controller import (
+    K8sControllerProvider,
+    _build_controller_deployment,
+    _build_controller_state_pvc,
+)
 from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_LABEL_FABRIC,
     CW_LABEL_LEAFGROUP,
@@ -75,8 +80,10 @@ from iris.cluster.platforms.k8s.rbac_manifests import (
     service_account_manifest,
 )
 from iris.cluster.platforms.k8s.service import CloudK8sService
+from iris.cluster.platforms.k8s.types import parse_k8s_cpu
 from iris.cluster.platforms.types import Labels, find_free_port
 from iris.cluster.types import AcceleratorType, CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device
+from iris.resources.state import JobState
 from iris.rpc import job_pb2
 
 # install_kueue is a sibling ops script under lib/iris/scripts/ (not part of the
@@ -108,6 +115,7 @@ _KIND_NODE_LABELS = {
     CW_LABEL_LEAFGROUP: "leafgroup-0",
     CW_LABEL_NVLINK_DOMAIN: "nvlink-domain-0",
 }
+_PREEMPTION_BATCH_SECONDS = 3600
 
 
 @dataclass(frozen=True)
@@ -245,6 +253,8 @@ class ControllerTarget:
             }
         )
         c.ensure_kueue_queues(cfg)
+        c.ensure_priority_classes()
+        self.kubectl.apply_json(_build_controller_state_pvc(namespace=self.namespace))
 
         # fresh=False: a controller restart must NOT wipe the SQLite DB, or an
         # in-flight submitted job vanishes (client then sees the job NOT_FOUND).
@@ -256,7 +266,12 @@ class ControllerTarget:
             fresh=False,
         )
         if local_image:
-            dep["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "IfNotPresent"
+            controller_container = dep["spec"]["template"]["spec"]["containers"][0]
+            controller_container["imagePullPolicy"] = "IfNotPresent"
+            controller_container["resources"] = {
+                "requests": {"cpu": "2", "memory": "4Gi"},
+                "limits": {"memory": "4Gi"},
+            }
         self.kubectl.apply_json(dep)
         self.kubectl.apply_json(
             {
@@ -337,12 +352,17 @@ class KindTarget(ControllerTarget):
         # flavor binds multinode-nvlink-ib (the superset Topology that includes the
         # nvlink.domain level) so the kind-mocked NVLink domain resolves and the gang
         # can exercise BOTH the soft leafgroup and hard nvlink.domain placements.
+        task_resources, _ = self.job_resources()
+        pod_cpu_millicores = int(task_resources.cpu * 1000) + parse_k8s_cpu(LOGSHIP_CPU_REQUEST)
+        if cfg.task_outputs is not None:
+            pod_cpu_millicores += parse_k8s_cpu(OUTPUT_UPLOADER_CPU_REQUEST)
         install_kueue.run_install(
             variant=install_kueue.VARIANT_UPSTREAM,
             kubeconfig=self.kubeconfig,
             chart_version=install_kueue.UPSTREAM_DEFAULT_VERSION,
             with_queues=True,
             cluster_queue=cfg.kubernetes_provider.kueue.cluster_queue,
+            nominal_quotas={"cpu": f"{self.args.replicas * pod_cpu_millicores}m"},
             flavor_topology=install_kueue.MULTINODE_TOPOLOGY_NAME,
             apply=True,
         )
@@ -562,9 +582,80 @@ def submit_gang(controller_url: str, target: ControllerTarget, args: SmokeArgs, 
         coscheduling=CoschedulingConfig(group_by=group_by),
     )
     status = job.wait(timeout=args.timeout, poll_interval=10.0, stream_logs=True, raise_on_failure=False)
-    state = job_pb2.JobState.Name(status.state)
-    logger.info("job %s finished in state %s", job_name, state)
-    return status.state == job_pb2.JOB_STATE_SUCCEEDED
+    logger.info("job %s finished in state %s", job_name, status.state)
+    return status.state is JobState.SUCCEEDED
+
+
+def kueue_preemption_events(target: ControllerTarget) -> dict[str, str]:
+    """Return Kueue Workload preemption event UIDs and object names."""
+    service = target.kubectl
+    assert service is not None
+    events = service.get_events()
+    return {
+        event["metadata"]["uid"]: event["involvedObject"]["name"]
+        for event in events
+        if event.get("reason") == "Preempted" and event.get("involvedObject", {}).get("kind") == "Workload"
+    }
+
+
+def validate_priority_preemption(controller_url: str, target: ControllerTarget, args: SmokeArgs) -> bool:
+    """Fill kind's binding CPU quota with batch, then require interactive to reclaim it."""
+    resources, _ = target.job_resources()
+    client = IrisClient.remote(controller_url, workspace=repo_root(), timeout_ms=300_000)
+    environment = EnvironmentSpec(setup_scripts=[])
+    batch = client.submit(
+        entrypoint=Entrypoint.from_command("python", "-c", f"import time; time.sleep({_PREEMPTION_BATCH_SECONDS})"),
+        name=f"{args.job_name}-preemption-batch",
+        resources=resources,
+        environment=environment,
+        replicas=args.replicas,
+        coscheduling=CoschedulingConfig(group_by=_GROUP_BY),
+        priority_band=job_pb2.PRIORITY_BAND_BATCH,
+    )
+    try:
+        deadline = time.monotonic() + args.timeout
+        while time.monotonic() < deadline:
+            if batch.status().state is JobState.RUNNING:
+                break
+            time.sleep(1)
+        else:
+            logger.error("batch quota filler did not reach RUNNING")
+            return False
+
+        existing_preemptions = kueue_preemption_events(target)
+        interactive = client.submit(
+            entrypoint=Entrypoint.from_command("python", "-c", "print('interactive preemption admitted')"),
+            name=f"{args.job_name}-preemption-interactive",
+            resources=resources,
+            environment=environment,
+            replicas=1,
+            coscheduling=CoschedulingConfig(group_by=_GROUP_BY),
+            priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE,
+        )
+        interactive_status = interactive.wait(
+            timeout=args.timeout,
+            poll_interval=2,
+            raise_on_failure=False,
+            stream_logs=True,
+        )
+        if interactive_status.state is not JobState.SUCCEEDED:
+            logger.error("interactive preemption probe finished in %s", interactive_status.state)
+            return False
+
+        preemption_deadline = time.monotonic() + args.timeout
+        while time.monotonic() < preemption_deadline:
+            current_preemptions = kueue_preemption_events(target)
+            new_preemptions = current_preemptions.keys() - existing_preemptions.keys()
+            if new_preemptions:
+                event_uid = next(iter(new_preemptions))
+                workload_name = current_preemptions[event_uid]
+                logger.info("interactive workload triggered Kueue preemption of Workload %s", workload_name)
+                return True
+            time.sleep(1)
+        logger.error("interactive workload ran without a Kueue Workload preemption event")
+        return False
+    finally:
+        batch.cancel()
 
 
 def run_smoke(cfg: IrisClusterConfig, args: SmokeArgs) -> bool:
@@ -580,6 +671,9 @@ def run_smoke(cfg: IrisClusterConfig, args: SmokeArgs) -> bool:
         if ok and args.target == "kind":
             logger.info("kind mirrors a GB200 NVLink layout; exercising hard nvlink.domain topology")
             ok = submit_gang(url, target, args, group_by=_NVLINK_GROUP_BY, job_name=f"{args.job_name}-nvlink")
+        if ok and args.target == "kind":
+            logger.info("kind exercising binding-quota interactive-over-batch preemption")
+            ok = validate_priority_preemption(url, target, args)
         return ok
     finally:
         if args.keep:

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -116,6 +116,7 @@ _KIND_NODE_LABELS = {
     CW_LABEL_LEAFGROUP: "leafgroup-0",
     CW_LABEL_NVLINK_DOMAIN: "nvlink-domain-0",
 }
+_CLIENT_TIMEOUT_MS = 300_000
 _PREEMPTION_BATCH_SECONDS = 3600
 
 
@@ -565,7 +566,7 @@ def submit_gang(controller_url: str, target: ControllerTarget, args: SmokeArgs, 
         extras=extras,
         env_vars={"GANG_SMOKE_STEPS": str(args.steps), "GANG_SMOKE_PDB": str(args.per_device_batch)},
     )
-    client = IrisClient.remote(controller_url, workspace=repo_root(), timeout_ms=300_000)
+    client = IrisClient.remote(controller_url, workspace=repo_root(), timeout_ms=_CLIENT_TIMEOUT_MS)
     logger.info(
         "submitting gang %r: %d replicas, %s, group_by=%s, extras=%s",
         job_name,
@@ -602,7 +603,7 @@ def kueue_preemption_events(target: ControllerTarget) -> dict[str, str]:
 def validate_priority_preemption(controller_url: str, target: ControllerTarget, args: SmokeArgs) -> bool:
     """Fill kind's binding CPU quota with batch, then require interactive to reclaim it."""
     resources, _ = target.job_resources()
-    client = IrisClient.remote(controller_url, workspace=repo_root(), timeout_ms=300_000)
+    client = IrisClient.remote(controller_url, workspace=repo_root(), timeout_ms=_CLIENT_TIMEOUT_MS)
     environment = EnvironmentSpec(setup_scripts=[])
     batch = client.submit(
         entrypoint=Entrypoint.from_command("python", "-c", f"import time; time.sleep({_PREEMPTION_BATCH_SECONDS})"),


### PR DESCRIPTION
Give CoreWeave ClusterQueues binding GPU and RDMA quotas derived from the
configured scale-group maxima. On cw-rno2a, a 1xH100 interactive workload
remained SchedulingGated for 23 minutes while batch held about 500 of 512 GPUs;
the sentinel quotas never entered Kueue's quota-driven preemption path.

Upgrade cks-kueue to 1.5.0, which contains Kueue 0.18.3, and enable same-cycle
TAS assignment recomputation. Kueue can now recompute a hostname nomination
consumed by an earlier workload in the same scheduling cycle, while binding
accelerator pressure lets LowerPriority select TAS-compatible victims.

In disposable kind, leaf-group and NVLink-domain gangs completed, and
interactive-over-batch admission produced a Kueue Workload preemption event.
Gang restart after head preemption remains scoped to #8774.

Fixes #8781
