### PR TITLE
Cancel unfinished Grug jobs after failed waits

### DIFF
--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -183,6 +183,17 @@ jobs:
           wandb-api-key: ${{ secrets.WANDB_API_KEY }}
           gha-run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+      - name: Cancel unfinished Iris job
+        if: >-
+          always() &&
+          steps.submit.outcome == 'success' &&
+          steps.wait.outcome != 'success' &&
+          steps.submit.outputs.job_id != ''
+        shell: bash -l {0}
+        run: |
+          .venv/bin/iris --config="$IRIS_CONFIG" job cancel --exact \
+            "${{ steps.submit.outputs.job_id }}"
+
       - name: Upload Slack message
         if: failure() || cancelled()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   grug-multislice-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 195
     concurrency:
       group: grug-multislice-smoke
       cancel-in-progress: true
@@ -109,11 +109,12 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GRUG_MULTISLICE_STEPS: ${{ inputs.steps || env.GRUG_MULTISLICE_STEPS }}
 
-      # Bound the wait below the job timeout (180) so a hung ferry fails this
-      # *step* (failure(), runner stays alive for Claude triage) instead of
-      # tripping the job timeout (cancelled(), which force-kills triage). See the
-      # same note in marin-canary-ferry.yaml. Healthy runs finish in ~20m, so 135
-      # leaves 45m for diagnostics + triage.
+      # Bound the wait below the job timeout so a hung ferry fails this step
+      # while the runner remains alive for diagnostics, live triage, and
+      # cancellation. Keep 135m because a healthy child has taken about 60m and
+      # scheduling shares this bound. The 195m job timeout leaves 60m after the
+      # wait: 5m for diagnostics, 30m for triage, and 25m for setup and cleanup.
+      # Upload diagnostics only after cancellation so it cannot consume this window.
       - name: Wait for Grug multislice smoke
         id: wait
         timeout-minutes: 135
@@ -142,6 +143,7 @@ jobs:
       - name: Capture failure diagnostics
         if: failure() || cancelled()
         continue-on-error: true
+        timeout-minutes: 5
         shell: bash -l {0}
         env:
           JOB_ID: ${{ steps.submit.outputs.job_id }}
@@ -157,15 +159,6 @@ jobs:
             --controller-label iris-marin-controller \
             --service-account "$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
             --ssh-key ~/.ssh/google_compute_engine
-
-      - name: Upload diagnostics
-        if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
-        with:
-          name: grug-multislice-diagnostics
-          path: grug-multislice-diagnostics/
-          retention-days: 14
-          if-no-files-found: ignore
 
       - name: Claude triage
         id: claude_triage
@@ -193,6 +186,15 @@ jobs:
         run: |
           .venv/bin/iris --config="$IRIS_CONFIG" job cancel --exact \
             "${{ steps.submit.outputs.job_id }}"
+
+      - name: Upload diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: grug-multislice-diagnostics
+          path: grug-multislice-diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Upload Slack message
         if: failure() || cancelled()

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -112,9 +112,9 @@ jobs:
       # Bound the wait below the job timeout so a hung ferry fails this step
       # while the runner remains alive for diagnostics, live triage, and
       # cancellation. Keep 135m because a healthy child has taken about 60m and
-      # scheduling shares this bound. The 195m job timeout leaves 60m after the
-      # wait: 5m for diagnostics, 30m for triage, and 25m for setup and cleanup.
-      # Upload diagnostics only after cancellation so it cannot consume this window.
+      # scheduling shares this bound. The 195m job budget assigns 135m to the
+      # wait, 5m to diagnostics, 30m to triage, and 25m to setup and cleanup.
+      # Upload diagnostics only after cancellation so upload cannot delay cleanup.
       - name: Wait for Grug multislice smoke
         id: wait
         timeout-minutes: 135


### PR DESCRIPTION
After a failed or timed-out `Wait for Grug multislice smoke` step on a live
runner, cancel the submitted Iris job. Cleanup requires a successful submission
and non-empty job ID, and a successful wait skips it. Failure diagnostics have
a five-minute limit. On scheduled runs, the existing Claude triage step can
inspect the live job for up to 30 minutes before cancellation. Cancellation
uses the captured parent job ID with exact-name matching; Iris stops that parent
and its descendants. Diagnostic upload follows cancellation so it cannot delay
cleanup.

Keep the existing 135-minute wait because a successful child in
[run 33114508707](https://github.com/marin-community/marin/actions/runs/33114508707)
took about 60 minutes after starting. Raise the workflow job timeout from 180
to 195 minutes. The job budget assigns 135 minutes to the wait, five to
diagnostics, 30 to triage, and 25 nominal minutes to setup and cleanup.

[Run 33259534576](https://github.com/marin-community/marin/actions/runs/33259534576)
ended while Iris parent `/runner/iris-run-job-20260829-151124` and its child
remained active. The tree outlived the workflow by more than seven hours.
Manual exact cancellation stopped both; Iris read them back as `killed` after
9 hours 58 minutes of total parent runtime.

The workflow parses locally, repository lint passes, and the affected-test
selector found no package tests for this workflow-only diff. The failure path
has not been exercised in a live workflow. A runner crash, a cancellation that
exhausts GitHub's grace period, or the 195-minute hard limit can still skip
cleanup. This workflow gives Iris no controller-side timeout.

The underlying multislice capacity failure remains tracked in #7429.
