### PR TITLE
Pad cuDNN grouped-Wgrad groups to the alignment the kernel requires

### DIFF
--- a/lib/levanter/src/levanter/grug/_moe/cudnn_wgrad_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/cudnn_wgrad_cute.py
@@ -12,12 +12,15 @@ import jax.numpy as jnp
 
 from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call
 
-# Row count each expert group is padded up to, so every group starts where the kernel's
-# tile loads expect it to.
-_GROUP_ALIGNMENT = 8
+# Token count each expert group is padded up to.
+# Per https://docs.nvidia.com/deeplearning/cudnn/latest/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad.html#bf16-contract,
+# every expert token count must be a multiple of `FIX_PAD_SIZE` (= 256).
+_GROUP_ALIGNMENT = 256
+
 # Vector width the feature (non-grouped) dimensions must divide, which is what the tensor
 # specs below declare to the kernel.
 _FEATURE_ALIGNMENT = 8
+
 _MMA_TILER_MN = (256, 256)
 _CLUSTER_SHAPE_MN = (2, 1)
 
@@ -47,6 +50,17 @@ def _cudnn_modules() -> _CudnnModules:
     )
 
 
+def _assert_group_alignment_compatible_with_kernel() -> None:
+    """Assert `_GROUP_ALIGNMENT` is a multiple of the installed kernel's `FIX_PAD_SIZE`."""
+    kernel_type = _cudnn_modules().kernel_type
+    if _GROUP_ALIGNMENT % kernel_type.FIX_PAD_SIZE != 0:
+        raise RuntimeError(
+            f"cuDNN grouped Wgrad pads groups to {_GROUP_ALIGNMENT} tokens, which is not a multiple "
+            f"of the installed kernel's FIX_PAD_SIZE of {kernel_type.FIX_PAD_SIZE}. See "
+            "https://docs.nvidia.com/deeplearning/cudnn/latest/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad.html#bf16-contract"
+        )
+
+
 @cute_launcher_factory
 def _build_launcher(
     modules,
@@ -72,7 +86,10 @@ def _build_launcher(
 
 
 def pad_grouped_rows(values: jax.Array, group_sizes: jax.Array) -> tuple[jax.Array, jax.Array]:
-    """Insert zero rows so each contiguous expert group ends on an eight-row boundary."""
+    """Insert zero rows so each expert group's token count is a multiple of `_GROUP_ALIGNMENT`.
+
+    Returns the padded rows and the groups' cumulative end offsets.
+    """
     if values.ndim != 2:
         raise ValueError(f"values must be rank 2, got shape={values.shape}")
     if values.shape[0] == 0:
@@ -81,21 +98,21 @@ def pad_grouped_rows(values: jax.Array, group_sizes: jax.Array) -> tuple[jax.Arr
         raise ValueError(f"group_sizes must be a nonempty vector, got shape={group_sizes.shape}")
 
     group_sizes = group_sizes.astype(jnp.int32)
-    padded_group_sizes = ((group_sizes + _GROUP_ALIGNMENT - 1) // _GROUP_ALIGNMENT) * _GROUP_ALIGNMENT
+    aligned_capacity = ((values.shape[0] + _GROUP_ALIGNMENT - 1) // _GROUP_ALIGNMENT) * _GROUP_ALIGNMENT
+    padded_capacity = aligned_capacity + _GROUP_ALIGNMENT * (group_sizes.shape[0] - 1)
+    head_sizes = ((group_sizes[:-1] + _GROUP_ALIGNMENT - 1) // _GROUP_ALIGNMENT) * _GROUP_ALIGNMENT
+    padded_offsets = jnp.concatenate(
+        [jnp.cumsum(head_sizes, dtype=jnp.int32), jnp.full((1,), padded_capacity, jnp.int32)]
+    )
     active_offsets = jnp.cumsum(group_sizes, dtype=jnp.int32)
-    padded_offsets = jnp.cumsum(padded_group_sizes, dtype=jnp.int32)
     active_starts = jnp.concatenate([jnp.zeros((1,), jnp.int32), active_offsets[:-1]])
     padded_starts = jnp.concatenate([jnp.zeros((1,), jnp.int32), padded_offsets[:-1]])
 
-    # At most seven rows are inserted per group. Keep a static worst-case tail so the output shape
-    # does not depend on the runtime routing counts.
-    padded_capacity = values.shape[0] + (_GROUP_ALIGNMENT - 1) * group_sizes.shape[0]
     padded_rows = jnp.arange(padded_capacity, dtype=jnp.int32)
     expert_ids = jnp.sum(padded_rows[:, None] >= padded_offsets[None, :], axis=1, dtype=jnp.int32)
-    safe_expert_ids = jnp.minimum(expert_ids, group_sizes.shape[0] - 1)
-    rows_within_group = padded_rows - padded_starts[safe_expert_ids]
-    source_rows = active_starts[safe_expert_ids] + rows_within_group
-    valid = (expert_ids < group_sizes.shape[0]) & (rows_within_group < group_sizes[safe_expert_ids])
+    rows_within_group = padded_rows - padded_starts[expert_ids]
+    source_rows = active_starts[expert_ids] + rows_within_group
+    valid = rows_within_group < group_sizes[expert_ids]
     source_rows = jnp.clip(source_rows, 0, values.shape[0] - 1)
     padded = jnp.where(valid[:, None], values[source_rows], jnp.zeros((), dtype=values.dtype))
     return padded, padded_offsets

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -101,10 +101,9 @@ def _cute_expert_mlp(
 ) -> Float[Array, "C H"]:
     """Expert MLP on QuACK's SM100 grouped GEMMs plus cuDNN grouped weight gradients.
 
-    The QuACK GEMMs take the active group sizes. They ignore the receiver buffer's trailing
-    padding. The cuDNN weight gradients need padded groups instead. `pad_grouped_rows` extends the
-    last expert's group to the end of the buffer and fills the extra rows with zeros. Zero rows add
-    nothing to a weight gradient, so the result is unchanged.
+    The QuACK GEMMs take the active group sizes. The cuDNN weight gradients need groups padded to
+    a fixed alignment, which `pad_grouped_rows` applies. Trailing padding in the receiver buffer
+    changes neither the output nor the weight gradients.
     """
     del activation_fn, physical_group_sizes
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -101,8 +101,10 @@ def _cute_expert_mlp(
 ) -> Float[Array, "C H"]:
     """Expert MLP on QuACK's SM100 grouped GEMMs plus cuDNN grouped weight gradients.
 
-    The grouped kernels are driven by segment boundaries, so they take the active sizes and
-    mask the receiver buffer's trailing padding rather than charging it to the last expert.
+    The QuACK GEMMs take the active group sizes. They ignore the receiver buffer's trailing
+    padding. The cuDNN weight gradients need padded groups instead. `pad_grouped_rows` extends the
+    last expert's group to the end of the buffer and fills the extra rows with zeros. Zero rows add
+    nothing to a weight gradient, so the result is unchanged.
     """
     del activation_fn, physical_group_sizes
 
@@ -125,9 +127,12 @@ def _quack_grouped_gemm_available() -> bool:
         return False
     try:
         import levanter.grug._moe.sonic_cute  # noqa: F401,PLC0415
-        from levanter.grug._moe.cudnn_wgrad_cute import _cudnn_modules  # noqa: PLC0415
+        from levanter.grug._moe.cudnn_wgrad_cute import _assert_group_alignment_compatible_with_kernel  # noqa: PLC0415
 
-        _ = _cudnn_modules()  # check if compatible cudnn is available
+        # Imports the kernel and pins its padding requirement in one step. A padding mismatch
+        # raises RuntimeError past the handler below, which is the point: it has to surface while
+        # the path is still being chosen, not from inside the expert MLP's backward pass.
+        _assert_group_alignment_compatible_with_kernel()
     except (ImportError, AttributeError) as exc:
         logger.warning(
             "SM100 GPU present but the QuACK/cuDNN grouped-GEMM kernels did not import (%s). "

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1179,19 +1179,23 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(impl
     w_up_gate_reference = w_up_gate.astype(jnp.float32)
     w_down_reference = w_down.astype(jnp.float32)
     cotangent_reference = cotangent.astype(jnp.float32)
-    expected = _dense_moe_output(
-        x_reference,
-        selected_experts,
-        combine_weights_reference,
-        w_up_gate_reference,
-        w_down_reference,
-    )
-    expected_gradients = jax.grad(
-        lambda x, w_up_gate, w_down: jnp.sum(
-            _dense_moe_output(x, selected_experts, combine_weights_reference, w_up_gate, w_down) * cotangent_reference
-        ),
-        argnums=(0, 1, 2),
-    )(x_reference, w_up_gate_reference, w_down_reference)
+    # TPU contracts fp32 inputs at bfloat16 precision by default, which costs far more than the
+    # tolerance below. Both sides of the comparison have to ask for the precision they are checked at.
+    with jax.default_matmul_precision("highest"):
+        expected = _dense_moe_output(
+            x_reference,
+            selected_experts,
+            combine_weights_reference,
+            w_up_gate_reference,
+            w_down_reference,
+        )
+        expected_gradients = jax.grad(
+            lambda x, w_up_gate, w_down: jnp.sum(
+                _dense_moe_output(x, selected_experts, combine_weights_reference, w_up_gate, w_down)
+                * cotangent_reference
+            ),
+            argnums=(0, 1, 2),
+        )(x_reference, w_up_gate_reference, w_down_reference)
 
     batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
     expert_sharding = NamedSharding(mesh, P("expert", None, None))
@@ -1215,7 +1219,7 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(impl
             capacity_factor=2.0,
         )
 
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual, overflow = backend_output(x, w_up_gate, w_down)
         actual_gradients = jax.grad(
             lambda x, w_up_gate, w_down: jnp.sum(backend_output(x, w_up_gate, w_down)[0] * cotangent),

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -18,12 +18,14 @@ from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, PartitionS
 from haliax.nn.ragged_dot import ragged_dot
 
 import levanter.grug.grug_moe as grug_moe
+from levanter.grug._moe.cudnn_wgrad_cute import cudnn_grouped_wgrad, pad_grouped_rows
 from levanter.grug._moe.common import (
     _prepare_moe_dispatch,
     _prepare_moe_dispatch_indices_with_assignment_ids,
     CapacityOverflow,
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
+from levanter.grug._moe.ep_ragged_all_to_all import _quack_grouped_gemm_available
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
@@ -179,6 +181,71 @@ def _skip_without_sonic_gpu_runtime() -> None:
         pytest.skip("raw Sonic optional dependencies are not installed")
     if not any(device.platform == "gpu" for device in jax.devices()):
         pytest.skip("raw Sonic triton_call tests require a GPU")
+
+
+def _wgrad_padding_reference(values: np.ndarray, sizes: list[int], offsets: list[int]) -> np.ndarray:
+    """Each group's rows copied to the start named by ``offsets``, every other row zero."""
+    padded = np.zeros((offsets[-1], values.shape[1]), dtype=values.dtype)
+    source = 0
+    for start, size in zip([0, *offsets[:-1]], sizes, strict=True):
+        padded[start : start + size] = values[source : source + size]
+        source += size
+    return padded
+
+
+@pytest.mark.parametrize(
+    "capacity,sizes,expected_offsets",
+    [
+        (1024, [300, 400, 200], [512, 1024, 1536]),
+        (256, [33, 32, 38, 25], [256, 512, 768, 1024]),
+        (100, [100], [256]),
+        (700, [0, 700, 0], [0, 768, 1280]),
+        (512, [256, 256], [256, 768]),
+    ],
+)
+def test_wgrad_padding_satisfies_both_halves_of_the_kernel_contract(capacity, sizes, expected_offsets):
+    """Every extent is a multiple of 256, the final offset is the buffer's row count, and each
+    group holds its own rows with zeros in the gaps.
+
+    The offsets are spelled out rather than derived from ``_GROUP_ALIGNMENT`` so that lowering the
+    constant -- the regression this padding exists to prevent -- fails here on CPU.
+    """
+    values = np.arange(1, capacity * 2 + 1, dtype=np.float32).reshape(capacity, 2)
+    padded, offsets = pad_grouped_rows(jnp.asarray(values), jnp.array(sizes, dtype=jnp.int32))
+
+    assert list(np.asarray(offsets)) == expected_offsets
+    assert int(offsets[-1]) == padded.shape[0]
+    np.testing.assert_array_equal(np.asarray(padded), _wgrad_padding_reference(values, sizes, expected_offsets))
+
+
+def test_cudnn_grouped_wgrad_matches_a_per_group_reference_on_gpu():
+    """The kernel must equal per-group ``lhs.T @ rhs`` when no group's token count is a multiple of
+    the alignment.
+
+    That is the case the padding exists for: a misaligned group addresses past its own rows and
+    contracts its successor's. The padding tests above pin the offsets and the zero fill, but they
+    never multiply anything, so only this comparison sees a wrong weight gradient.
+    """
+    if not _quack_grouped_gemm_available():
+        pytest.skip("cuDNN grouped Wgrad needs an SM100 GPU and levanter's gpu extra")
+
+    group_sizes = [300, 400, 200, 124]
+    rows = sum(group_sizes)
+    lhs = jax.random.normal(jax.random.key(0), (rows, 128), dtype=jnp.bfloat16)
+    rhs = jax.random.normal(jax.random.key(1), (rows, 64), dtype=jnp.bfloat16)
+
+    actual = jax.jit(cudnn_grouped_wgrad)(lhs, rhs, jnp.array(group_sizes, dtype=jnp.int32))
+
+    lhs_reference = np.asarray(lhs, dtype=np.float32)
+    rhs_reference = np.asarray(rhs, dtype=np.float32)
+    actual = np.asarray(actual, dtype=np.float32)
+    assert actual.shape == (len(group_sizes), lhs.shape[1], rhs.shape[1])
+    start = 0
+    for expert, size in enumerate(group_sizes):
+        expected = lhs_reference[start : start + size].T @ rhs_reference[start : start + size]
+        error = np.max(np.abs(actual[expert] - expected)) / np.max(np.abs(expected))
+        assert error < _BF16_MOE_RELATIVE_TOLERANCE, f"expert {expert} relative error {error}"
+        start += size
 
 
 def test_interleaved_receiver_ranks_allocate_capacity_round_robin_over_sources():


### PR DESCRIPTION
- Pad every expert group to 256 tokens instead of 8, and give the last group every remaining row so the final offset is the token total.
- Add `_assert_group_alignment_compatible_with_kernel`, checked at backend selection against the installed kernel's `FIX_PAD_SIZE`.
- Test `pad_grouped_rows` against literal expected offsets, and `cudnn_grouped_wgrad` against an fp32 per-group reference.

The BF16 contract requires every expert token count to be a multiple of 256, and the final offset to equal the token total: https://docs.nvidia.com/deeplearning/cudnn/latest/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad.html#bf16-contract. `_GROUP_ALIGNMENT` was 8, and the last group ended at its own rounded size rather than the buffer's end, so neither clause held. dw13 and dw2 were silently wrong for every expert but the last, on every run of the ragged transport with the cute expert MLP.

The deployed hero run is not affected: it runs the pooled-wave backend, whose expert MLP is a plain `jnp.einsum` with no grouped GEMM. This corrupts the ragged all-to-all backend on `main`, which routes dw13 and dw2 through this kernel, so it blocks migrating the hero onto that backend.

Closes #8339. That issue was closed as completed on 2026-08-17, but the fix it validated (alignment 64, on the `marin-ep-8081` measurement branch) never merged, and the correction comment on it establishes that 64 would still violate the contract. `main` reached `_GROUP_ALIGNMENT = 8` independently when #8549 landed the reworked backend.

Measured on GB200 through the 4-GPU ragged-EP gate, which checks gradients against an exact fp32 dense reference. Same gate, same seeds, only the padding changed:

| seed | ragged grad error before | after | ring reference |
|---|---|---|---|
| 0 | 0.0259 | 0.000807 | 0.000673 |
| 1 | 0.0301 | 0.000443 | 0.000604 |
| 2 | 0.0229 | 0.000539 | 0.000738 |
| 3 | 0.0255 | 0.000515 | 0.000532 |

A 30-70x reduction to the ring backend's own floor. A full hero-shape EP64 restore scores 24.016 MFU against 24.07 before it, inside run-to-run noise.
