### PR TITLE
[finelog] Re-register tables after catalog replacement

### DIFF
--- a/infra/pulumi/tests/test_finelog.py
+++ b/infra/pulumi/tests/test_finelog.py
@@ -15,11 +15,7 @@ from iac.kubernetes.finelog import FinelogServerArgs, finelog_resource_args
 from rigging.provenance import Provenance
 
 
-def _args(
-    cache_storage: K8sCacheStorage = K8sCacheStorage.PERSISTENT_VOLUME,
-    *,
-    cache_pvc_name: str | None = None,
-) -> FinelogServerArgs:
+def _args(cache_storage: K8sCacheStorage = K8sCacheStorage.PERSISTENT_VOLUME) -> FinelogServerArgs:
     config = FinelogConfig(
         name="finelog-cw",
         port=10001,
@@ -29,7 +25,6 @@ def _args(
             k8s=K8sDeployment(
                 namespace="iris",
                 cache_storage=cache_storage,
-                cache_pvc_name=cache_pvc_name,
                 storage_gb=250,
             )
         ),

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -93,6 +93,13 @@ permanent rejection or retention eviction. Hub copies can be stale during the fa
 they diagnose, so operators check metric freshness and query the regional namespace
 when the hub or network is unavailable.
 
+Client-owned namespaces register lazily on their first write. A long-lived `Table`
+handle that receives `NOT_FOUND` from `WriteRows` retains the failed batch, registers
+its schema again, and retries. This lets producers recover when a node-local Finelog
+restart replaces the catalog. Producers running a client without this behavior need
+a restart, which creates a new `Table` handle and repeats lazy registration, or a
+manual `RegisterTable` call before their writes resume.
+
 Only the k8s backend can forward — it projects the key through a Secret. The gcp
 backend refuses, because its only channel to the server is world-readable
 startup-script metadata.

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -240,10 +240,12 @@ class Table:
     LogClient drains every Table.
 
     Registration is deferred to the flush thread: if a ``registrar`` is given,
-    it is invoked once before the first send to register the namespace and
-    return its effective schema. A failing registration is treated like any
-    other flush failure (retried with backoff, or the batch dropped on a
-    non-retryable error) and never blocks the caller that created the Table.
+    it is invoked before the first send to register the namespace and return
+    its effective schema. If a later write reports that the namespace no longer
+    exists, the same batch is retained while the table registers again. A
+    failing registration is treated like any other flush failure (retried with
+    backoff, or the batch dropped on a non-retryable error) and never blocks the
+    caller that created the Table.
     """
 
     def __init__(
@@ -485,7 +487,14 @@ class Table:
             batch = _rows_to_record_batch(rows, self._arrow_schema, self._schema)
             self._flusher(self._namespace, batch)
         except Exception as exc:
-            retryable = is_retryable_error(exc) or isinstance(exc, (ConnectionError, OSError, TimeoutError))
+            namespace_missing = self._registrar is not None and (
+                isinstance(exc, NamespaceNotFoundError) or (isinstance(exc, ConnectError) and exc.code == Code.NOT_FOUND)
+            )
+            if namespace_missing:
+                self._registered = False
+            retryable = (
+                namespace_missing or is_retryable_error(exc) or isinstance(exc, (ConnectionError, OSError, TimeoutError))
+            )
             summary = _format_exc_summary(exc)
             logger.warning(
                 "Table(%s) send failure (%d rows, retryable=%s): %s",

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -267,10 +267,10 @@ class Table:
         self._arrow_schema = schema_to_arrow(schema)
         self._flusher = flusher
         self._querier = querier
-        # When set, the flush thread calls this once before its first send to
-        # register the namespace; the returned effective schema replaces the
-        # locally-requested one for Arrow encoding. ``None`` means the
-        # namespace is already registered server-side (e.g. ``log``).
+        # When set, the flush thread calls this before its first send and again
+        # after WriteRows reports a missing namespace. The returned effective
+        # schema replaces the locally-requested one for Arrow encoding. ``None``
+        # means the namespace is registered server-side (e.g. ``log``).
         self._registrar = registrar
         self._registered = registrar is None
         self._flush_interval = flush_interval

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -87,9 +87,8 @@ class K8sDeployment:
     cache_storage: K8sCacheStorage = K8sCacheStorage.PERSISTENT_VOLUME
     storage_class: str | None = None
     storage_gb: int = 200
-    # Existing replacement claim to adopt and mount instead of `<name>-cache`.
-    # With node-local storage, keeps that claim managed but unmounted for one
-    # transition update so Pulumi can retain it safely.
+    # Existing claim to adopt and mount instead of `<name>-cache` when using
+    # persistent-volume storage.
     cache_pvc_name: str | None = None
     cpu_request: str = "2"
     cpu_limit: str = "8"
@@ -111,6 +110,8 @@ class K8sDeployment:
             raise ValueError("deployment.k8s.storage_gb must be > 0")
         if self.cache_storage is K8sCacheStorage.NODE_LOCAL and self.storage_class is not None:
             raise ValueError("deployment.k8s.storage_class cannot be set with node-local cache storage")
+        if self.cache_storage is K8sCacheStorage.NODE_LOCAL and self.cache_pvc_name is not None:
+            raise ValueError("deployment.k8s.cache_pvc_name cannot be set with node-local cache storage")
 
 
 @dataclass(frozen=True)

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -620,6 +620,43 @@ def test_get_table_retries_transient_registration_failure(tracked_clients, monke
         client.close()
 
 
+def test_get_table_reregisters_after_server_loses_namespace(tracked_clients, monkeypatch):
+    """A server-side catalog reset must not strand a long-lived Table handle."""
+    monkeypatch.setattr(log_client_mod, "_BACKOFF_INITIAL", 1e-9)
+    monkeypatch.setattr(log_client_mod, "_BACKOFF_MAX", 1e-9)
+
+    catalog_registered = False
+    real_register = _FakeStatsServiceClient.register_table
+    real_write = _FakeStatsServiceClient.write_rows
+
+    def register(self, request):
+        nonlocal catalog_registered
+        catalog_registered = True
+        return real_register(self, request)
+
+    def require_registration(self, request):
+        if not catalog_registered:
+            raise ConnectError(Code.NOT_FOUND, f'namespace "{request.namespace}" is not registered')
+        return real_write(self, request)
+
+    monkeypatch.setattr(_FakeStatsServiceClient, "register_table", register)
+    monkeypatch.setattr(_FakeStatsServiceClient, "write_rows", require_registration)
+    client = LogClient.connect("http://h:1")
+    try:
+        table = client.get_table("iris.worker", WorkerStat)
+        table.write([WorkerStat(worker_id="w-1", timestamp_ms=1, mem_bytes=128)])
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
+
+        catalog_registered = False
+        table.write([WorkerStat(worker_id="w-2", timestamp_ms=2, mem_bytes=256)])
+
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
+        rows = [_decode_ipc_table(request.arrow_ipc) for request in tracked_clients[0].writes]
+        assert pa.concat_tables(rows).column("worker_id").to_pylist() == ["w-1", "w-2"]
+    finally:
+        client.close()
+
+
 def test_table_query_round_trips(tracked_clients):
     client = LogClient.connect("http://h:1")
     try:

--- a/lib/finelog/tests/test_config.py
+++ b/lib/finelog/tests/test_config.py
@@ -137,7 +137,7 @@ def test_derive_endpoint_uri_k8s() -> None:
     assert metadata == {"port": "10001"}
 
 
-def test_load_config_allows_pvc_retention_during_node_local_transition(tmp_path: Path) -> None:
+def test_load_config_rejects_pvc_name_with_node_local_storage(tmp_path: Path) -> None:
     cfg_path = tmp_path / "node-local.yaml"
     _write_config(
         cfg_path,
@@ -155,10 +155,8 @@ def test_load_config_allows_pvc_retention_during_node_local_transition(tmp_path:
         """,
     )
 
-    cfg = load_finelog_config(str(cfg_path))
-
-    assert cfg.deployment.k8s is not None
-    assert cfg.deployment.k8s.cache_pvc_name == "finelog-cache"
+    with pytest.raises(ValueError, match="cache_pvc_name cannot be set with node-local cache storage"):
+        load_finelog_config(str(cfg_path))
 
 
 def test_auth_layers_serialize_to_finelog_policy_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Recover long-lived Finelog `Table` handles after a server starts with a replacement catalog. When `WriteRows` returns namespace `NOT_FOUND`, the handle keeps the failed batch queued, clears its registered state, runs lazy schema registration again, and retries the same batch. The forwarding server remains independent of Iris-specific namespace definitions.

Before this change, the cw-us-east-08a Iris controller stayed healthy through the node-local Finelog rollout but dropped each new `iris.task_state` batch. The hub's last state row was 2026-08-30 16:19:09 UTC, which triggered `TrainingRunHealthDegraded` with reason `iris_state_stale`; the hero coordinator and 176 training tasks remained running, and Levanter metrics stayed fresh. Manual registration restored all seven Iris namespaces on each of the three regional forwarders, and fresh state rows from every cluster reached the hub by 16:51 UTC without restarting Iris or Finelog.

Node-local deployment configuration now rejects `cache_pvc_name` because that storage mode does not render or manage a claim. Producers running a client without the re-registration behavior still require a manual `RegisterTable` call or a restart that creates a new handle and runs lazy registration on its first write.

The complete Finelog suite passes 116 tests, the Pulumi resource tests pass 3 tests, and lint and type checking pass.

Incident record: https://echo.oa.dev/wiki/285

Follow-up to #8789.
