### PR TITLE
[grafana] Preserve collector failures at counter boundaries

### DIFF
--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -418,13 +418,22 @@ WITH base AS (
     WHERE timestamp_ms >= {start_ms}
       AND name = 'prometheus_source_available'
       AND json_get(attributes_json, 'metric_source') = 'vllm'
-), collection_failure_totals AS (
+), collection_failure_increments AS (
     SELECT COALESCE(json_get(attributes_json, 'stage'), 'unknown') AS stage,
-           SUM(delta) AS value
-    FROM increments
-    WHERE name = 'prometheus_stage_failures'
+           CASE
+               WHEN previous_value IS NULL THEN NULL
+               WHEN value < previous_value THEN value
+               ELSE value - previous_value
+           END AS delta,
+           CASE WHEN previous_value IS NULL AND value > 0 THEN 1 ELSE 0 END AS uncertain
+    FROM cumulative_samples
+    WHERE timestamp_ms >= {start_ms}
+      AND name = 'prometheus_stage_failures'
       AND json_get(attributes_json, 'metric_source') = 'vllm'
-      AND delta > 0
+), collection_failure_totals AS (
+    SELECT stage, SUM(delta) AS value
+    FROM collection_failure_increments
+    WHERE delta > 0
     GROUP BY 1
 ), dropped_sample_totals AS (
     SELECT COALESCE(json_get(attributes_json, 'drop_reason'), 'unknown') AS drop_reason,
@@ -441,6 +450,7 @@ WITH base AS (
            CASE
                WHEN COALESCE(unavailable_polls, 0) > 0
                  OR failure_stages > 0
+                 OR uncertain_failures > 0
                  OR drop_reasons > 0
                THEN 'incomplete'
                WHEN polls > 0 THEN 'healthy'
@@ -448,6 +458,7 @@ WITH base AS (
            END AS status
     FROM collector_polls
     CROSS JOIN (SELECT COUNT(*) AS failure_stages FROM collection_failure_totals)
+    CROSS JOIN (SELECT COUNT(*) AS uncertain_failures FROM collection_failure_increments WHERE uncertain > 0)
     CROSS JOIN (SELECT COUNT(*) AS drop_reasons FROM dropped_sample_totals)
 ), producer_samples AS (
     SELECT DISTINCT origin_cluster, service, resource_attributes_json, timestamp_ms

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -429,6 +429,53 @@ def test_query_health_only_reports_healthy_without_serving_freshness():
     assert _one(rows, "freshness", "telemetry", "latest_sample_age")["status"] == "no_data"
 
 
+def test_query_marks_positive_failure_without_predecessor_incomplete_without_delta():
+    records = [
+        _record(
+            "a",
+            "prometheus_source_available",
+            1,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm"),
+        ),
+        _record(
+            "a",
+            "prometheus_stage_failures",
+            1,
+            135_000,
+            _attributes("cumulative_snapshot", metric_source="vllm", stage="process"),
+        ),
+    ]
+
+    health = [row for row in _query_rows(_database(records)) if row["section"] == "telemetry_health"]
+
+    assert [(row["metric"], row["series"], row["value"], row["status"]) for row in health] == [
+        ("collector", "all resources", 1.0, "incomplete"),
+    ]
+
+
+def test_query_counts_positive_failure_after_reset():
+    failure = _attributes("cumulative_snapshot", metric_source="vllm", stage="process")
+    records = [
+        _record(
+            "a",
+            "prometheus_source_available",
+            1,
+            135_000,
+            _attributes("current_snapshot", metric_source="vllm"),
+        ),
+        _record("a", "prometheus_stage_failures", 5, 105_000, failure),
+        _record("a", "prometheus_stage_failures", 1, 135_000, failure),
+    ]
+
+    health = [row for row in _query_rows(_database(records)) if row["section"] == "telemetry_health"]
+
+    assert [(row["metric"], row["series"], row["value"], row["status"]) for row in health] == [
+        ("collector", "all resources", 1.0, "incomplete"),
+        ("collection failures", "process", 1.0, None),
+    ]
+
+
 def test_query_reports_combined_collector_loss_across_replicas():
     current = _attributes("current_snapshot", metric_source="vllm")
     records = [


### PR DESCRIPTION
Mark collector health `incomplete` when a positive in-window stage-failure sample has no predecessor in the bounded scan. Keep that value out of the numeric failure total because its pre-window portion is unknown.

Count a positive post-reset value as the definite contribution since the reset. Ordinary increases keep `value - previous_value`; shared token, outcome, histogram, and preemption counter rules are unchanged.

On current `origin/main`, both boundary regressions reported `healthy`; the final focused suite passes 19 tests. The generated SQL passed the production Finelog planner and returned the ordered ten-column response.

Fixes #8798
