### PR TITLE
[grafana] Remove TPU ferry minimum duration

### DIFF
--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -61,7 +61,7 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from=None,
         active_until=None,
         overdue_grace_minutes=300,
-        expected_min_seconds=60 * 60,
+        expected_min_seconds=0,
         expected_max_seconds=195 * 60,
     ),
     NightlyLane(


### PR DESCRIPTION
Stop classifying successful TPU ferry runs as unhealthy solely because they
finish in under one hour. A [healthy
run](https://github.com/marin-community/marin/actions/runs/33294173253) completed
in about 14 minutes, while a [capacity-exhausted
run](https://github.com/marin-community/marin/actions/runs/32939622815) that ran
no training took about 16 minutes. A lower duration bound cannot distinguish
these outcomes.

Set the minimum to zero and retain the 195-minute maximum. The workflow's step
and loss checks still gate training quality.
[#8718](https://github.com/marin-community/marin/pull/8718) must land first
because it makes capacity exhaustion fail explicitly.
