### PR TITLE
[eval] Preserve Iris capability URLs in Harbor jobs

### DIFF
--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -26,6 +26,7 @@ from harbor_config.models.agent.name import AgentName  # pyrefly: ignore[missing
 from harbor_config.models.job.config import DatasetConfig  # pyrefly: ignore[missing-import]
 from harbor_config.models.trial.config import AgentConfig  # pyrefly: ignore[missing-import]
 from pydantic import BaseModel, ConfigDict, ValidationError
+from upath import UPath  # pyrefly: ignore[missing-import]  # installed by external driver
 
 _HOSTED_VLLM_PROVIDER = "hosted_vllm"
 _HOSTED_VLLM_DISPLAY_NAME = "Hosted vLLM"
@@ -283,7 +284,7 @@ def _effective_config(config: JobConfig, overlay: RuntimeOverlay) -> JobConfig:
     effective = config.model_copy(
         update={
             "job_name": overlay.job_name,
-            "jobs_dir": overlay.jobs_dir,
+            "jobs_dir": UPath(overlay.jobs_dir),
             "agents": [agent],
             "datasets": [dataset],
         }

--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -288,7 +288,7 @@ def _effective_config(config: JobConfig, overlay: RuntimeOverlay) -> JobConfig:
             "datasets": [dataset],
         }
     )
-    return JobConfig.model_validate(effective.model_dump(mode="json"), extra="forbid")
+    return effective
 
 
 def _stable_config(config: JobConfig) -> JobConfig:

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -452,12 +452,14 @@ def test_effective_aime_job_preserves_capability_url_in_live_config_and_redacts_
         "from marin.evaluation.harbor.trial_driver import effective_job_config; "
         f"config=effective_job_config(Path({str(policy_path)!r}), Path({str(overlay_path)!r})); "
         'print(json.dumps({"api_base": config.agents[0].kwargs["api_base"], '
+        '"job_dir": str(config.jobs_dir / config.job_name), '
         '"serialized": config.model_dump(mode="json")}))'
     )
 
     result = json.loads(_external_python("-c", script).stdout)
 
     assert result["api_base"] == capability_url
+    assert result["job_dir"] == str(tmp_path / "jobs" / "runtime-job")
     serialized = result["serialized"]
     assert serialized["agents"][0]["kwargs"]["api_base"] == (
         "https://iris.example/proxy/t/<redacted>/serve.inference-test/v1"

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -427,6 +427,46 @@ def test_effective_job_applies_runtime_precedence_and_validates_nested_updates(t
     }
 
 
+def test_effective_aime_job_preserves_capability_url_in_live_config_and_redacts_dump(tmp_path, checked_policies):
+    capability_token = "dummy-capability-token"
+    capability_url = f"https://iris.example/proxy/t/{capability_token}/serve.inference-test/v1"
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(checked_policies["aime-smoke.yaml"]["stable_policy_json"])
+    overlay_path = tmp_path / "overlay.json"
+    overlay_path.write_text(
+        json.dumps(
+            {
+                "job_name": "runtime-job",
+                "jobs_dir": str(tmp_path / "jobs"),
+                "dataset_path": str(tmp_path / "tasks"),
+                "endpoint_url": capability_url,
+                "served_model": "served-qwen",
+                "task_limit": 3,
+                "model_agent_kwargs": {},
+            }
+        )
+    )
+    script = (
+        "import json; "
+        "from pathlib import Path; "
+        "from marin.evaluation.harbor.trial_driver import effective_job_config; "
+        f"config=effective_job_config(Path({str(policy_path)!r}), Path({str(overlay_path)!r})); "
+        'print(json.dumps({"api_base": config.agents[0].kwargs["api_base"], '
+        '"serialized": config.model_dump(mode="json")}))'
+    )
+
+    result = json.loads(_external_python("-c", script).stdout)
+
+    assert result["api_base"] == capability_url
+    serialized = result["serialized"]
+    assert serialized["agents"][0]["kwargs"]["api_base"] == (
+        "https://iris.example/proxy/t/<redacted>/serve.inference-test/v1"
+    )
+    serialized_json = json.dumps(serialized)
+    assert capability_token not in serialized_json
+    assert "<redacted>" in serialized_json
+
+
 @pytest.mark.parametrize(
     "document",
     _INVALID_SOURCE_DOCUMENTS.values(),


### PR DESCRIPTION
Marin rebuilt Harbor's live `JobConfig` by serializing and revalidating it. Harbor correctly redacted the Iris capability token during serialization, so the live agent received a literal `<redacted>` URL and every request returned 401.

Keep the already validated models live, and convert only `jobs_dir` to Harbor's required `UPath`. Serialized configs still redact the dummy token. This changes Marin only; stable Harbor remains `83709b4aa03c2b9a92d8d78a8c12157b31d1e461`, with no pin change or promotion.

Local evidence:

- The focused regression failed before the fix because the live `api_base` contained `<redacted>`, then passed with the exact dummy capability URL live and the token absent from `model_dump(mode="json")`.
- The final focused regression passed and also proved `jobs_dir / job_name` composes.
- The integration file reported 14 passed and 1 failed. The sole failure is the unchanged `attempt_index` mismatch in `test_terminus_policies_retry_transient_endpoint_errors`; this PR does not change it.
- The affected runner and full pre-commit gate passed. Semantic review found no issues.
- High-tier GOAL review found no material candidate issue in the successful Claude and Codex passes. Gemini was unavailable after one bounded retry.

Production evidence at exact Marin `f163302dfbcedddbf83e01543e0894d5a2338c0c` and stable Harbor `83709b4aa03c2b9a92d8d78a8c12157b31d1e461`:

- AIME run `20260831-040512-qwen3-0.6b-aime-smoke-3b20` completed successfully on `v5litepod-4` in `us-west4`.
- Coverage was 8/8 scored (100%), with no unanswered items or recorded errors.
- Metrics were nonempty: attempted 8, total 8, accuracy 0.0, mean reward 0.0, and solved 0.0.
- The complete 1,556-line Iris log contained eight successful evaluation requests and no `401` or `Unauthorized`.
- The orchestrator is terminal succeeded, the inference child is terminal after launcher cleanup, and the exact prefix has no running jobs.
- Durable record: `gs://marin-eval-metadata/evals/20260831-040512-qwen3-0.6b-aime-smoke-3b20/record.json`.

The earlier run at `88978b607f` failed on `jobs_dir` before creating a trial or making an evaluation request. Its lack of 401 text was not authentication evidence.

Echo incident: https://echo.oa.dev/wiki/290

Part of #8323
