### PR TITLE
[grafana] Remove CoreWeave ferry minimum duration

### DIFF
--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -79,7 +79,7 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from=None,
         active_until=None,
         overdue_grace_minutes=300,
-        expected_min_seconds=15 * 60,
+        expected_min_seconds=0,
         expected_max_seconds=40 * 60,
     ),
     NightlyLane(


### PR DESCRIPTION
Stop classifying successful CoreWeave ferry runs as unhealthy solely because they finish in under 15 minutes. Scheduled run [33317151515](https://github.com/marin-community/marin/actions/runs/33317151515) completed in 834 seconds; submission, execution, and metric validation all passed.

Set the minimum to zero and retain the 40-minute maximum. The workflow still requires successful job completion, at least 40 training steps, and loss at or below 10.0.
