### PR TITLE
[grafana] Show active nightlies as running

### DIFF
--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -189,6 +189,11 @@
               "type": "string"
             },
             {
+              "selector": "status",
+              "text": "status",
+              "type": "string"
+            },
+            {
               "selector": "duration_state",
               "text": "duration_state",
               "type": "string"

--- a/infra/grafana/marin-infra-panel/src/components/NightlyMatrix.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/NightlyMatrix.tsx
@@ -10,6 +10,7 @@ interface Props { frames: DataFrame[]; width: number; height: number }
 
 const GROUP_NAMES: Record<string, string> = { marin: 'Marin', forks: 'Forks' };
 const SUBGROUP_NAMES: Record<string, string> = { training: 'Training', data: 'Data', cluster: 'Cluster', evaluation: 'Evaluation', rl: 'RL', inference: 'Inference' };
+const SUMMARY_ORDER = ['passed', 'running', 'slow', 'failed', 'no run', 'data unavailable', 'not due'];
 
 function formatDuration(seconds?: number): string {
   if (seconds === undefined) {return '—';}
@@ -18,16 +19,26 @@ function formatDuration(seconds?: number): string {
   return minutes < 60 ? `${minutes}m` : `${Math.floor(minutes / 60)}h${String(minutes % 60).padStart(2, '0')}`;
 }
 
-function status(cell: NightlyCell): { icon: string; tone: string; label: string } {
+function status(cell: NightlyCell): { icon: string; tone: string; label: string; summary?: string } {
   if (cell.state === 'run') {
-    if (!cell.healthy) {return { icon: '×', tone: '#f43f5e', label: cell.conclusion ?? 'failed' };}
-    if (cell.durationState === 'very-slow') {return { icon: '✓', tone: '#b45309', label: 'very slow success' };}
-    if (cell.durationState === 'slow') {return { icon: '✓', tone: '#92400e', label: 'slow success' };}
-    return { icon: '✓', tone: '#064e3b', label: 'success' };
+    if (cell.runStatus === 'queued' || cell.runStatus === 'in_progress') {
+      return { icon: '↻', tone: '#1d4ed8', label: 'Running', summary: 'running' };
+    }
+    if (!cell.healthy) {
+      const detail = cell.durationState === 'too-short' ? 'too short' : cell.conclusion;
+      return { icon: '×', tone: '#f43f5e', label: detail ? `Failed (${detail})` : 'Failed', summary: 'failed' };
+    }
+    if (cell.durationState === 'very-slow') {
+      return { icon: '⚠', tone: '#b45309', label: 'Very slow', summary: 'slow' };
+    }
+    if (cell.durationState === 'slow') {
+      return { icon: '⚠', tone: '#92400e', label: 'Slow', summary: 'slow' };
+    }
+    return { icon: '✓', tone: '#064e3b', label: 'Passed', summary: 'passed' };
   }
-  if (cell.state === 'missing') {return { icon: '!', tone: '#9f1239', label: 'missing' };}
-  if (cell.state === 'unavailable') {return { icon: '!', tone: '#9a3412', label: 'source unavailable' };}
-  if (cell.state === 'not-yet-due') {return { icon: '◷', tone: '#1e3a8a', label: 'not yet due' };}
+  if (cell.state === 'missing') {return { icon: '!', tone: '#9f1239', label: 'No run', summary: 'no run' };}
+  if (cell.state === 'unavailable') {return { icon: '?', tone: '#9a3412', label: 'Data unavailable', summary: 'data unavailable' };}
+  if (cell.state === 'not-yet-due') {return { icon: '◷', tone: '#475569', label: 'Not due', summary: 'not due' };}
   return { icon: '–', tone: 'transparent', label: cell.state.replaceAll('-', ' ') };
 }
 
@@ -53,15 +64,23 @@ export function NightlyMatrix({ frames, width, height }: Props) {
   const dates = [...new Set(cells.map((cell) => cell.date))].sort().reverse();
   const byKey = new Map(cells.map((cell) => [`${cell.laneId}\u0000${cell.date}`, cell]));
   const today = dates[0];
-  const todayCells = cells.filter((cell) => cell.date === today && cell.due);
+  const todayCounts = new Map<string, number>();
+  for (const cell of cells.filter((cell) => cell.date === today)) {
+    const summary = status(cell).summary;
+    if (summary) {todayCounts.set(summary, (todayCounts.get(summary) ?? 0) + 1);}
+  }
+  const todaySummary = SUMMARY_ORDER
+    .filter((summary) => todayCounts.has(summary))
+    .map((summary) => `${todayCounts.get(summary)} ${summary}`)
+    .join(' · ');
   const groups = spans(lanes, (lane) => lane.group);
   const subgroups = spans(lanes, (lane) => `${lane.group}/${lane.subgroup}`);
   const border = theme.colors.border.weak;
   return (
     <section className={css`width:${width}px;min-height:${height}px;color:${theme.colors.text.primary};padding:2px 4px;`} aria-label="Nightly regression status">
-      <div className={css`display:flex;align-items:baseline;justify-content:space-between;margin:0 2px 5px;font-size:13px;color:${theme.colors.text.secondary};`}>
-        <span><strong className={css`color:${theme.colors.text.primary};font-size:16px;`}>Nightly regressions</strong>{todayCells.length > 0 && ` · Today: ${todayCells.filter((cell) => cell.healthy).length}/${todayCells.length} healthy`}</span>
-        <span>✓ healthy · amber slow · × failed · ! missing</span>
+      <div className={css`display:flex;flex-wrap:wrap;gap:4px 12px;align-items:baseline;justify-content:space-between;margin:0 2px 5px;font-size:13px;color:${theme.colors.text.secondary};`}>
+        <span><strong className={css`color:${theme.colors.text.primary};font-size:16px;`}>Nightly regressions</strong>{todaySummary && ` · Today: ${todaySummary}`}</span>
+        <span role="note" aria-label="Nightly state legend">✓ Passed · ↻ Running · ⚠ Slow · × Failed · ! No run · ? Data unavailable · ◷ Not due</span>
       </div>
       <table className={css`width:100%;border-collapse:separate;border-spacing:2px;table-layout:fixed;font-size:12px;`}>
         <caption className={css`position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);`}>Seven UTC days of scheduled regression status and duration by lane</caption>

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -35,6 +35,29 @@ function frame(refId: string, rows: Array<Record<string, unknown>>) {
   });
 }
 
+test('nightly matrix presents active runs as running and summarizes states by category', () => {
+  const base = {
+    date: '2026-08-31', label: 'Nightly', group: 'marin', subgroup: 'training', state: 'run',
+    duration_state: 'normal', conclusion: null, url: 'https://example/run', workflow_url: 'https://example/workflow',
+    healthy: false, due: true, source_error: null,
+  };
+  const rows = [
+    { ...base, lane_id: 'queued', lane: 'Queued', label: 'Queued nightly', status: 'queued', duration_seconds: null, lane_order: 0 },
+    { ...base, lane_id: 'active', lane: 'Active', label: 'Active nightly', status: 'in_progress', duration_seconds: 600, lane_order: 1 },
+    { ...base, lane_id: 'failed', lane: 'Failed', label: 'Failed nightly', status: 'completed', conclusion: 'failure', duration_seconds: 600, lane_order: 2 },
+  ];
+
+  render(<NightlyMatrix frames={[frame('N', rows)]} width={1200} height={300} />);
+
+  expect(screen.getAllByRole('link', { name: /Running/ })).toHaveLength(2);
+  expect(screen.getByRole('link', { name: /Active nightly.*Running.*10m/ })).toBeInTheDocument();
+  expect(screen.getByText(/Today: 2 running · 1 failed/)).toBeInTheDocument();
+  const legend = screen.getByRole('note', { name: 'Nightly state legend' });
+  for (const state of ['Passed', 'Running', 'Slow', 'Failed', 'No run', 'Data unavailable', 'Not due']) {
+    expect(legend).toHaveTextContent(state);
+  }
+});
+
 test('cluster capacity rolls tasks into jobs and packs requested GPUs onto their nodes', () => {
   const frames = [
     frame('W', [{

--- a/infra/grafana/marin-infra-panel/src/data.test.ts
+++ b/infra/grafana/marin-infra-panel/src/data.test.ts
@@ -21,13 +21,15 @@ function frame(rows: Array<Record<string, unknown>>, refId?: string) {
 
 const CELL = {
   lane_id: 'tpu-ferry', date: '2026-07-21', lane: 'TPU ferry', label: 'TPU ferry',
-  group: 'marin', subgroup: 'training', state: 'run', duration_state: 'normal',
+  group: 'marin', subgroup: 'training', state: 'run', status: 'completed', duration_state: 'normal',
   duration_seconds: 3600, healthy: true, due: true, url: 'https://example/run', lane_order: 0,
 };
 
 test('nightlyCells reads fields by name and preserves the link contract', () => {
   const [cell] = nightlyCells(frame([CELL]));
-  expect(cell).toMatchObject({ laneId: 'tpu-ferry', durationSeconds: 3600, healthy: true, url: 'https://example/run' });
+  expect(cell).toMatchObject({
+    laneId: 'tpu-ferry', runStatus: 'completed', durationSeconds: 3600, healthy: true, url: 'https://example/run',
+  });
 });
 
 test('nightlyCells rejects duplicate lane and date cells', () => {

--- a/infra/grafana/marin-infra-panel/src/data.ts
+++ b/infra/grafana/marin-infra-panel/src/data.ts
@@ -69,6 +69,7 @@ export function nightlyCells(frame: DataFrame): NightlyCell[] {
       group: requiredString(row, 'group'),
       subgroup: requiredString(row, 'subgroup'),
       state: requiredString(row, 'state'),
+      runStatus: optionalString(row, 'status'),
       durationState: requiredString(row, 'duration_state'),
       durationSeconds: optionalNumber(row, 'duration_seconds'),
       conclusion: optionalString(row, 'conclusion'),

--- a/infra/grafana/marin-infra-panel/src/types.ts
+++ b/infra/grafana/marin-infra-panel/src/types.ts
@@ -12,6 +12,7 @@ export interface NightlyCell {
   group: string;
   subgroup: string;
   state: string;
+  runStatus?: string;
   durationState: string;
   durationSeconds?: number;
   conclusion?: string;

--- a/infra/grafana/src/nightly.py
+++ b/infra/grafana/src/nightly.py
@@ -155,6 +155,7 @@ def _row(
     healthy: bool,
     duration_state: NightlyDurationState,
     duration_seconds: int | None,
+    status: str | None,
     conclusion: str | None,
     url: str | None,
 ) -> dict:
@@ -175,6 +176,7 @@ def _row(
         "due": due,
         "duration_state": duration_state,
         "duration_seconds": duration_seconds,
+        "status": status,
         "conclusion": conclusion,
         "url": url,
         "source_error": None,
@@ -213,6 +215,7 @@ def _empty_row(
         healthy=False,
         duration_state=NightlyDurationState.NOT_APPLICABLE,
         duration_seconds=None,
+        status=None,
         conclusion=None,
         url=None,
     )
@@ -236,6 +239,7 @@ def _run_row(lane: NightlyLane, date: str, ts: int, candidates: Sequence[Nightly
         healthy=healthy,
         duration_state=duration_state,
         duration_seconds=duration_seconds,
+        status=run.status,
         conclusion=run.conclusion,
         url=run.url,
     )

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -44,6 +44,7 @@ def _nightlies() -> list[dict]:
                     "group": group,
                     "subgroup": subgroup,
                     "state": "run",
+                    "status": "completed",
                     "duration_state": "slow" if slow else "normal",
                     "duration_seconds": 1800 + lane_order * 137 + offset * 83,
                     "conclusion": "failure" if failed else "success",

--- a/infra/grafana/tests/test_nightly.py
+++ b/infra/grafana/tests/test_nightly.py
@@ -84,6 +84,7 @@ def test_weekly_lane_shows_one_missing_occurrence_and_six_quiet_non_occurrences(
     assert missing["healthy"] is False
     assert missing["status_code"] == 4
     assert missing["duration_state"] == "not-applicable"
+    assert missing["status"] is None
 
     not_scheduled = _cell(rows, weekly, "2026-07-17")
     assert not_scheduled["due"] is False
@@ -140,6 +141,34 @@ def test_too_short_success_is_excluded_from_health_but_baseline_pending_is_healt
     today_rows = [row for row in rows if row["date"] == "2026-07-17"]
     assert sum(row["due"] for row in today_rows) == 2
     assert sum(row["healthy"] for row in today_rows) == 1
+
+
+def test_projection_exposes_active_run_lifecycle_and_elapsed_duration():
+    active = _lane(id="active", short_label="Active")
+    now = datetime(2026, 7, 17, 15, 0, 0, tzinfo=UTC)
+
+    rows = project_nightlies(
+        [active],
+        [
+            _snapshot(
+                active.id,
+                [
+                    _run(
+                        status="in_progress",
+                        conclusion=None,
+                        run_started_at="2026-07-17T14:50:00.000Z",
+                        updated_at="2026-07-17T14:55:00.000Z",
+                    )
+                ],
+            )
+        ],
+        now,
+    )
+
+    today = _cell(rows, active, "2026-07-17")
+    assert today["status"] == "in_progress"
+    assert today["conclusion"] is None
+    assert today["duration_seconds"] == 600
 
 
 def test_projection_exposes_stable_lane_order_and_workflow_link():


### PR DESCRIPTION
Show queued and in-progress GitHub Actions runs as Running before completed-run and quality-gate logic. Carry lifecycle status through the backend projection, Grafana target N, and panel data parsing. The daily header now reports categorical counts, and the cells, tooltips, and legend name every operator state.

Validation passed: `uv run --with pytest --with pytest-timeout --with pytest-xdist pytest infra/grafana/tests/test_nightly.py` (5 tests); `npm run test:ci` (13 tests); `npm run typecheck`; `npm run lint`; `npm run build`; `./infra/pre-commit.py --changed-files --fix`; and branch advisory lint (no findings). `uv run --no-project infra/ci/run_tests.py` completed successfully but selected no packages for these Grafana paths.

Fixes #8810
