### PR TITLE
[grug] Stop copying the ragged all-to-all zero inits every layer

### DIFF
--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -23,7 +23,7 @@ import functools
 import logging
 import math
 from collections.abc import Callable
-from enum import auto, IntEnum, unique
+from enum import auto, IntEnum
 from typing import Protocol
 
 import jax
@@ -211,7 +211,6 @@ def _gather_dispatch_rows_bwd(
 _gather_dispatch_rows.defvjp(_gather_dispatch_rows_fwd, _gather_dispatch_rows_bwd)
 
 
-@unique
 class _LoopLocalZeroSite(IntEnum):
     DISPATCH_OUTPUT = auto()
     DISPATCH_COTANGENT = auto()
@@ -221,7 +220,7 @@ class _LoopLocalZeroSite(IntEnum):
 
 
 def _loop_local_zeros(
-    rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."], site: _LoopLocalZeroSite
+    rows: int, hidden_dim: int, dtype, tie: Int[Array, "N"], site: _LoopLocalZeroSite
 ) -> Float[Array, "rows H"]:
     """Return an exact-zero output init for an in-place collective.
 
@@ -229,7 +228,7 @@ def _loop_local_zeros(
     """
     # The traced minimum keeps the fill inside the loop; unique site values keep separate
     # collective output buffers from merging under CSE.
-    zero = (jnp.minimum(tie.reshape(-1)[0], -site) + site).astype(dtype)
+    zero = (jnp.minimum(tie[0], -site) + site).astype(dtype)
     return jax.lax.broadcast(zero, (rows, hidden_dim))
 
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -286,15 +286,15 @@ def _dispatch_ragged_a2a_bwd(
     # The transpose of a ragged all-to-all is the reverse ragged all-to-all: swap the send and
     # recv roles and exchange the offset vectors across shards, exactly as jax's transpose rule
     # does. Source rows that were clipped receive no cotangent and keep the init's zeros.
-    output_offsets_x = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
-    input_offsets_x = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
+    exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
+    exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
     # Tie to this side's send_sizes, not recv_sizes: the return path's passthrough fill ties to
     # its own send_sizes, which is the SAME tensor as this dispatch's recv_sizes, and two fills
     # with identical shape and tie CSE back into one value with a destructive consumer --
     # re-minting exactly the copy this construction removes.
     init = _loop_local_zeros(source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=2)
     source_ct = jax.lax.ragged_all_to_all(
-        cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
+        cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
     return source_ct, None, None, None, None
 
@@ -345,18 +345,22 @@ def _return_ragged_a2a_bwd(
     cotangent: Float[Array, "TK H"],
 ) -> tuple[Float[Array, "C H"], Float[Array, "TK H"], None, None, None, None]:
     input_offsets, send_sizes, output_offsets, recv_sizes = residuals
-    output_offsets_x = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
-    input_offsets_x = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
+    exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
+    exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
     init = _loop_local_zeros(capacity, cotangent.shape[1], cotangent.dtype, recv_sizes, site=3)
     out_dispatch_ct = jax.lax.ragged_all_to_all(
-        cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
+        cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
     # Rows this a2a overwrote took their value from ``out_dispatch``, so the pass-through
     # cotangent to ``returned`` is zeroed on exactly the written intervals. This mirrors jax's
     # transpose rule op for op (interval marks, cumsum, integer select_n) so the behavior is
     # bit-identical, including on degenerate empty-group offset patterns.
     interval_marks = (
-        jnp.zeros(cotangent.shape[0], jnp.int32).at[output_offsets_x].set(1).at[output_offsets_x + recv_sizes].add(-1)
+        jnp.zeros(cotangent.shape[0], jnp.int32)
+        .at[exchanged_output_offsets]
+        .set(1)
+        .at[exchanged_output_offsets + recv_sizes]
+        .add(-1)
     )
     written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
     passthrough_zero = _loop_local_zeros(cotangent.shape[0], cotangent.shape[1], cotangent.dtype, send_sizes, site=4)

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -16,6 +16,7 @@ Axis names used in the shape annotations:
     Echunk  experts in one sequential chunk, Elocal / chunks
     C       rows in one chunk's receiver buffer, the per-chunk capacity
     S       shards on the expert axis
+    U       expert-granular transfers on the expert axis
 """
 
 import functools
@@ -222,29 +223,17 @@ class _LoopLocalZeroSite(IntEnum):
 def _loop_local_zeros(
     rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."], site: _LoopLocalZeroSite
 ) -> Float[Array, "rows H"]:
-    """Zero buffer for an in-place ``ragged_all_to_all`` output slot, built so XLA never copies it.
+    """Return an exact-zero output init for an in-place collective.
 
-    ``ragged_all_to_all`` writes its result in place into the output-init operand. A literal
-    ``jnp.zeros`` init is a trace-time constant: it gets hoisted out of the layer scan (and
-    identical inits CSE together), so CopyInsertion must mint a fresh multi-GB device copy of
-    the pristine zeros into the a2a's output slot on every scan iteration. Deriving the zeros
-    from ``tie`` -- a per-site, per-iteration traced value -- keeps each init inside the loop
-    body and distinct from every other init, so it lowers to one write-only fill kernel whose
-    buffer the a2a updates directly.
-
-    ``tie`` must be a non-negative integer array (group or transfer sizes): with ``site >= 0``,
-    ``min(tie[0], -site) + site`` is exactly zero at runtime but not foldable at compile time.
-
-    Each ``site`` enum member identifies one call site. Two sites can hold the SAME tie tensor
-    without it being obvious (dispatch send_sizes and return recv_sizes are one tensor in
-    ep_common), and same-shape same-tie fills CSE into one value with two destructive in-place a2a
-    consumers -- which makes CopyInsertion mint back the multi-GB copy this helper exists to
-    prevent.
+    ``tie`` must contain non-negative integers. ``site`` must identify the call site.
     """
+    # The traced minimum keeps the fill inside the loop; unique site values keep separate
+    # collective output buffers from merging under CSE.
     zero = (jnp.minimum(tie.reshape(-1)[0], -site) + site).astype(dtype)
     return jax.lax.broadcast(zero, (rows, hidden_dim))
 
 
+# JAX's transpose rule uses hoisted zero inits, so these wrappers reproduce it with loop-local buffers.
 @functools.partial(jax.custom_vjp, nondiff_argnums=(0, 1))
 def _dispatch_ragged_a2a(
     capacity: int,
@@ -255,15 +244,6 @@ def _dispatch_ragged_a2a(
     output_offsets: Int[Array, "U"],
     recv_sizes: Int[Array, "U"],
 ) -> Float[Array, "C H"]:
-    """Dispatch-direction ``ragged_all_to_all`` into a freshly zeroed receiver buffer.
-
-    Owning the output-init here (instead of taking a caller-built ``jnp.zeros``) lets both the
-    primal and the transposed direction build their inits with `_loop_local_zeros`. jax's
-    built-in transpose rule inits the swapped a2a with plain zeros, which XLA hoists out of
-    the layer loop and re-copies every iteration; the custom vjp below is that same rule with
-    the init construction replaced. Zeros stay load-bearing: receiver rows no peer writes must
-    read 0 downstream, and dropped source rows must read a 0 cotangent in the backward.
-    """
     del source_rows
     output_init = _loop_local_zeros(
         capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_OUTPUT
@@ -296,15 +276,9 @@ def _dispatch_ragged_a2a_bwd(
 ) -> tuple[Float[Array, "TK H"], None, None, None, None]:
     del capacity
     input_offsets, send_sizes, output_offsets, recv_sizes = residuals
-    # The transpose of a ragged all-to-all is the reverse ragged all-to-all: swap the send and
-    # recv roles and exchange the offset vectors across shards, exactly as jax's transpose rule
-    # does. Source rows that were clipped receive no cotangent and keep the init's zeros.
+    # Reverse the collective with exchanged offsets, matching JAX's transpose rule.
     exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
     exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
-    # Tie to this side's send_sizes, not recv_sizes: the return path's passthrough fill ties to
-    # its own send_sizes, which is the SAME tensor as this dispatch's recv_sizes, and two fills
-    # with identical shape and tie CSE back into one value with a destructive consumer --
-    # re-minting exactly the copy this construction removes.
     init = _loop_local_zeros(
         source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_COTANGENT
     )
@@ -327,12 +301,6 @@ def _return_ragged_a2a(
     output_offsets: Int[Array, "U"],
     recv_sizes: Int[Array, "U"],
 ) -> Float[Array, "TK H"]:
-    """Return-direction ``ragged_all_to_all``: write expert outputs back over ``returned``.
-
-    Same construction as `_dispatch_ragged_a2a`: the primal is unchanged, and the custom vjp
-    replicates jax's transpose rule operation for operation, replacing only the transposed
-    a2a's zero init so it is built per-iteration instead of hoisted and copied.
-    """
     del capacity
     return jax.lax.ragged_all_to_all(
         out_dispatch, returned, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
@@ -368,10 +336,7 @@ def _return_ragged_a2a_bwd(
     out_dispatch_ct = jax.lax.ragged_all_to_all(
         cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
-    # Rows this a2a overwrote took their value from ``out_dispatch``, so the pass-through
-    # cotangent to ``returned`` is zeroed on exactly the written intervals. This mirrors jax's
-    # transpose rule op for op (interval marks, cumsum, integer select_n) so the behavior is
-    # bit-identical, including on degenerate empty-group offset patterns.
+    # Match JAX's transpose rule when masking rows overwritten in the primal.
     interval_marks = (
         jnp.zeros(cotangent.shape[0], jnp.int32)
         .at[exchanged_output_offsets]
@@ -438,9 +403,7 @@ def _moe_mlp_ep_ragged_a2a_local(
 
     expert_mlp = _select_expert_mlp(activation_fn)
     chunk_of_expert = (jnp.arange(num_experts, dtype=jnp.int32) % local_experts) // chunk_experts  # [E]
-    # Built per-iteration (not jnp.zeros) so the layer scan does not re-copy a hoisted
-    # constant into the in-place return a2a's output slot every step; see _loop_local_zeros.
-    # The zeros are load-bearing: rows no peer writes back must read 0 in the combine.
+    # Unwritten rows remain zero for the final combine.
     returned = _loop_local_zeros(
         assignments_per_shard, hidden_dim, x_local.dtype, group_sizes, site=_LoopLocalZeroSite.RETURN_OUTPUT
     )  # [TK, H]

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -209,6 +209,157 @@ def _gather_dispatch_rows_bwd(
 _gather_dispatch_rows.defvjp(_gather_dispatch_rows_fwd, _gather_dispatch_rows_bwd)
 
 
+def _loop_local_zeros(rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."]) -> Float[Array, "rows H"]:
+    """Zero buffer for an in-place ``ragged_all_to_all`` output slot, built so XLA never copies it.
+
+    ``ragged_all_to_all`` writes its result in place into the output-init operand. A literal
+    ``jnp.zeros`` init is a trace-time constant: it gets hoisted out of the layer scan (and
+    identical inits CSE together), so CopyInsertion must mint a fresh multi-GB device copy of
+    the pristine zeros into the a2a's output slot on every scan iteration. Deriving the zeros
+    from ``tie`` -- a per-site, per-iteration traced value -- keeps each init inside the loop
+    body and distinct from every other init, so it lowers to one write-only fill kernel whose
+    buffer the a2a updates directly.
+
+    ``tie`` must be a non-negative integer array (group or transfer sizes): ``min(tie[0], 0)``
+    is exactly zero at runtime but not foldable at compile time.
+    """
+    zero = jnp.minimum(tie.reshape(-1)[0], 0).astype(dtype)
+    return jax.lax.broadcast(zero, (rows, hidden_dim))
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0, 1))
+def _dispatch_ragged_a2a(
+    capacity: int,
+    source_rows: int,
+    chunk_source: Float[Array, "TK H"],
+    input_offsets: Int[Array, "U"],
+    send_sizes: Int[Array, "U"],
+    output_offsets: Int[Array, "U"],
+    recv_sizes: Int[Array, "U"],
+) -> Float[Array, "C H"]:
+    """Dispatch-direction ``ragged_all_to_all`` into a freshly zeroed receiver buffer.
+
+    Owning the output-init here (instead of taking a caller-built ``jnp.zeros``) lets both the
+    primal and the transposed direction build their inits with `_loop_local_zeros`. jax's
+    built-in transpose rule inits the swapped a2a with plain zeros, which XLA hoists out of
+    the layer loop and re-copies every iteration; the custom vjp below is that same rule with
+    the init construction replaced. Zeros stay load-bearing: receiver rows no peer writes must
+    read 0 downstream, and dropped source rows must read a 0 cotangent in the backward.
+    """
+    del source_rows
+    output_init = _loop_local_zeros(capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes)
+    return jax.lax.ragged_all_to_all(
+        chunk_source, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
+    )
+
+
+def _dispatch_ragged_a2a_fwd(
+    capacity: int,
+    source_rows: int,
+    chunk_source: Float[Array, "TK H"],
+    input_offsets: Int[Array, "U"],
+    send_sizes: Int[Array, "U"],
+    output_offsets: Int[Array, "U"],
+    recv_sizes: Int[Array, "U"],
+) -> tuple[Float[Array, "C H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
+    result = _dispatch_ragged_a2a(
+        capacity, source_rows, chunk_source, input_offsets, send_sizes, output_offsets, recv_sizes
+    )
+    return result, (input_offsets, send_sizes, output_offsets, recv_sizes)
+
+
+def _dispatch_ragged_a2a_bwd(
+    capacity: int,
+    source_rows: int,
+    residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
+    cotangent: Float[Array, "C H"],
+) -> tuple[Float[Array, "TK H"], None, None, None, None]:
+    del capacity
+    input_offsets, send_sizes, output_offsets, recv_sizes = residuals
+    # The transpose of a ragged all-to-all is the reverse ragged all-to-all: swap the send and
+    # recv roles and exchange the offset vectors across shards, exactly as jax's transpose rule
+    # does. Source rows that were clipped receive no cotangent and keep the init's zeros.
+    output_offsets_x = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
+    input_offsets_x = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
+    # Tie to this side's send_sizes, not recv_sizes: the return path's passthrough fill ties to
+    # its own send_sizes, which is the SAME tensor as this dispatch's recv_sizes, and two fills
+    # with identical shape and tie CSE back into one value with a destructive consumer --
+    # re-minting exactly the copy this construction removes.
+    init = _loop_local_zeros(source_rows, cotangent.shape[1], cotangent.dtype, send_sizes)
+    source_ct = jax.lax.ragged_all_to_all(
+        cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
+    )
+    return source_ct, None, None, None, None
+
+
+_dispatch_ragged_a2a.defvjp(_dispatch_ragged_a2a_fwd, _dispatch_ragged_a2a_bwd)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
+def _return_ragged_a2a(
+    capacity: int,
+    out_dispatch: Float[Array, "C H"],
+    returned: Float[Array, "TK H"],
+    input_offsets: Int[Array, "U"],
+    send_sizes: Int[Array, "U"],
+    output_offsets: Int[Array, "U"],
+    recv_sizes: Int[Array, "U"],
+) -> Float[Array, "TK H"]:
+    """Return-direction ``ragged_all_to_all``: write expert outputs back over ``returned``.
+
+    Same construction as `_dispatch_ragged_a2a`: the primal is unchanged, and the custom vjp
+    replicates jax's transpose rule operation for operation, replacing only the transposed
+    a2a's zero init so it is built per-iteration instead of hoisted and copied.
+    """
+    del capacity
+    return jax.lax.ragged_all_to_all(
+        out_dispatch, returned, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
+    )
+
+
+def _return_ragged_a2a_fwd(
+    capacity: int,
+    out_dispatch: Float[Array, "C H"],
+    returned: Float[Array, "TK H"],
+    input_offsets: Int[Array, "U"],
+    send_sizes: Int[Array, "U"],
+    output_offsets: Int[Array, "U"],
+    recv_sizes: Int[Array, "U"],
+) -> tuple[Float[Array, "TK H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
+    result = _return_ragged_a2a(
+        capacity, out_dispatch, returned, input_offsets, send_sizes, output_offsets, recv_sizes
+    )
+    return result, (input_offsets, send_sizes, output_offsets, recv_sizes)
+
+
+def _return_ragged_a2a_bwd(
+    capacity: int,
+    residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
+    cotangent: Float[Array, "TK H"],
+) -> tuple[Float[Array, "C H"], Float[Array, "TK H"], None, None, None, None]:
+    input_offsets, send_sizes, output_offsets, recv_sizes = residuals
+    output_offsets_x = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
+    input_offsets_x = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
+    init = _loop_local_zeros(capacity, cotangent.shape[1], cotangent.dtype, recv_sizes)
+    out_dispatch_ct = jax.lax.ragged_all_to_all(
+        cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
+    )
+    # Rows this a2a overwrote took their value from ``out_dispatch``, so the pass-through
+    # cotangent to ``returned`` is zeroed on exactly the written intervals. This mirrors jax's
+    # transpose rule op for op (interval marks, cumsum, integer select_n) so the behavior is
+    # bit-identical, including on degenerate empty-group offset patterns.
+    interval_marks = (
+        jnp.zeros(cotangent.shape[0], jnp.int32).at[output_offsets_x].set(1).at[output_offsets_x + recv_sizes].add(-1)
+    )
+    written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
+    passthrough_zero = _loop_local_zeros(cotangent.shape[0], cotangent.shape[1], cotangent.dtype, send_sizes)
+    returned_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
+    return out_dispatch_ct, returned_ct, None, None, None, None
+
+
+_return_ragged_a2a.defvjp(_return_ragged_a2a_fwd, _return_ragged_a2a_bwd)
+
+
 def _moe_mlp_ep_ragged_a2a_local(
     x_local: Float[Array, "Tlocal H"],
     selected_experts_local: Int[Array, "Tlocal K"],
@@ -253,7 +404,10 @@ def _moe_mlp_ep_ragged_a2a_local(
 
     expert_mlp = _select_expert_mlp(activation_fn)
     chunk_of_expert = (jnp.arange(num_experts, dtype=jnp.int32) % local_experts) // chunk_experts  # [E]
-    returned = jnp.zeros((assignments_per_shard, hidden_dim), dtype=x_local.dtype)  # [TK, H]
+    # Built per-iteration (not jnp.zeros) so the layer scan does not re-copy a hoisted
+    # constant into the in-place return a2a's output slot every step; see _loop_local_zeros.
+    # The zeros are load-bearing: rows no peer writes back must read 0 in the combine.
+    returned = _loop_local_zeros(assignments_per_shard, hidden_dim, x_local.dtype, group_sizes)  # [TK, H]
     accepted_local = jnp.zeros((), dtype=jnp.int32)
     for chunk_index in range(chunks):
         with jax.named_scope(f"moe_chunk_{chunk_index}"):
@@ -277,15 +431,14 @@ def _moe_mlp_ep_ragged_a2a_local(
             # But it does not increase the speed. The transport and the MLP compete for the
             # same SMs.
             chunk_source, _ = jax.lax.optimization_barrier((sorted_x, returned))
-            dispatch_out_shape = jnp.zeros((chunk_capacity, hidden_dim), dtype=x_local.dtype)  # [C, H]
             # Accepted rows are the prefix of each unclipped expert group and receiver offsets
             # pack arrivals expert-major, so the received buffer feeds the grouped MLP
             # directly: no sender compaction and no receiver-side permute.
-            x_dispatch = jax.lax.ragged_all_to_all(  # [C, H]
+            x_dispatch = _dispatch_ragged_a2a(  # [C, H]
+                chunk_capacity,
+                assignments_per_shard,
                 chunk_source,
-                dispatch_out_shape,
                 *dispatch_params,
-                axis_name="expert",
             )
             active_all = jnp.sum(  # [Elocal]
                 clipped_group_sizes.reshape(ep_size, ep_size, local_experts)[:, shard_id, :], axis=0
@@ -307,11 +460,11 @@ def _moe_mlp_ep_ragged_a2a_local(
             # Chaining every chunk through one output buffer composes the disjoint writes;
             # dropped rows keep the buffer's zeros, so the final gather-sum reads dropped
             # slots as zero contributions with no expansion step.
-            returned = jax.lax.ragged_all_to_all(
+            returned = _return_ragged_a2a(
+                chunk_capacity,
                 out_dispatch,
                 returned,
                 *return_params,
-                axis_name="expert",
             )
             accepted_local = accepted_local + jnp.sum(clipped_group_sizes[shard_id], dtype=jnp.int32)
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -209,7 +209,9 @@ def _gather_dispatch_rows_bwd(
 _gather_dispatch_rows.defvjp(_gather_dispatch_rows_fwd, _gather_dispatch_rows_bwd)
 
 
-def _loop_local_zeros(rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."]) -> Float[Array, "rows H"]:
+def _loop_local_zeros(
+    rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."], site: int = 0
+) -> Float[Array, "rows H"]:
     """Zero buffer for an in-place ``ragged_all_to_all`` output slot, built so XLA never copies it.
 
     ``ragged_all_to_all`` writes its result in place into the output-init operand. A literal
@@ -220,10 +222,15 @@ def _loop_local_zeros(rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."])
     body and distinct from every other init, so it lowers to one write-only fill kernel whose
     buffer the a2a updates directly.
 
-    ``tie`` must be a non-negative integer array (group or transfer sizes): ``min(tie[0], 0)``
-    is exactly zero at runtime but not foldable at compile time.
+    ``tie`` must be a non-negative integer array (group or transfer sizes): with ``site >= 0``,
+    ``min(tie[0], -site) + site`` is exactly zero at runtime but not foldable at compile time.
+
+    ``site`` must be distinct per call site. Two sites can hold the SAME tie tensor without it
+    being obvious (dispatch send_sizes and return recv_sizes are one tensor in ep_common), and
+    same-shape same-tie fills CSE into one value with two destructive in-place a2a consumers --
+    which makes CopyInsertion mint back the multi-GB copy this helper exists to prevent.
     """
-    zero = jnp.minimum(tie.reshape(-1)[0], 0).astype(dtype)
+    zero = (jnp.minimum(tie.reshape(-1)[0], -site) + site).astype(dtype)
     return jax.lax.broadcast(zero, (rows, hidden_dim))
 
 
@@ -247,7 +254,7 @@ def _dispatch_ragged_a2a(
     read 0 downstream, and dropped source rows must read a 0 cotangent in the backward.
     """
     del source_rows
-    output_init = _loop_local_zeros(capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes)
+    output_init = _loop_local_zeros(capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes, site=1)
     return jax.lax.ragged_all_to_all(
         chunk_source, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
     )
@@ -285,7 +292,7 @@ def _dispatch_ragged_a2a_bwd(
     # its own send_sizes, which is the SAME tensor as this dispatch's recv_sizes, and two fills
     # with identical shape and tie CSE back into one value with a destructive consumer --
     # re-minting exactly the copy this construction removes.
-    init = _loop_local_zeros(source_rows, cotangent.shape[1], cotangent.dtype, send_sizes)
+    init = _loop_local_zeros(source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=2)
     source_ct = jax.lax.ragged_all_to_all(
         cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
     )
@@ -340,7 +347,7 @@ def _return_ragged_a2a_bwd(
     input_offsets, send_sizes, output_offsets, recv_sizes = residuals
     output_offsets_x = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
     input_offsets_x = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
-    init = _loop_local_zeros(capacity, cotangent.shape[1], cotangent.dtype, recv_sizes)
+    init = _loop_local_zeros(capacity, cotangent.shape[1], cotangent.dtype, recv_sizes, site=3)
     out_dispatch_ct = jax.lax.ragged_all_to_all(
         cotangent, init, output_offsets_x, recv_sizes, input_offsets_x, send_sizes, axis_name="expert"
     )
@@ -352,7 +359,7 @@ def _return_ragged_a2a_bwd(
         jnp.zeros(cotangent.shape[0], jnp.int32).at[output_offsets_x].set(1).at[output_offsets_x + recv_sizes].add(-1)
     )
     written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
-    passthrough_zero = _loop_local_zeros(cotangent.shape[0], cotangent.shape[1], cotangent.dtype, send_sizes)
+    passthrough_zero = _loop_local_zeros(cotangent.shape[0], cotangent.shape[1], cotangent.dtype, send_sizes, site=4)
     returned_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
     return out_dispatch_ct, returned_ct, None, None, None, None
 
@@ -407,7 +414,7 @@ def _moe_mlp_ep_ragged_a2a_local(
     # Built per-iteration (not jnp.zeros) so the layer scan does not re-copy a hoisted
     # constant into the in-place return a2a's output slot every step; see _loop_local_zeros.
     # The zeros are load-bearing: rows no peer writes back must read 0 in the combine.
-    returned = _loop_local_zeros(assignments_per_shard, hidden_dim, x_local.dtype, group_sizes)  # [TK, H]
+    returned = _loop_local_zeros(assignments_per_shard, hidden_dim, x_local.dtype, group_sizes, site=5)  # [TK, H]
     accepted_local = jnp.zeros((), dtype=jnp.int32)
     for chunk_index in range(chunks):
         with jax.named_scope(f"moe_chunk_{chunk_index}"):

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -34,6 +34,7 @@ from haliax.nn.ragged_dot import ragged_dot
 from levanter.grug._moe.common import CapacityOverflow
 from levanter.grug._moe.sonic import sonic_gather_sum, sonic_gather_sum_available
 from levanter.grug._moe.ep_common import (
+    ExpertA2aParams,
     _clip_receiver_group_sizes,
     _expert_granular_a2a_params,
     _sort_activations,
@@ -243,49 +244,45 @@ def _ragged_a2a(
     operand_rows: int,
     operand: Float[Array, "R H"],
     output_init: Float[Array, "O H"],
-    input_offsets: Int[Array, "U"],
-    send_sizes: Int[Array, "U"],
-    output_offsets: Int[Array, "U"],
-    recv_sizes: Int[Array, "U"],
+    params: ExpertA2aParams,
 ) -> Float[Array, "O H"]:
     """``ragged_all_to_all`` over the expert axis whose transpose builds its zero inits in the loop.
 
     ``operand_rows`` is ``operand.shape[0]``. The backward needs it and does not see the operand.
     """
     del operand_rows
-    return jax.lax.ragged_all_to_all(
-        operand, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
-    )
+    return jax.lax.ragged_all_to_all(operand, output_init, *params, axis_name="expert")
 
 
 def _ragged_a2a_fwd(
     operand_rows: int,
     operand: Float[Array, "R H"],
     output_init: Float[Array, "O H"],
-    input_offsets: Int[Array, "U"],
-    send_sizes: Int[Array, "U"],
-    output_offsets: Int[Array, "U"],
-    recv_sizes: Int[Array, "U"],
-) -> tuple[Float[Array, "O H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
-    result = _ragged_a2a(operand_rows, operand, output_init, input_offsets, send_sizes, output_offsets, recv_sizes)
-    return result, (input_offsets, send_sizes, output_offsets, recv_sizes)
+    params: ExpertA2aParams,
+) -> tuple[Float[Array, "O H"], ExpertA2aParams]:
+    return _ragged_a2a(operand_rows, operand, output_init, params), params
 
 
 def _ragged_a2a_bwd(
     operand_rows: int,
-    residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
+    params: ExpertA2aParams,
     cotangent: Float[Array, "O H"],
-) -> tuple[Float[Array, "R H"], Float[Array, "O H"], None, None, None, None]:
-    input_offsets, send_sizes, output_offsets, recv_sizes = residuals
+) -> tuple[Float[Array, "R H"], Float[Array, "O H"], None]:
     hidden_dim = cotangent.shape[1]
     # Reverse the collective with exchanged offsets, matching JAX's transpose rule.
-    exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
-    exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
+    exchanged_output_offsets = jax.lax.all_to_all(params.output_offsets, "expert", 0, 0, tiled=True)
+    exchanged_input_offsets = jax.lax.all_to_all(params.input_offsets, "expert", 0, 0, tiled=True)
     init = _loop_local_zeros(
-        operand_rows, hidden_dim, cotangent.dtype, recv_sizes, site=_LoopLocalZeroSite.OPERAND_COTANGENT
+        operand_rows, hidden_dim, cotangent.dtype, params.recv_sizes, site=_LoopLocalZeroSite.OPERAND_COTANGENT
     )
     operand_ct = jax.lax.ragged_all_to_all(
-        cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
+        cotangent,
+        init,
+        exchanged_output_offsets,
+        params.recv_sizes,
+        exchanged_input_offsets,
+        params.send_sizes,
+        axis_name="expert",
     )
     # Match JAX's transpose rule when masking rows overwritten in the primal. When ``output_init``
     # carries no gradient, JAX drops this branch at lowering.
@@ -293,15 +290,15 @@ def _ragged_a2a_bwd(
         jnp.zeros(cotangent.shape[0], jnp.int32)
         .at[exchanged_output_offsets]
         .set(1)
-        .at[exchanged_output_offsets + recv_sizes]
+        .at[exchanged_output_offsets + params.recv_sizes]
         .add(-1)
     )
     written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
     passthrough_zero = _loop_local_zeros(
-        cotangent.shape[0], hidden_dim, cotangent.dtype, send_sizes, site=_LoopLocalZeroSite.OUTPUT_PASSTHROUGH
+        cotangent.shape[0], hidden_dim, cotangent.dtype, params.send_sizes, site=_LoopLocalZeroSite.OUTPUT_PASSTHROUGH
     )
     output_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
-    return operand_ct, output_ct, None, None, None, None
+    return operand_ct, output_ct, None
 
 
 _ragged_a2a.defvjp(_ragged_a2a_fwd, _ragged_a2a_bwd)
@@ -388,7 +385,7 @@ def _moe_mlp_ep_ragged_a2a_local(
                 dispatch_params.send_sizes,
                 site=_LoopLocalZeroSite.DISPATCH_OUTPUT,
             )
-            x_dispatch = _ragged_a2a(assignments_per_shard, chunk_source, dispatch_init, *dispatch_params)  # [C, H]
+            x_dispatch = _ragged_a2a(assignments_per_shard, chunk_source, dispatch_init, dispatch_params)  # [C, H]
             active_all = jnp.sum(  # [Elocal]
                 clipped_group_sizes.reshape(ep_size, ep_size, local_experts)[:, shard_id, :], axis=0
             )
@@ -409,7 +406,7 @@ def _moe_mlp_ep_ragged_a2a_local(
             # Chaining every chunk through one output buffer composes the disjoint writes;
             # dropped rows keep the buffer's zeros, so the final gather-sum reads dropped
             # slots as zero contributions with no expansion step.
-            returned = _ragged_a2a(chunk_capacity, out_dispatch, returned, *return_params)
+            returned = _ragged_a2a(chunk_capacity, out_dispatch, returned, return_params)
             accepted_local = accepted_local + jnp.sum(clipped_group_sizes[shard_id], dtype=jnp.int32)
 
     with jax.named_scope("combine"):

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -22,6 +22,7 @@ import functools
 import logging
 import math
 from collections.abc import Callable
+from enum import auto, IntEnum, unique
 from typing import Protocol
 
 import jax
@@ -209,8 +210,17 @@ def _gather_dispatch_rows_bwd(
 _gather_dispatch_rows.defvjp(_gather_dispatch_rows_fwd, _gather_dispatch_rows_bwd)
 
 
+@unique
+class _LoopLocalZeroSite(IntEnum):
+    DISPATCH_OUTPUT = auto()
+    DISPATCH_COTANGENT = auto()
+    RETURN_COTANGENT = auto()
+    RETURN_PASSTHROUGH = auto()
+    RETURN_OUTPUT = auto()
+
+
 def _loop_local_zeros(
-    rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."], site: int = 0
+    rows: int, hidden_dim: int, dtype, tie: Int[Array, "..."], site: _LoopLocalZeroSite
 ) -> Float[Array, "rows H"]:
     """Zero buffer for an in-place ``ragged_all_to_all`` output slot, built so XLA never copies it.
 
@@ -225,10 +235,11 @@ def _loop_local_zeros(
     ``tie`` must be a non-negative integer array (group or transfer sizes): with ``site >= 0``,
     ``min(tie[0], -site) + site`` is exactly zero at runtime but not foldable at compile time.
 
-    ``site`` must be distinct per call site. Two sites can hold the SAME tie tensor without it
-    being obvious (dispatch send_sizes and return recv_sizes are one tensor in ep_common), and
-    same-shape same-tie fills CSE into one value with two destructive in-place a2a consumers --
-    which makes CopyInsertion mint back the multi-GB copy this helper exists to prevent.
+    Each ``site`` enum member identifies one call site. Two sites can hold the SAME tie tensor
+    without it being obvious (dispatch send_sizes and return recv_sizes are one tensor in
+    ep_common), and same-shape same-tie fills CSE into one value with two destructive in-place a2a
+    consumers -- which makes CopyInsertion mint back the multi-GB copy this helper exists to
+    prevent.
     """
     zero = (jnp.minimum(tie.reshape(-1)[0], -site) + site).astype(dtype)
     return jax.lax.broadcast(zero, (rows, hidden_dim))
@@ -254,7 +265,9 @@ def _dispatch_ragged_a2a(
     read 0 downstream, and dropped source rows must read a 0 cotangent in the backward.
     """
     del source_rows
-    output_init = _loop_local_zeros(capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes, site=1)
+    output_init = _loop_local_zeros(
+        capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_OUTPUT
+    )
     return jax.lax.ragged_all_to_all(
         chunk_source, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
     )
@@ -292,7 +305,9 @@ def _dispatch_ragged_a2a_bwd(
     # its own send_sizes, which is the SAME tensor as this dispatch's recv_sizes, and two fills
     # with identical shape and tie CSE back into one value with a destructive consumer --
     # re-minting exactly the copy this construction removes.
-    init = _loop_local_zeros(source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=2)
+    init = _loop_local_zeros(
+        source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_COTANGENT
+    )
     source_ct = jax.lax.ragged_all_to_all(
         cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
@@ -347,7 +362,9 @@ def _return_ragged_a2a_bwd(
     input_offsets, send_sizes, output_offsets, recv_sizes = residuals
     exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
     exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
-    init = _loop_local_zeros(capacity, cotangent.shape[1], cotangent.dtype, recv_sizes, site=3)
+    init = _loop_local_zeros(
+        capacity, cotangent.shape[1], cotangent.dtype, recv_sizes, site=_LoopLocalZeroSite.RETURN_COTANGENT
+    )
     out_dispatch_ct = jax.lax.ragged_all_to_all(
         cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
@@ -363,7 +380,13 @@ def _return_ragged_a2a_bwd(
         .add(-1)
     )
     written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
-    passthrough_zero = _loop_local_zeros(cotangent.shape[0], cotangent.shape[1], cotangent.dtype, send_sizes, site=4)
+    passthrough_zero = _loop_local_zeros(
+        cotangent.shape[0],
+        cotangent.shape[1],
+        cotangent.dtype,
+        send_sizes,
+        site=_LoopLocalZeroSite.RETURN_PASSTHROUGH,
+    )
     returned_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
     return out_dispatch_ct, returned_ct, None, None, None, None
 
@@ -418,7 +441,9 @@ def _moe_mlp_ep_ragged_a2a_local(
     # Built per-iteration (not jnp.zeros) so the layer scan does not re-copy a hoisted
     # constant into the in-place return a2a's output slot every step; see _loop_local_zeros.
     # The zeros are load-bearing: rows no peer writes back must read 0 in the combine.
-    returned = _loop_local_zeros(assignments_per_shard, hidden_dim, x_local.dtype, group_sizes, site=5)  # [TK, H]
+    returned = _loop_local_zeros(
+        assignments_per_shard, hidden_dim, x_local.dtype, group_sizes, site=_LoopLocalZeroSite.RETURN_OUTPUT
+    )  # [TK, H]
     accepted_local = jnp.zeros((), dtype=jnp.int32)
     for chunk_index in range(chunks):
         with jax.named_scope(f"moe_chunk_{chunk_index}"):

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -213,10 +213,9 @@ _gather_dispatch_rows.defvjp(_gather_dispatch_rows_fwd, _gather_dispatch_rows_bw
 
 class _LoopLocalZeroSite(IntEnum):
     DISPATCH_OUTPUT = auto()
-    DISPATCH_COTANGENT = auto()
-    RETURN_COTANGENT = auto()
-    RETURN_PASSTHROUGH = auto()
     RETURN_OUTPUT = auto()
+    OPERAND_COTANGENT = auto()
+    OUTPUT_PASSTHROUGH = auto()
 
 
 def _loop_local_zeros(
@@ -238,110 +237,58 @@ def _loop_local_zeros(
     return jax.lax.broadcast(zero, (rows, hidden_dim))
 
 
-# JAX's transpose rule uses hoisted zero inits, so these wrappers reproduce it with loop-local buffers.
-@functools.partial(jax.custom_vjp, nondiff_argnums=(0, 1))
-def _dispatch_ragged_a2a(
-    capacity: int,
-    source_rows: int,
-    chunk_source: Float[Array, "TK H"],
+# JAX's transpose rule uses hoisted zero inits, so this wrapper reproduces it with loop-local buffers.
+@functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
+def _ragged_a2a(
+    operand_rows: int,
+    operand: Float[Array, "R H"],
+    output_init: Float[Array, "O H"],
     input_offsets: Int[Array, "U"],
     send_sizes: Int[Array, "U"],
     output_offsets: Int[Array, "U"],
     recv_sizes: Int[Array, "U"],
-) -> Float[Array, "C H"]:
-    del source_rows
-    output_init = _loop_local_zeros(
-        capacity, chunk_source.shape[1], chunk_source.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_OUTPUT
-    )
+) -> Float[Array, "O H"]:
+    """``ragged_all_to_all`` over the expert axis whose transpose builds its zero inits in the loop.
+
+    ``operand_rows`` is ``operand.shape[0]``. The backward needs it and does not see the operand.
+    """
+    del operand_rows
     return jax.lax.ragged_all_to_all(
-        chunk_source, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
+        operand, output_init, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
     )
 
 
-def _dispatch_ragged_a2a_fwd(
-    capacity: int,
-    source_rows: int,
-    chunk_source: Float[Array, "TK H"],
+def _ragged_a2a_fwd(
+    operand_rows: int,
+    operand: Float[Array, "R H"],
+    output_init: Float[Array, "O H"],
     input_offsets: Int[Array, "U"],
     send_sizes: Int[Array, "U"],
     output_offsets: Int[Array, "U"],
     recv_sizes: Int[Array, "U"],
-) -> tuple[Float[Array, "C H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
-    result = _dispatch_ragged_a2a(
-        capacity, source_rows, chunk_source, input_offsets, send_sizes, output_offsets, recv_sizes
-    )
+) -> tuple[Float[Array, "O H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
+    result = _ragged_a2a(operand_rows, operand, output_init, input_offsets, send_sizes, output_offsets, recv_sizes)
     return result, (input_offsets, send_sizes, output_offsets, recv_sizes)
 
 
-def _dispatch_ragged_a2a_bwd(
-    capacity: int,
-    source_rows: int,
+def _ragged_a2a_bwd(
+    operand_rows: int,
     residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
-    cotangent: Float[Array, "C H"],
-) -> tuple[Float[Array, "TK H"], None, None, None, None]:
-    del capacity
+    cotangent: Float[Array, "O H"],
+) -> tuple[Float[Array, "R H"], Float[Array, "O H"], None, None, None, None]:
     input_offsets, send_sizes, output_offsets, recv_sizes = residuals
+    hidden_dim = cotangent.shape[1]
     # Reverse the collective with exchanged offsets, matching JAX's transpose rule.
     exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
     exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
     init = _loop_local_zeros(
-        source_rows, cotangent.shape[1], cotangent.dtype, send_sizes, site=_LoopLocalZeroSite.DISPATCH_COTANGENT
+        operand_rows, hidden_dim, cotangent.dtype, recv_sizes, site=_LoopLocalZeroSite.OPERAND_COTANGENT
     )
-    source_ct = jax.lax.ragged_all_to_all(
+    operand_ct = jax.lax.ragged_all_to_all(
         cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
     )
-    return source_ct, None, None, None, None
-
-
-_dispatch_ragged_a2a.defvjp(_dispatch_ragged_a2a_fwd, _dispatch_ragged_a2a_bwd)
-
-
-@functools.partial(jax.custom_vjp, nondiff_argnums=(0,))
-def _return_ragged_a2a(
-    capacity: int,
-    out_dispatch: Float[Array, "C H"],
-    returned: Float[Array, "TK H"],
-    input_offsets: Int[Array, "U"],
-    send_sizes: Int[Array, "U"],
-    output_offsets: Int[Array, "U"],
-    recv_sizes: Int[Array, "U"],
-) -> Float[Array, "TK H"]:
-    del capacity
-    return jax.lax.ragged_all_to_all(
-        out_dispatch, returned, input_offsets, send_sizes, output_offsets, recv_sizes, axis_name="expert"
-    )
-
-
-def _return_ragged_a2a_fwd(
-    capacity: int,
-    out_dispatch: Float[Array, "C H"],
-    returned: Float[Array, "TK H"],
-    input_offsets: Int[Array, "U"],
-    send_sizes: Int[Array, "U"],
-    output_offsets: Int[Array, "U"],
-    recv_sizes: Int[Array, "U"],
-) -> tuple[Float[Array, "TK H"], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
-    result = _return_ragged_a2a(
-        capacity, out_dispatch, returned, input_offsets, send_sizes, output_offsets, recv_sizes
-    )
-    return result, (input_offsets, send_sizes, output_offsets, recv_sizes)
-
-
-def _return_ragged_a2a_bwd(
-    capacity: int,
-    residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
-    cotangent: Float[Array, "TK H"],
-) -> tuple[Float[Array, "C H"], Float[Array, "TK H"], None, None, None, None]:
-    input_offsets, send_sizes, output_offsets, recv_sizes = residuals
-    exchanged_output_offsets = jax.lax.all_to_all(output_offsets, "expert", 0, 0, tiled=True)
-    exchanged_input_offsets = jax.lax.all_to_all(input_offsets, "expert", 0, 0, tiled=True)
-    init = _loop_local_zeros(
-        capacity, cotangent.shape[1], cotangent.dtype, recv_sizes, site=_LoopLocalZeroSite.RETURN_COTANGENT
-    )
-    out_dispatch_ct = jax.lax.ragged_all_to_all(
-        cotangent, init, exchanged_output_offsets, recv_sizes, exchanged_input_offsets, send_sizes, axis_name="expert"
-    )
-    # Match JAX's transpose rule when masking rows overwritten in the primal.
+    # Match JAX's transpose rule when masking rows overwritten in the primal. When ``output_init``
+    # carries no gradient, JAX drops this branch at lowering.
     interval_marks = (
         jnp.zeros(cotangent.shape[0], jnp.int32)
         .at[exchanged_output_offsets]
@@ -351,17 +298,13 @@ def _return_ragged_a2a_bwd(
     )
     written = jnp.broadcast_to(jnp.cumsum(interval_marks)[:, None], cotangent.shape)
     passthrough_zero = _loop_local_zeros(
-        cotangent.shape[0],
-        cotangent.shape[1],
-        cotangent.dtype,
-        send_sizes,
-        site=_LoopLocalZeroSite.RETURN_PASSTHROUGH,
+        cotangent.shape[0], hidden_dim, cotangent.dtype, send_sizes, site=_LoopLocalZeroSite.OUTPUT_PASSTHROUGH
     )
-    returned_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
-    return out_dispatch_ct, returned_ct, None, None, None, None
+    output_ct = jax.lax.select_n(written, cotangent, passthrough_zero)
+    return operand_ct, output_ct, None, None, None, None
 
 
-_return_ragged_a2a.defvjp(_return_ragged_a2a_fwd, _return_ragged_a2a_bwd)
+_ragged_a2a.defvjp(_ragged_a2a_fwd, _ragged_a2a_bwd)
 
 
 def _moe_mlp_ep_ragged_a2a_local(
@@ -438,12 +381,14 @@ def _moe_mlp_ep_ragged_a2a_local(
             # Accepted rows are the prefix of each unclipped expert group and receiver offsets
             # pack arrivals expert-major, so the received buffer feeds the grouped MLP
             # directly: no sender compaction and no receiver-side permute.
-            x_dispatch = _dispatch_ragged_a2a(  # [C, H]
+            dispatch_init = _loop_local_zeros(  # [C, H]
                 chunk_capacity,
-                assignments_per_shard,
-                chunk_source,
-                *dispatch_params,
+                hidden_dim,
+                x_local.dtype,
+                dispatch_params.send_sizes,
+                site=_LoopLocalZeroSite.DISPATCH_OUTPUT,
             )
+            x_dispatch = _ragged_a2a(assignments_per_shard, chunk_source, dispatch_init, *dispatch_params)  # [C, H]
             active_all = jnp.sum(  # [Elocal]
                 clipped_group_sizes.reshape(ep_size, ep_size, local_experts)[:, shard_id, :], axis=0
             )
@@ -464,12 +409,7 @@ def _moe_mlp_ep_ragged_a2a_local(
             # Chaining every chunk through one output buffer composes the disjoint writes;
             # dropped rows keep the buffer's zeros, so the final gather-sum reads dropped
             # slots as zero contributions with no expansion step.
-            returned = _return_ragged_a2a(
-                chunk_capacity,
-                out_dispatch,
-                returned,
-                *return_params,
-            )
+            returned = _ragged_a2a(chunk_capacity, out_dispatch, returned, *return_params)
             accepted_local = accepted_local + jnp.sum(clipped_group_sizes[shard_id], dtype=jnp.int32)
 
     with jax.named_scope("combine"):

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -222,12 +222,18 @@ class _LoopLocalZeroSite(IntEnum):
 def _loop_local_zeros(
     rows: int, hidden_dim: int, dtype, tie: Int[Array, "N"], site: _LoopLocalZeroSite
 ) -> Float[Array, "rows H"]:
-    """Return an exact-zero output init for an in-place collective.
+    """Return an exact-zero output init for an in-place ``ragged_all_to_all``.
+
+    A ``jnp.zeros`` init is a trace-time constant. XLA hoists it out of the layer loop and merges
+    equal-shaped inits under CSE. Each collective then writes into one shared constant, so
+    CopyInsertion copies the pristine zeros into every output slot on every layer (#8822).
+
+    ``min(tie[0], -site) + site`` is zero for every non-negative ``tie`` but depends on a
+    loop-carried value, so XLA cannot hoist or fold it. ``site`` makes each call's expression
+    distinct, so CSE cannot merge two inits into one shared buffer.
 
     ``tie`` must contain non-negative integers. ``site`` must identify the call site.
     """
-    # The traced minimum keeps the fill inside the loop; unique site values keep separate
-    # collective output buffers from merging under CSE.
     zero = (jnp.minimum(tie[0], -site) + site).astype(dtype)
     return jax.lax.broadcast(zero, (rows, hidden_dim))
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1410,17 +1410,20 @@ def test_loop_local_zeros_fills_exact_zeros(site: int, tie: np.ndarray):
     np.testing.assert_array_equal(np.asarray(filled), np.zeros((4, 3), dtype=np.float32))
 
 
-def _fill_survives_xla_constant_folding(fill_fn) -> bool:
-    """Whether the compiled fill still reads its input, judged on the post-optimization HLO.
+def _optimized_hlo_opcode_count(fill_fn, opcode_name: str) -> int:
+    """Count an opcode in the optimized HLO produced for ``fill_fn``.
 
     XLA's simplifier is what folds a fill into a constant, so a jaxpr-level check cannot see the
-    property: ``tie[0] * 0`` consumes ``tie`` in the jaxpr and still folds. Reading the optimized
-    entry computation instead, a folded fill leaves its parameter dead.
+    property: ``tie[0] * 0`` consumes ``tie`` in the jaxpr and still folds.
     """
     tie = jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
-    entry = jax.jit(fill_fn).lower(tie).compile().as_text().split("ENTRY ")[-1]
-    parameter = next(line.split("=")[0].strip() for line in entry.splitlines() if "parameter(0)" in line)
-    return entry.count(parameter) > 1
+    executable = jax.jit(fill_fn).lower(tie).compile().runtime_executable()
+    return sum(
+        instruction.opcode.name == opcode_name
+        for module in executable.hlo_modules()
+        for computation in module.computations()
+        for instruction in computation.instructions()
+    )
 
 
 def test_loop_local_zeros_is_not_a_foldable_constant():
@@ -1431,7 +1434,27 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
     ``min(tie[0], -site) + site`` resists the fold because XLA cannot prove ``tie`` is
     non-negative; an arithmetic identity such as ``tie[0] * 0`` would not.
     """
-    assert _fill_survives_xla_constant_folding(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1))
-    assert not _fill_survives_xla_constant_folding(
-        lambda tie: jnp.broadcast_to((tie.reshape(-1)[0] * 0).astype(jnp.float32), (4, 3))
+    assert _optimized_hlo_opcode_count(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1), "kMinimum") == 1
+    assert (
+        _optimized_hlo_opcode_count(
+            lambda tie: jnp.broadcast_to((tie.reshape(-1)[0] * 0).astype(jnp.float32), (4, 3)), "kMinimum"
+        )
+        == 0
     ), "the folding probe no longer folds, so this test can no longer detect a foldable fill"
+
+
+def test_loop_local_zeros_sites_prevent_cse():
+    def distinct_sites(tie):
+        return (
+            _loop_local_zeros(4, 3, jnp.float32, tie, site=1),
+            _loop_local_zeros(4, 3, jnp.float32, tie, site=2),
+        )
+
+    def repeated_site(tie):
+        fill = _loop_local_zeros(4, 3, jnp.float32, tie, site=1)
+        return fill, fill
+
+    assert _optimized_hlo_opcode_count(distinct_sites, "kMinimum") == 2
+    assert (
+        _optimized_hlo_opcode_count(repeated_site, "kMinimum") == 1
+    ), "the CSE probe no longer merges repeated sites, so this test can no longer detect a site collision"

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1397,11 +1397,6 @@ def test_ragged_a2a_receiver_clipping_respects_capacity():
     ids=["all-empty-groups", "mixed", "large-first-group"],
 )
 def test_loop_local_zeros_fills_exact_zeros(site: _LoopLocalZeroSite, tie: np.ndarray):
-    """The ragged-a2a output inits must be exactly zero at every call site the backend uses.
-
-    Dropped source rows, and receiver rows no peer writes, keep this init; the combine reads them
-    as zero contributions. A non-zero fill corrupts training without raising.
-    """
     filled = _loop_local_zeros(4, 3, jnp.float32, jnp.asarray(tie), site=site)
 
     assert filled.shape == (4, 3)
@@ -1409,11 +1404,6 @@ def test_loop_local_zeros_fills_exact_zeros(site: _LoopLocalZeroSite, tie: np.nd
 
 
 def _optimized_hlo_opcode_count(fill_fn, opcode_name: str) -> int:
-    """Count an opcode in the optimized HLO produced for ``fill_fn``.
-
-    XLA's simplifier is what folds a fill into a constant, so a jaxpr-level check cannot see the
-    property: ``tie[0] * 0`` consumes ``tie`` in the jaxpr and still folds.
-    """
     tie = jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
     executable = jax.jit(fill_fn).lower(tie).compile().runtime_executable()
     return sum(
@@ -1425,13 +1415,6 @@ def _optimized_hlo_opcode_count(fill_fn, opcode_name: str) -> int:
 
 
 def test_loop_local_zeros_is_not_a_foldable_constant():
-    """The fill must still read its tie after XLA optimizes, which is what keeps it in the scan.
-
-    XLA hoists a constant-foldable fill out of the layer loop, and CopyInsertion then mints a
-    fresh multi-GB copy into the in-place ``ragged_all_to_all`` output slot every iteration.
-    ``min(tie[0], -site) + site`` resists the fold because XLA cannot prove ``tie`` is
-    non-negative; an arithmetic identity such as ``tie[0] * 0`` would not.
-    """
     assert (
         _optimized_hlo_opcode_count(
             lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT),

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1423,7 +1423,9 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
         == 1
     )
     assert (
-        _optimized_hlo_opcode_count(lambda tie: jnp.broadcast_to((tie[0] * 0).astype(jnp.float32), (4, 3)), "kMinimum")
+        _optimized_hlo_opcode_count(
+            lambda tie: jnp.broadcast_to((jnp.minimum(tie[0], 5) * 0).astype(jnp.float32), (4, 3)), "kMinimum"
+        )
         == 0
     ), "the folding probe no longer folds, so this test can no longer detect a foldable fill"
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -25,6 +25,7 @@ from levanter.grug._moe.common import (
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
+from levanter.grug._moe.ep_ragged_all_to_all import _loop_local_zeros
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
     _interleaved_receiver_ranks,
@@ -1383,3 +1384,44 @@ def test_ragged_a2a_receiver_clipping_respects_capacity():
         ),
     )
     assert int(jnp.sum(clipped)) < int(jnp.sum(group_sizes))
+
+
+@pytest.mark.parametrize("site", [0, 1, 2, 3, 4, 5])
+@pytest.mark.parametrize(
+    "tie",
+    [
+        np.array([0, 0, 0, 0], dtype=np.int32),
+        np.array([1, 7, 0, 3], dtype=np.int32),
+        np.array([2**20, 5, 5, 5], dtype=np.int32),
+    ],
+    ids=["all-empty-groups", "mixed", "large-first-group"],
+)
+def test_loop_local_zeros_fills_exact_zeros(site: int, tie: np.ndarray):
+    """The ragged-a2a output inits must be exactly zero at every call site the backend uses.
+
+    Dropped source rows, and receiver rows no peer writes, keep this init; the combine reads them
+    as zero contributions. A non-zero fill corrupts training without raising. ``site=0`` is the
+    boundary case: its value is zero only because ``tie`` is non-negative, which an all-zero
+    ``tie`` exercises tightest.
+    """
+    filled = _loop_local_zeros(4, 3, jnp.float32, jnp.asarray(tie), site=site)
+
+    assert filled.shape == (4, 3)
+    np.testing.assert_array_equal(np.asarray(filled), np.zeros((4, 3), dtype=np.float32))
+
+
+def test_loop_local_zeros_is_not_a_foldable_constant():
+    """The fill must stay a function of a traced value so it lowers inside the layer scan.
+
+    XLA hoists a constant-foldable fill out of the loop, and CopyInsertion then mints a fresh
+    multi-GB copy into the in-place ``ragged_all_to_all`` output slot every iteration. Reading
+    ``tie`` prevents the fold, so a refactor that produced the zeros without it would keep the
+    zero-value test above passing while restoring that copy.
+    """
+    jaxpr = jax.make_jaxpr(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1))(
+        jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
+    )
+
+    assert jaxpr.jaxpr.invars, "the fill takes no traced input, so it can be folded and hoisted"
+    consumed = {id(var) for eqn in jaxpr.jaxpr.eqns for var in eqn.invars}
+    assert any(id(var) in consumed for var in jaxpr.jaxpr.invars), "the fill ignores its tie, so it can be folded"

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1410,17 +1410,28 @@ def test_loop_local_zeros_fills_exact_zeros(site: int, tie: np.ndarray):
     np.testing.assert_array_equal(np.asarray(filled), np.zeros((4, 3), dtype=np.float32))
 
 
-def test_loop_local_zeros_is_not_a_foldable_constant():
-    """The fill must stay a function of a traced value so it lowers inside the layer scan.
+def _fill_survives_xla_constant_folding(fill_fn) -> bool:
+    """Whether the compiled fill still reads its input, judged on the post-optimization HLO.
 
-    XLA hoists a constant-foldable fill out of the loop, and CopyInsertion then mints a fresh
-    multi-GB copy into the in-place ``ragged_all_to_all`` output slot every iteration. Reading
-    ``tie`` prevents the fold, so a refactor that produced the zeros without it would keep the
-    zero-value test above passing while restoring that copy.
+    XLA's simplifier is what folds a fill into a constant, so a jaxpr-level check cannot see the
+    property: ``tie[0] * 0`` consumes ``tie`` in the jaxpr and still folds. Reading the optimized
+    entry computation instead, a folded fill leaves its parameter dead.
     """
-    jaxpr = jax.make_jaxpr(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1))(
-        jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
-    )
+    tie = jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
+    entry = jax.jit(fill_fn).lower(tie).compile().as_text().split("ENTRY ")[-1]
+    parameter = next(line.split("=")[0].strip() for line in entry.splitlines() if "parameter(0)" in line)
+    return entry.count(parameter) > 1
 
-    consumed = {id(var) for eqn in jaxpr.jaxpr.eqns for var in eqn.invars}
-    assert any(id(var) in consumed for var in jaxpr.jaxpr.invars), "the fill ignores its tie, so it can be folded"
+
+def test_loop_local_zeros_is_not_a_foldable_constant():
+    """The fill must still read its tie after XLA optimizes, which is what keeps it in the scan.
+
+    XLA hoists a constant-foldable fill out of the layer loop, and CopyInsertion then mints a
+    fresh multi-GB copy into the in-place ``ragged_all_to_all`` output slot every iteration.
+    ``min(tie[0], -site) + site`` resists the fold because XLA cannot prove ``tie`` is
+    non-negative; an arithmetic identity such as ``tie[0] * 0`` would not.
+    """
+    assert _fill_survives_xla_constant_folding(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1))
+    assert not _fill_survives_xla_constant_folding(
+        lambda tie: jnp.broadcast_to((tie.reshape(-1)[0] * 0).astype(jnp.float32), (4, 3))
+    ), "the folding probe no longer folds, so this test can no longer detect a foldable fill"

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1422,6 +1422,5 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
         jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
     )
 
-    assert jaxpr.jaxpr.invars, "the fill takes no traced input, so it can be folded and hoisted"
     consumed = {id(var) for eqn in jaxpr.jaxpr.eqns for var in eqn.invars}
     assert any(id(var) in consumed for var in jaxpr.jaxpr.invars), "the fill ignores its tie, so it can be folded"

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -25,12 +25,12 @@ from levanter.grug._moe.common import (
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
-from levanter.grug._moe.ep_ragged_all_to_all import _loop_local_zeros, _LoopLocalZeroSite
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
     _interleaved_receiver_ranks,
     _receiver_ranks,
 )
+from levanter.grug._moe.ep_ragged_all_to_all import _loop_local_zeros, _LoopLocalZeroSite
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
     MoEExpertMlp,
@@ -1423,9 +1423,7 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
         == 1
     )
     assert (
-        _optimized_hlo_opcode_count(
-            lambda tie: jnp.broadcast_to((tie.reshape(-1)[0] * 0).astype(jnp.float32), (4, 3)), "kMinimum"
-        )
+        _optimized_hlo_opcode_count(lambda tie: jnp.broadcast_to((tie[0] * 0).astype(jnp.float32), (4, 3)), "kMinimum")
         == 0
     ), "the folding probe no longer folds, so this test can no longer detect a foldable fill"
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1434,7 +1434,7 @@ def test_loop_local_zeros_sites_prevent_cse():
     def distinct_sites(tie):
         return (
             _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT),
-            _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_COTANGENT),
+            _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.OPERAND_COTANGENT),
         )
 
     def repeated_site(tie):

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -25,7 +25,7 @@ from levanter.grug._moe.common import (
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
-from levanter.grug._moe.ep_ragged_all_to_all import _loop_local_zeros
+from levanter.grug._moe.ep_ragged_all_to_all import _loop_local_zeros, _LoopLocalZeroSite
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
     _interleaved_receiver_ranks,
@@ -1386,7 +1386,7 @@ def test_ragged_a2a_receiver_clipping_respects_capacity():
     assert int(jnp.sum(clipped)) < int(jnp.sum(group_sizes))
 
 
-@pytest.mark.parametrize("site", [0, 1, 2, 3, 4, 5])
+@pytest.mark.parametrize("site", list(_LoopLocalZeroSite))
 @pytest.mark.parametrize(
     "tie",
     [
@@ -1396,13 +1396,11 @@ def test_ragged_a2a_receiver_clipping_respects_capacity():
     ],
     ids=["all-empty-groups", "mixed", "large-first-group"],
 )
-def test_loop_local_zeros_fills_exact_zeros(site: int, tie: np.ndarray):
+def test_loop_local_zeros_fills_exact_zeros(site: _LoopLocalZeroSite, tie: np.ndarray):
     """The ragged-a2a output inits must be exactly zero at every call site the backend uses.
 
     Dropped source rows, and receiver rows no peer writes, keep this init; the combine reads them
-    as zero contributions. A non-zero fill corrupts training without raising. ``site=0`` is the
-    boundary case: its value is zero only because ``tie`` is non-negative, which an all-zero
-    ``tie`` exercises tightest.
+    as zero contributions. A non-zero fill corrupts training without raising.
     """
     filled = _loop_local_zeros(4, 3, jnp.float32, jnp.asarray(tie), site=site)
 
@@ -1434,7 +1432,13 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
     ``min(tie[0], -site) + site`` resists the fold because XLA cannot prove ``tie`` is
     non-negative; an arithmetic identity such as ``tie[0] * 0`` would not.
     """
-    assert _optimized_hlo_opcode_count(lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=1), "kMinimum") == 1
+    assert (
+        _optimized_hlo_opcode_count(
+            lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT),
+            "kMinimum",
+        )
+        == 1
+    )
     assert (
         _optimized_hlo_opcode_count(
             lambda tie: jnp.broadcast_to((tie.reshape(-1)[0] * 0).astype(jnp.float32), (4, 3)), "kMinimum"
@@ -1446,12 +1450,12 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
 def test_loop_local_zeros_sites_prevent_cse():
     def distinct_sites(tie):
         return (
-            _loop_local_zeros(4, 3, jnp.float32, tie, site=1),
-            _loop_local_zeros(4, 3, jnp.float32, tie, site=2),
+            _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT),
+            _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_COTANGENT),
         )
 
     def repeated_site(tie):
-        fill = _loop_local_zeros(4, 3, jnp.float32, tie, site=1)
+        fill = _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT)
         return fill, fill
 
     assert _optimized_hlo_opcode_count(distinct_sites, "kMinimum") == 2

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1403,6 +1403,10 @@ def test_loop_local_zeros_fills_exact_zeros(site: _LoopLocalZeroSite, tie: np.nd
     np.testing.assert_array_equal(np.asarray(filled), np.zeros((4, 3), dtype=np.float32))
 
 
+# The zero fill's traced minimum, as XLA names the opcode in optimized HLO.
+MINIMUM_OPCODE = "kMinimum"
+
+
 def _optimized_hlo_opcode_count(fill_fn, opcode_name: str) -> int:
     tie = jnp.asarray([1, 7, 0, 3], dtype=jnp.int32)
     executable = jax.jit(fill_fn).lower(tie).compile().runtime_executable()
@@ -1418,13 +1422,13 @@ def test_loop_local_zeros_is_not_a_foldable_constant():
     assert (
         _optimized_hlo_opcode_count(
             lambda tie: _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT),
-            "kMinimum",
+            MINIMUM_OPCODE,
         )
         == 1
     )
     assert (
         _optimized_hlo_opcode_count(
-            lambda tie: jnp.broadcast_to((jnp.minimum(tie[0], 5) * 0).astype(jnp.float32), (4, 3)), "kMinimum"
+            lambda tie: jnp.broadcast_to((jnp.minimum(tie[0], 5) * 0).astype(jnp.float32), (4, 3)), MINIMUM_OPCODE
         )
         == 0
     ), "the folding probe no longer folds, so this test can no longer detect a foldable fill"
@@ -1441,7 +1445,7 @@ def test_loop_local_zeros_sites_prevent_cse():
         fill = _loop_local_zeros(4, 3, jnp.float32, tie, site=_LoopLocalZeroSite.DISPATCH_OUTPUT)
         return fill, fill
 
-    assert _optimized_hlo_opcode_count(distinct_sites, "kMinimum") == 2
+    assert _optimized_hlo_opcode_count(distinct_sites, MINIMUM_OPCODE) == 2
     assert (
-        _optimized_hlo_opcode_count(repeated_site, "kMinimum") == 1
+        _optimized_hlo_opcode_count(repeated_site, MINIMUM_OPCODE) == 1
     ), "the CSE probe no longer merges repeated sites, so this test can no longer detect a site collision"


### PR DESCRIPTION
Every ragged all-to-all output init is now built inside the layer loop from a traced, per-site salted expression. One custom VJP wrapper gives the dispatch and return collectives the same loop-local inits in their transpose path. Hero EP64 throughput rises by 0.4 MFU.

`ragged_all_to_all` writes into its output-init operand. A `jnp.zeros` init is a trace-time constant. XLA hoists it out of the layer scan, and CSE merges equal inits. CopyInsertion then copies the pristine zeros into each collective output slot on every scan iteration. At the hero shape these copies cost 785 ms per step of compute-stream `MemcpyD2D`. The expression `min(size[0], -site) + site` is zero for non-negative sizes and depends on the traced size. Each call site uses a distinct `site` literal. XLA keeps the fills separate and inside the loop. Each init lowers to a write-only fill that the collective updates in place. Compute-stream D2D falls from 785 to about 4 ms per step. The async-start instruction count does not change.

Measurements use one GB200 NVL72 rack at EP64, restore the production hero checkpoint at step 30000, and score the median of `throughput/mfu` over restore steps +5 through +19. On the research/mcwitt/8753-mfu-loop tree, two treatment draws scored 23.68 and 23.78 against five same-night controls between 23.24 and 23.38. Peak HBM fell by 3.1 GiB on that tree. On current main the peak is 132.8 GiB with and without the change, so the change does not lower it there. A same-night ablation on current main scored the merge base at 23.24 and 23.18, the forward inits alone at 23.50, and the full change at 23.65. The wrappers carry about 0.15 of the 0.40 gain. The control draws had five and four scored steps about 5% below their medians. The treatment draws had none. The drop rate is 3.3e-5 in every arm. Pointwise loss differences between arms stay within 4.2e-5. State layout and dtype do not change, so checkpoints remain compatible.

The backward reproduces JAX 0.11.1's transpose rule, including its mask for rows the primal overwrote. That mask under-masks after an empty receive group. In this layer the mask cannot change a gradient. Each chunk's reverse transport reads only the rows that chunk wrote, and the first chunk's init carries no gradient. The 4-GPU gate in `tests/cluster/grug/test_ragged_ep_check.py` passed on 14a56fa645. Gradients match an exact fp32 dense reference on four seeds with and without drops. The worst per-slice median deviation is 8.1e-4, the same band as the ring backend. `ragged_all_to_all` does not lower on XLA:CPU, so CI traces the backward and does not run it.

Part of #8317.
