### PR TITLE
[levanter] Keep the whole-stack norm when splitting scan layers

### DIFF
--- a/lib/levanter/src/levanter/analysis/tree_stats.py
+++ b/lib/levanter/src/levanter/analysis/tree_stats.py
@@ -28,6 +28,22 @@ def _array_stacked_layer_in_axes(stacked: Any, num_layers: int) -> Any:
     )
 
 
+def _stacked_leaves(stacked: Any) -> list[tuple[str, Any]]:
+    """(key path, leaf) for each array leaf of a scan module's stacked body.
+
+    Keyed as the non-split path keys them so the whole-stack norm, taken over each original leaf,
+    stays comparable to non-split logging (and is correct for leaves shared across layers).
+    """
+    key_paths = jax_utils.leaf_key_paths(stacked, is_leaf=is_named_array)
+    return list(
+        zip(
+            jax.tree.leaves(key_paths, is_leaf=is_named_array),
+            jax.tree.leaves(stacked, is_leaf=is_named_array),
+            strict=True,
+        )
+    )
+
+
 def summary_statistics_for_tree(
     prefix: str,
     tree: Any,
@@ -80,8 +96,9 @@ def summary_statistics_for_tree(
                     for i in range(g.Block.size):
                         hists[f"{key_path}.{i}.{k}"] = jax.tree.map(lambda x: x[i] if is_jax_array_like(x) else x, v)
 
-                for k, v in vmapped_norms.items():
-                    norms[f"{key_path}.stacked.{k}"] = optax.global_norm(v)
+                if include_norms:
+                    for sub_key, leaf in _stacked_leaves(g.stacked):
+                        norms[f"{key_path}.stacked.{sub_key}"] = optax.global_norm(leaf)
 
             elif split_scan_layers and isinstance(g, haliax.nn.ArrayStacked):
                 num_layers = g.num_layers
@@ -98,8 +115,9 @@ def summary_statistics_for_tree(
                     for i in range(num_layers):
                         hists[f"{key_path}.{i}.{k}"] = jax.tree.map(lambda x: x[i] if is_jax_array_like(x) else x, v)
 
-                for k, v in vmapped_norms.items():
-                    norms[f"{key_path}.stacked.{k}"] = optax.global_norm(v)
+                if include_norms:
+                    for sub_key, leaf in _stacked_leaves(g.stacked):
+                        norms[f"{key_path}.stacked.{sub_key}"] = optax.global_norm(leaf)
 
             elif isinstance(g, NamedArray):
                 if include_norms:

--- a/lib/levanter/src/levanter/analysis/tree_stats.py
+++ b/lib/levanter/src/levanter/analysis/tree_stats.py
@@ -80,6 +80,9 @@ def summary_statistics_for_tree(
                     for i in range(g.Block.size):
                         hists[f"{key_path}.{i}.{k}"] = jax.tree.map(lambda x: x[i] if is_jax_array_like(x) else x, v)
 
+                for k, v in vmapped_norms.items():
+                    norms[f"{key_path}.stacked.{k}"] = optax.global_norm(v)
+
             elif split_scan_layers and isinstance(g, haliax.nn.ArrayStacked):
                 num_layers = g.num_layers
                 in_axes = _array_stacked_layer_in_axes(g.stacked, num_layers)
@@ -94,6 +97,9 @@ def summary_statistics_for_tree(
                 for k, v in vmapped_hists.items():
                     for i in range(num_layers):
                         hists[f"{key_path}.{i}.{k}"] = jax.tree.map(lambda x: x[i] if is_jax_array_like(x) else x, v)
+
+                for k, v in vmapped_norms.items():
+                    norms[f"{key_path}.stacked.{k}"] = optax.global_norm(v)
 
             elif isinstance(g, NamedArray):
                 if include_norms:

--- a/lib/levanter/tests/test_tree_stats.py
+++ b/lib/levanter/tests/test_tree_stats.py
@@ -60,6 +60,19 @@ def test_array_stacked_split_also_keeps_whole_stack_norm():
         assert jnp.allclose(stats[key], optax.global_norm(expected))
 
 
+def test_array_stacked_split_whole_stack_norm_handles_shared_leaves():
+    num_layers, width = 4, 3
+    model = _make_model(num_layers, width)
+    # A leaf shared across layers has no leading num_layers axis, so its aggregate must be its own
+    # norm, not sqrt(num_layers) times it.
+    shared_bias = jax.random.normal(jax.random.PRNGKey(2), (width,))
+    model = eqx.tree_at(lambda m: m.blocks.stacked.bias, model, shared_bias)
+
+    stats = summary_statistics_for_tree("grad", model, split_scan_layers=True)
+
+    assert jnp.allclose(stats["grad/norm/blocks.stacked.bias"], optax.global_norm(shared_bias))
+
+
 def test_array_stacked_split_distinguishes_divergent_layers():
     # A single layer with a blown-up weight must be identifiable by its own key.
     num_layers, width = 4, 3

--- a/lib/levanter/tests/test_tree_stats.py
+++ b/lib/levanter/tests/test_tree_stats.py
@@ -46,6 +46,20 @@ def test_array_stacked_split_emits_per_layer_norms():
             assert jnp.allclose(stats[key], optax.global_norm(expected))
 
 
+def test_array_stacked_split_also_keeps_whole_stack_norm():
+    num_layers, width = 4, 3
+    model = _make_model(num_layers, width)
+
+    stats = summary_statistics_for_tree("grad", model, split_scan_layers=True)
+
+    # Splitting still logs the whole-stack norm under the non-split key, so runs stay comparable to
+    # those logged before per-layer splitting.
+    for name, expected in (("weight", model.blocks.stacked.weight), ("bias", model.blocks.stacked.bias)):
+        key = f"grad/norm/blocks.stacked.{name}"
+        assert key in stats, f"missing {key}; got {sorted(stats)}"
+        assert jnp.allclose(stats[key], optax.global_norm(expected))
+
+
 def test_array_stacked_split_distinguishes_divergent_layers():
     # A single layer with a blown-up weight must be identifiable by its own key.
     num_layers, width = 4, 3


### PR DESCRIPTION
Per-layer splitting of scan-layer norms replaced the whole-stack norm with one norm per layer, so runs logged with splitting on no longer carry the aggregate that non-split runs recorded, and the two can't be overlaid in W&B.

Emit the whole-stack norm alongside the per-layer norms, under the same `{param}.stacked.{name}` key that non-split logging uses. The aggregate is `global_norm` over the vector of per-layer norms, which equals the norm of the full stacked array, so it reproduces the pre-splitting value exactly and is comparable to historical runs. It is always emitted when a stacked parameter is present — no config flag.
