### PR TITLE
[moe] Rename capacity-overflow stages

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -69,15 +69,15 @@ paired hero. Pooled-wave needed the master to fit at all.
 
 These ran before the ragged transport, at capacity and process settings the recipe no longer uses.
 
-The 1.10 sender and 1.15 receiver configuration completed a 20-step, one-rack gate. Median
+The 1.10 pre-transport pool and 1.15 post-transport expert configuration completed a 20-step, one-rack gate. Median
 throughput over steps 2 through 19 was 250,691 tokens/s, and final throughput was 246,947 tokens/s.
-The final loss was 6.3224. The final total drop rate was 19.33%: 7.14% at the sender and 12.19% at
-the receiver. The receiver dropped 13.12% of assignments that reached it. This short gate validates
-memory use and metric reporting. It does not estimate the steady drop rate. All 16 workers completed
+The final loss was 6.3224. The final total drop rate was 19.33%: 7.14% before transport and 12.19%
+after transport. Post-transport clipping dropped 13.12% of assignments that reached that stage. This
+short gate validates memory use and metric reporting. It does not estimate the steady drop rate. All 16 workers completed
 without an OOM, nonfinite value, failure, or preemption. See the
 [W&B run](https://wandb.ai/marin-community/rav_moe/runs/mhep-118-recv-metrics-send110-recv115-smoke).
 
-The prior 1.05 sender and 1.33 receiver configuration completed 200 steps on one rack. Over steps
+The prior 1.05 pre-transport pool and 1.33 post-transport expert configuration completed 200 steps on one rack. Over steps
 150 through 199, median throughput was 256,818 tokens/s and median MFU was 24.03%. Median routing
 drop rate was 2.41%, and the final drop rate was 2.21%. The final loss was 3.2510. All 16 workers
 completed without an OOM, nonfinite value, failure, or preemption. See the

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -56,6 +56,9 @@ from transformers import PretrainedConfig as HfConfig
 
 _GATED_NORM_RANK = 128
 _ROUTING_RENORM_SUM = 2.5
+MOE_DROPPED_ASSIGNMENTS_METRIC = "moe/dropped_assignments"
+MOE_PRE_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC = "moe/pre_transport_dropped_assignments"
+MOE_POST_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC = "moe/post_transport_dropped_assignments"
 # Large-vocab CE via the plain-XLA path (no shared-memory tiling, so v_block can be large).
 # v=4096 is the dominant MFU lever for the 128k vocab; the SMEM-tiled batched_xla kernel caps the
 # h*v weight tile at ~99KB and cannot take v=4096.
@@ -1389,11 +1392,11 @@ class Transformer(eqx.Module):
                 # the host in int64. Summing here with jnp.sum overflows int32 at large batch (e.g. batch
                 # 4096: 4096*4096*8*48 ~ 6.4e9 assignments > 2.1e9) and breaks the total accounting check,
                 # since jax_enable_x64 is off so an in-device int64 sum silently downcasts.
-                summarized_metrics["moe/dropped_assignments"] = router_metrics["capacity_overflow_per_layer"]
-                summarized_metrics["moe/pre_transport_dropped_assignments"] = router_metrics[
+                summarized_metrics[MOE_DROPPED_ASSIGNMENTS_METRIC] = router_metrics["capacity_overflow_per_layer"]
+                summarized_metrics[MOE_PRE_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC] = router_metrics[
                     "pre_transport_capacity_overflow_per_layer"
                 ]
-                summarized_metrics["moe/post_transport_dropped_assignments"] = router_metrics[
+                summarized_metrics[MOE_POST_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC] = router_metrics[
                     "post_transport_capacity_overflow_per_layer"
                 ]
             return loss, summarized_metrics

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -783,8 +783,8 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
-    sender_capacity_overflow = router_metrics["sender_capacity_overflow_per_layer"]
-    receiver_capacity_overflow = router_metrics["receiver_capacity_overflow_per_layer"]
+    pre_transport_capacity_overflow = router_metrics["pre_transport_capacity_overflow_per_layer"]
+    post_transport_capacity_overflow = router_metrics["post_transport_capacity_overflow_per_layer"]
     margin_min = router_metrics["margin_min_per_layer"]  # HIST estimator's live grid lo per layer (0 under TOPK)
     margin_max = router_metrics["margin_max_per_layer"]  # HIST estimator's live grid hi per layer (0 under TOPK)
     qb_beta = router_metrics.get("qb_beta_per_layer")  # per-layer per-expert beta; router_bias = -qb_beta
@@ -793,8 +793,12 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
     assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
     capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
-    sender_overflow_rate = sender_capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
-    receiver_overflow_rate = receiver_capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
+    pre_transport_overflow_rate = pre_transport_capacity_overflow.astype(jnp.float32) / jnp.maximum(
+        assignments_per_layer, 1.0
+    )
+    post_transport_overflow_rate = post_transport_capacity_overflow.astype(jnp.float32) / jnp.maximum(
+        assignments_per_layer, 1.0
+    )
 
     out: dict[str, jax.Array | SummaryStats] = {
         "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
@@ -802,8 +806,8 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/router_z_loss": jnp.mean(router_z_loss),
         "train/router/routing_counts_per_layer": routing_counts,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
-        "train/router/sender_overflow_rate_mean": jnp.mean(sender_overflow_rate),
-        "train/router/receiver_overflow_rate_mean": jnp.mean(receiver_overflow_rate),
+        "train/router/pre_transport_overflow_rate_mean": jnp.mean(pre_transport_overflow_rate),
+        "train/router/post_transport_overflow_rate_mean": jnp.mean(post_transport_overflow_rate),
         # QB HIST margin range: min over layers and max over layers, plus per-layer below.
         "train/router/margin_min": jnp.min(margin_min),
         "train/router/margin_max": jnp.max(margin_max),
@@ -1061,16 +1065,16 @@ class MoEMLP(eqx.Module):
         if self.cfg.report_capacity_overflow:
             routed_flat, capacity_overflow = moe_out
             dropped_assignments = capacity_overflow.total
-            sender_dropped_assignments = capacity_overflow.sender
-            receiver_dropped_assignments = capacity_overflow.receiver
+            pre_transport_dropped_assignments = capacity_overflow.pre_transport
+            post_transport_dropped_assignments = capacity_overflow.post_transport
         else:
             routed_flat = moe_out
             dropped_assignments = _zero_dropped_assignments()
-            sender_dropped_assignments = _zero_dropped_assignments()
-            receiver_dropped_assignments = _zero_dropped_assignments()
+            pre_transport_dropped_assignments = _zero_dropped_assignments()
+            post_transport_dropped_assignments = _zero_dropped_assignments()
         router_stats["capacity_overflow"] = dropped_assignments
-        router_stats["sender_capacity_overflow"] = sender_dropped_assignments
-        router_stats["receiver_capacity_overflow"] = receiver_dropped_assignments
+        router_stats["pre_transport_capacity_overflow"] = pre_transport_dropped_assignments
+        router_stats["post_transport_capacity_overflow"] = post_transport_dropped_assignments
 
         # Expand after the combine: `expert_mlp` already returns the weight-summed expert output,
         # which is the vector the paper's W_up acts on.
@@ -1312,8 +1316,8 @@ class Transformer(eqx.Module):
             "router_z_loss_per_layer": reduced_router_stats["router_z_loss"],
             "qb_beta_per_layer": reduced_router_stats["qb_beta"],
             "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
-            "sender_capacity_overflow_per_layer": stacked_router_stats["sender_capacity_overflow"],
-            "receiver_capacity_overflow_per_layer": stacked_router_stats["receiver_capacity_overflow"],
+            "pre_transport_capacity_overflow_per_layer": stacked_router_stats["pre_transport_capacity_overflow"],
+            "post_transport_capacity_overflow_per_layer": stacked_router_stats["post_transport_capacity_overflow"],
             "margin_min_per_layer": stacked_router_stats["margin_min"],
             "margin_max_per_layer": stacked_router_stats["margin_max"],
         }
@@ -1383,14 +1387,14 @@ class Transformer(eqx.Module):
             if self.config.report_capacity_overflow:
                 # Keep the per-layer int32 counts (each fits int32); the trainer sums them over layers on
                 # the host in int64. Summing here with jnp.sum overflows int32 at large batch (e.g. batch
-                # 4096: 4096*4096*8*48 ~ 6.4e9 assignments > 2.1e9) and breaks the total==sender+receiver
-                # accounting check, since jax_enable_x64 is off so an in-device int64 sum silently downcasts.
+                # 4096: 4096*4096*8*48 ~ 6.4e9 assignments > 2.1e9) and breaks the total accounting check,
+                # since jax_enable_x64 is off so an in-device int64 sum silently downcasts.
                 summarized_metrics["moe/dropped_assignments"] = router_metrics["capacity_overflow_per_layer"]
-                summarized_metrics["moe/sender_dropped_assignments"] = router_metrics[
-                    "sender_capacity_overflow_per_layer"
+                summarized_metrics["moe/pre_transport_dropped_assignments"] = router_metrics[
+                    "pre_transport_capacity_overflow_per_layer"
                 ]
-                summarized_metrics["moe/receiver_dropped_assignments"] = router_metrics[
-                    "receiver_capacity_overflow_per_layer"
+                summarized_metrics["moe/post_transport_dropped_assignments"] = router_metrics[
+                    "post_transport_capacity_overflow_per_layer"
                 ]
             return loss, summarized_metrics
         return loss

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -710,8 +710,8 @@ def initial_state(
 
 def _drop_metrics(
     dropped_assignments: jax.Array,
-    sender_dropped_assignments: jax.Array,
-    receiver_dropped_assignments: jax.Array,
+    pre_transport_dropped_assignments: jax.Array,
+    post_transport_dropped_assignments: jax.Array,
     *,
     batch_size: int,
     sequence_length: int,
@@ -724,20 +724,22 @@ def _drop_metrics(
         return int(np.asarray(per_layer).astype(np.int64).sum())
 
     dropped_assignments_host = _sum_int64(dropped_assignments)
-    sender_dropped_assignments_host = _sum_int64(sender_dropped_assignments)
-    receiver_dropped_assignments_host = _sum_int64(receiver_dropped_assignments)
-    if dropped_assignments_host != sender_dropped_assignments_host + receiver_dropped_assignments_host:
-        raise ValueError("total dropped assignments must equal sender plus receiver dropped assignments")
+    pre_transport_dropped_assignments_host = _sum_int64(pre_transport_dropped_assignments)
+    post_transport_dropped_assignments_host = _sum_int64(post_transport_dropped_assignments)
+    if dropped_assignments_host != pre_transport_dropped_assignments_host + post_transport_dropped_assignments_host:
+        raise ValueError("total dropped assignments must equal pre-transport plus post-transport dropped assignments")
     total_assignments = batch_size * sequence_length * top_k * num_layers
-    receiver_assignments = total_assignments - sender_dropped_assignments_host
+    post_transport_assignments = total_assignments - pre_transport_dropped_assignments_host
     return {
         "moe/dropped_assignments": dropped_assignments_host,
         "moe/drop_fraction": dropped_assignments_host / total_assignments,
-        "moe/sender_dropped_assignments": sender_dropped_assignments_host,
-        "moe/sender_drop_fraction": sender_dropped_assignments_host / total_assignments,
-        "moe/receiver_dropped_assignments": receiver_dropped_assignments_host,
-        "moe/receiver_drop_fraction": receiver_dropped_assignments_host / total_assignments,
-        "moe/receiver_drop_fraction_of_received": receiver_dropped_assignments_host / max(receiver_assignments, 1),
+        "moe/pre_transport_dropped_assignments": pre_transport_dropped_assignments_host,
+        "moe/pre_transport_drop_fraction": pre_transport_dropped_assignments_host / total_assignments,
+        "moe/post_transport_dropped_assignments": post_transport_dropped_assignments_host,
+        "moe/post_transport_drop_fraction": post_transport_dropped_assignments_host / total_assignments,
+        "moe/post_transport_drop_fraction_of_received": (
+            post_transport_dropped_assignments_host / max(post_transport_assignments, 1)
+        ),
     }
 
 
@@ -1194,8 +1196,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     if "moe/dropped_assignments" in metrics:
                         drop_metrics = _drop_metrics(
                             metrics["moe/dropped_assignments"],
-                            metrics["moe/sender_dropped_assignments"],
-                            metrics["moe/receiver_dropped_assignments"],
+                            metrics["moe/pre_transport_dropped_assignments"],
+                            metrics["moe/post_transport_dropped_assignments"],
                             batch_size=batch.tokens.shape[0],
                             sequence_length=batch.tokens.shape[1],
                             top_k=config.model.num_experts_per_token,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -58,7 +58,15 @@ from experiments.grug.checkpointing import (
     restore_grug_state_from_checkpoint,
 )
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe_hero_ep.model import OFFLOAD_CARRY_REMAT_MODE, GrugModelConfig, RematMode, Transformer
+from experiments.grug.moe_hero_ep.model import (
+    MOE_DROPPED_ASSIGNMENTS_METRIC,
+    MOE_POST_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC,
+    MOE_PRE_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC,
+    OFFLOAD_CARRY_REMAT_MODE,
+    GrugModelConfig,
+    RematMode,
+    Transformer,
+)
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
@@ -731,11 +739,11 @@ def _drop_metrics(
     total_assignments = batch_size * sequence_length * top_k * num_layers
     post_transport_assignments = total_assignments - pre_transport_dropped_assignments_host
     return {
-        "moe/dropped_assignments": dropped_assignments_host,
+        MOE_DROPPED_ASSIGNMENTS_METRIC: dropped_assignments_host,
         "moe/drop_fraction": dropped_assignments_host / total_assignments,
-        "moe/pre_transport_dropped_assignments": pre_transport_dropped_assignments_host,
+        MOE_PRE_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC: pre_transport_dropped_assignments_host,
         "moe/pre_transport_drop_fraction": pre_transport_dropped_assignments_host / total_assignments,
-        "moe/post_transport_dropped_assignments": post_transport_dropped_assignments_host,
+        MOE_POST_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC: post_transport_dropped_assignments_host,
         "moe/post_transport_drop_fraction": post_transport_dropped_assignments_host / total_assignments,
         "moe/post_transport_drop_fraction_of_received": (
             post_transport_dropped_assignments_host / max(post_transport_assignments, 1)
@@ -1193,11 +1201,11 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                             {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
                             step=step,
                         )
-                    if "moe/dropped_assignments" in metrics:
+                    if MOE_DROPPED_ASSIGNMENTS_METRIC in metrics:
                         drop_metrics = _drop_metrics(
-                            metrics["moe/dropped_assignments"],
-                            metrics["moe/pre_transport_dropped_assignments"],
-                            metrics["moe/post_transport_dropped_assignments"],
+                            metrics[MOE_DROPPED_ASSIGNMENTS_METRIC],
+                            metrics[MOE_PRE_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC],
+                            metrics[MOE_POST_TRANSPORT_DROPPED_ASSIGNMENTS_METRIC],
                             batch_size=batch.tokens.shape[0],
                             sequence_length=batch.tokens.shape[1],
                             top_k=config.model.num_experts_per_token,

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -1801,7 +1801,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'moe_drop_fraction' THEN value END) AS drop_fraction, AVG(CASE WHEN name = 'moe_sender_drop_fraction' THEN value END) AS sender_drop_fraction, AVG(CASE WHEN name = 'moe_receiver_drop_fraction' THEN value END) AS receiver_drop_fraction, CAST(0.07 AS DOUBLE) AS alert_threshold FROM telemetry WHERE name IN ('moe_drop_fraction', 'moe_sender_drop_fraction', 'moe_receiver_drop_fraction') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'moe_drop_fraction' THEN value END) AS drop_fraction, AVG(CASE WHEN name = 'moe_pre_transport_drop_fraction' THEN value END) AS pre_transport_drop_fraction, AVG(CASE WHEN name = 'moe_post_transport_drop_fraction' THEN value END) AS post_transport_drop_fraction, CAST(0.07 AS DOUBLE) AS alert_threshold FROM telemetry WHERE name IN ('moe_drop_fraction', 'moe_pre_transport_drop_fraction', 'moe_post_transport_drop_fraction') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -1825,13 +1825,13 @@
               "type": "number"
             },
             {
-              "selector": "sender_drop_fraction",
-              "text": "sender drop",
+              "selector": "pre_transport_drop_fraction",
+              "text": "pre-transport drop",
               "type": "number"
             },
             {
-              "selector": "receiver_drop_fraction",
-              "text": "receiver drop",
+              "selector": "post_transport_drop_fraction",
+              "text": "post-transport drop",
               "type": "number"
             },
             {

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -1159,8 +1159,8 @@ def test_training_moe_health_queries_show_routing_signals():
         "INSERT INTO telemetry_v1 VALUES ('levanter', 'hero-run', ?, ?, ?)",
         [
             ("moe_drop_fraction", 0.04, at),
-            ("moe_sender_drop_fraction", 0.03, at),
-            ("moe_receiver_drop_fraction", 0.02, at),
+            ("moe_pre_transport_drop_fraction", 0.03, at),
+            ("moe_post_transport_drop_fraction", 0.02, at),
             ("train_router_routing_entropy_mean", 5.93, at),
             ("train_router_bias_max", 390.0, at),
             ("train_router_bias_min", -380.0, at),

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -130,12 +130,12 @@ MOE_REMAT_SAVE_NAMES = (
 class CapacityOverflow(NamedTuple):
     """Expert assignments dropped before and after transport."""
 
-    sender: Int[Array, ""]
-    receiver: Int[Array, ""]
+    pre_transport: Int[Array, ""]
+    post_transport: Int[Array, ""]
 
     @property
     def total(self) -> Int[Array, ""]:
-        return self.sender + self.receiver
+        return self.pre_transport + self.post_transport
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -194,6 +194,6 @@ def _moe_mlp_ep_deepep_local(
             )
         dropped_total = jnp.array(0, dtype=jnp.int32)
     return out_local.astype(x_local.dtype), CapacityOverflow(
-        sender=dropped_total,
-        receiver=jnp.zeros_like(dropped_total),
+        pre_transport=dropped_total,
+        post_transport=jnp.zeros_like(dropped_total),
     )

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_all_to_all.py
@@ -178,4 +178,4 @@ def _moe_mlp_ep_fixed_a2a_local(
         ).astype(x_local.dtype)
         dropped_local = assignments_per_shard - jnp.sum(keep, dtype=jnp.int32)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, CapacityOverflow(sender=dropped_total, receiver=jnp.zeros_like(dropped_total))
+    return out_local, CapacityOverflow(pre_transport=dropped_total, post_transport=jnp.zeros_like(dropped_total))

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -596,5 +596,5 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
     sender_dropped = assignments_per_shard - jnp.sum(sender_keep, dtype=jnp.int32)
     dropped_by_stage_local = jnp.stack((sender_dropped, receiver_dropped))
     dropped_by_stage = jax.lax.psum(dropped_by_stage_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    overflow = CapacityOverflow(sender=dropped_by_stage[0], receiver=dropped_by_stage[1])
+    overflow = CapacityOverflow(pre_transport=dropped_by_stage[0], post_transport=dropped_by_stage[1])
     return out_local.astype(x_local.dtype), overflow

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -325,4 +325,4 @@ def _moe_mlp_ep_ragged_a2a_local(
         ).astype(x_local.dtype)
         dropped_local = jnp.sum(group_sizes, dtype=jnp.int32) - accepted_local
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, CapacityOverflow(sender=dropped_total, receiver=jnp.zeros_like(dropped_total))
+    return out_local, CapacityOverflow(pre_transport=dropped_total, post_transport=jnp.zeros_like(dropped_total))

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -114,4 +114,4 @@ def _moe_mlp_ep_ring_local(
         # reducing contributions from experts across the EP mesh.
         out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, CapacityOverflow(sender=jnp.zeros_like(dropped_total), receiver=dropped_total)
+    return out_local, CapacityOverflow(pre_transport=jnp.zeros_like(dropped_total), post_transport=dropped_total)

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -165,8 +165,8 @@ def moe_mlp(
     precomputed token-to-expert assignments. Routing logits/top-k selection
     stays in the caller (e.g. model MLP block).
 
-    Set `report_capacity_overflow=True` to also return sender and receiver
-    counts for expert assignments dropped by EP capacity clipping.
+    Set `report_capacity_overflow=True` to also return pre-transport and
+    post-transport counts for expert assignments dropped by EP capacity clipping.
 
     `expert_chunks` applies only to the local `sonic_cute` FSDP path. Values
     greater than one split the expert bank into equal, statically sized chunks.
@@ -222,7 +222,7 @@ def moe_mlp(
             expert_chunks=expert_chunks,
         )
         if report_capacity_overflow:
-            return out, CapacityOverflow(sender=dropped, receiver=jnp.zeros_like(dropped))
+            return out, CapacityOverflow(pre_transport=dropped, post_transport=jnp.zeros_like(dropped))
         return out
 
     batch_spec = _batch_spec_from_x(x, mesh)
@@ -282,7 +282,7 @@ def moe_mlp(
                 w_up_gate_spec,
                 w_down_spec,
             ),
-            out_specs=(batch_spec, CapacityOverflow(sender=P(), receiver=P())),
+            out_specs=(batch_spec, CapacityOverflow(pre_transport=P(), post_transport=P())),
             check_vma=False,
         )
         out, overflow = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
@@ -352,7 +352,7 @@ def moe_mlp(
     )
     out, dropped = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
     if report_capacity_overflow:
-        return out, CapacityOverflow(sender=dropped, receiver=jnp.zeros_like(dropped))
+        return out, CapacityOverflow(pre_transport=dropped, post_transport=jnp.zeros_like(dropped))
     return out
 
 

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -769,7 +769,6 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
         )
     assert int(overflow.pre_transport) == 4
     assert int(overflow.post_transport) == 0
-    assert int(overflow.total) == int(overflow.pre_transport + overflow.post_transport)
 
 
 @pytest.mark.timeout(180)
@@ -903,7 +902,6 @@ def test_fixed_pooled_wave_all_to_all_reports_pre_and_post_transport_drops():
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
     assert int(overflow.pre_transport) == 3
     assert int(overflow.post_transport) == 3
-    assert int(overflow.total) == int(overflow.pre_transport + overflow.post_transport)
 
 
 @pytest.mark.parametrize("implementation", ["ring", "fixed_all_to_all", "fixed_pooled_wave_all_to_all"])
@@ -1373,7 +1371,6 @@ def test_moe_mlp_reports_positive_drop_count_in_ring_ep_when_over_capacity():
     assert dropped.total.shape == ()
     assert int(dropped.pre_transport) == 0
     assert int(dropped.post_transport) > 0
-    assert int(dropped.total) == int(dropped.pre_transport + dropped.post_transport)
 
 
 def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
@@ -1420,7 +1417,6 @@ def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
     assert dropped.total.shape == ()
     assert int(dropped.pre_transport) > 0
     assert int(dropped.post_transport) == 0
-    assert int(dropped.total) == int(dropped.pre_transport + dropped.post_transport)
 
 
 def test_ragged_a2a_receiver_clipping_respects_capacity():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -733,7 +733,7 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
         fixed_a2a,
         mesh=mesh,
         in_specs=(P(), P(), P(), P(), P()),
-        out_specs=(P(), CapacityOverflow(sender=P(), receiver=P())),
+        out_specs=(P(), CapacityOverflow(pre_transport=P(), post_transport=P())),
         check_vma=False,
     )
     with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
@@ -767,8 +767,9 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
             rtol=1e-5,
             atol=1e-5,
         )
-    assert int(overflow.sender) == 4
-    assert int(overflow.receiver) == 0
+    assert int(overflow.pre_transport) == 4
+    assert int(overflow.post_transport) == 0
+    assert int(overflow.total) == int(overflow.pre_transport + overflow.post_transport)
 
 
 @pytest.mark.timeout(180)
@@ -855,7 +856,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
     assert _count_jaxpr_primitives(gradient_jaxpr, "all_to_all") == 6 * num_expert_waves
 
 
-def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
+def test_fixed_pooled_wave_all_to_all_reports_pre_and_post_transport_drops():
     mesh = _make_single_expert_mesh()
     tokens = 6
     hidden_dim = 4
@@ -890,7 +891,7 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
         pooled_output,
         mesh=mesh,
         in_specs=(P(), P(), P(), P()),
-        out_specs=(P(), CapacityOverflow(sender=P(), receiver=P())),
+        out_specs=(P(), CapacityOverflow(pre_transport=P(), post_transport=P())),
         check_vma=False,
     )
     with jax.set_mesh(mesh):
@@ -900,8 +901,9 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     expected = _dense_moe_output(x, selected_experts, combine_weights * keep, w_up_gate, w_down)
 
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
-    assert int(overflow.sender) == 3
-    assert int(overflow.receiver) == 3
+    assert int(overflow.pre_transport) == 3
+    assert int(overflow.post_transport) == 3
+    assert int(overflow.total) == int(overflow.pre_transport + overflow.post_transport)
 
 
 @pytest.mark.parametrize("implementation", ["ring", "fixed_all_to_all", "fixed_pooled_wave_all_to_all"])
@@ -1369,7 +1371,9 @@ def test_moe_mlp_reports_positive_drop_count_in_ring_ep_when_over_capacity():
 
     assert out.shape == (tokens, hidden_dim)
     assert dropped.total.shape == ()
-    assert int(dropped.total) > 0
+    assert int(dropped.pre_transport) == 0
+    assert int(dropped.post_transport) > 0
+    assert int(dropped.total) == int(dropped.pre_transport + dropped.post_transport)
 
 
 def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
@@ -1414,7 +1418,9 @@ def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
 
     assert out.shape == (tokens, hidden_dim)
     assert dropped.total.shape == ()
-    assert int(dropped.total) > 0
+    assert int(dropped.pre_transport) > 0
+    assert int(dropped.post_transport) == 0
+    assert int(dropped.total) == int(dropped.pre_transport + dropped.post_transport)
 
 
 def test_ragged_a2a_receiver_clipping_respects_capacity():

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -1081,7 +1081,7 @@ def test_fp32_host_master_preserves_float32_initialization(monkeypatch):
     )
 
 
-def test_drop_metrics_reports_sender_and_receiver_fractions():
+def test_drop_metrics_reports_pre_and_post_transport_fractions():
     metrics = train._drop_metrics(
         jnp.array(5, dtype=jnp.int32),
         jnp.array(2, dtype=jnp.int32),
@@ -1095,37 +1095,50 @@ def test_drop_metrics_reports_sender_and_receiver_fractions():
     assert metrics == {
         "moe/dropped_assignments": 5,
         "moe/drop_fraction": 5 / 16,
-        "moe/sender_dropped_assignments": 2,
-        "moe/sender_drop_fraction": 2 / 16,
-        "moe/receiver_dropped_assignments": 3,
-        "moe/receiver_drop_fraction": 3 / 16,
-        "moe/receiver_drop_fraction_of_received": 3 / 14,
+        "moe/pre_transport_dropped_assignments": 2,
+        "moe/pre_transport_drop_fraction": 2 / 16,
+        "moe/post_transport_dropped_assignments": 3,
+        "moe/post_transport_drop_fraction": 3 / 16,
+        "moe/post_transport_drop_fraction_of_received": 3 / 14,
     }
 
 
 def test_drop_metrics_sums_per_layer_counts_in_int64_without_overflow():
     # Per-layer int32 counts whose 48-layer sum exceeds int32 (jax_enable_x64 is off, so an in-device
-    # jnp.sum would wrap and break the total==sender+receiver check). The host sum must stay exact.
+    # jnp.sum would wrap and break the total==pre-transport+post-transport check). The host sum must stay exact.
     num_layers = 48
-    per_layer_sender = jnp.full((num_layers,), 40_000_000, dtype=jnp.int32)  # 48 * 40M = 1.92e9
-    per_layer_receiver = jnp.full((num_layers,), 60_000_000, dtype=jnp.int32)  # 48 * 60M = 2.88e9 > int32
-    per_layer_total = per_layer_sender + per_layer_receiver
-    sender_total = 48 * 40_000_000
-    receiver_total = 48 * 60_000_000
+    per_layer_pre_transport = jnp.full((num_layers,), 40_000_000, dtype=jnp.int32)  # 48 * 40M = 1.92e9
+    per_layer_post_transport = jnp.full((num_layers,), 60_000_000, dtype=jnp.int32)  # 48 * 60M = 2.88e9 > int32
+    per_layer_total = per_layer_pre_transport + per_layer_post_transport
+    pre_transport_total = 48 * 40_000_000
+    post_transport_total = 48 * 60_000_000
 
     metrics = train._drop_metrics(
         per_layer_total,
-        per_layer_sender,
-        per_layer_receiver,
+        per_layer_pre_transport,
+        per_layer_post_transport,
         batch_size=4096,
         sequence_length=4096,
         top_k=8,
         num_layers=num_layers,
     )
 
-    assert metrics["moe/dropped_assignments"] == sender_total + receiver_total  # no int32 wrap
-    assert metrics["moe/sender_dropped_assignments"] == sender_total
-    assert metrics["moe/receiver_dropped_assignments"] == receiver_total
+    assert metrics["moe/dropped_assignments"] == pre_transport_total + post_transport_total  # no int32 wrap
+    assert metrics["moe/pre_transport_dropped_assignments"] == pre_transport_total
+    assert metrics["moe/post_transport_dropped_assignments"] == post_transport_total
+
+
+def test_drop_metrics_rejects_inconsistent_total():
+    with pytest.raises(ValueError):
+        train._drop_metrics(
+            jnp.array(6, dtype=jnp.int32),
+            jnp.array(2, dtype=jnp.int32),
+            jnp.array(3, dtype=jnp.int32),
+            batch_size=2,
+            sequence_length=4,
+            top_k=2,
+            num_layers=1,
+        )
 
 
 def test_baseline_eval_hook_runs_once_after_the_first_step():


### PR DESCRIPTION
Report staged MoE capacity overflow with pre-transport and post-transport terminology. The staged `moe/sender_` and `moe/receiver_` metric prefixes become `moe/pre_transport_` and `moe/post_transport_`; the `CapacityOverflow` result fields follow the same mapping. Ragged all-to-all capacity clipping maps to pre-transport. Pooled-wave maps sender-pool clipping to pre-transport and receiver-expert clipping to post-transport. The total `moe/dropped_assignments` and `moe/drop_fraction` metrics retain their names.

The prior sender/receiver prefixes made a ragged all-to-all run appear to use pooled-wave staging even though its drops occur before transport. Corresponding numeric values and training behavior do not change. Dispatch math, capacity factors, clipping, model outputs, loss, gradients, and checkpoint formats are unchanged.
