### PR TITLE
[profiling] Skip empty XProf tool outputs

### DIFF
--- a/lib/marin/src/marin/profiling/xplane.py
+++ b/lib/marin/src/marin/profiling/xplane.py
@@ -151,6 +151,9 @@ def export_xplane_tables(
             continue
         target = output_dir / f"{tool}.json"
         encoded = _tool_data_to_bytes(data)
+        if not encoded.strip():
+            target.unlink(missing_ok=True)
+            continue
         target.write_bytes(encoded)
         sizes[tool] = len(encoded)
 

--- a/tests/profiling/test_profile_summary.py
+++ b/tests/profiling/test_profile_summary.py
@@ -733,6 +733,8 @@ def test_export_xplane_tables_accepts_text_and_counts_trace_events(tmp_path: Pat
             return b'{"returnedEventsSize":1000000}', "application/json"
         if tool == "overview_page":
             return '{"cols":[],"rows":[]}', "application/json"
+        if tool == "memory_profile":
+            return b"", "application/json"
         return b'{"cols":[],"rows":[]}', "application/json"
 
     raw_to_tool_data_module.__dict__["xspace_to_tool_data"] = xspace_to_tool_data
@@ -742,11 +744,16 @@ def test_export_xplane_tables_accepts_text_and_counts_trace_events(tmp_path: Pat
     monkeypatch.setitem(sys.modules, "xprof.convert", convert_module)
     monkeypatch.setitem(sys.modules, "xprof.convert.raw_to_tool_data", raw_to_tool_data_module)
 
-    export = export_xplane_tables(xplane_path, tmp_path / "tables", count_trace_events=True)
+    output_dir = tmp_path / "tables"
+    output_dir.mkdir()
+    (output_dir / "memory_profile.json").write_text('{"stale":true}', encoding="utf-8")
+    export = export_xplane_tables(xplane_path, output_dir, count_trace_events=True)
 
     assert export.trace_event_count == 1_000_000
     assert export.table_sizes["overview_page"] == len('{"cols":[],"rows":[]}')
     assert (export.output_dir / "overview_page.json").read_text(encoding="utf-8") == '{"cols":[],"rows":[]}'
+    assert "memory_profile" not in export.table_sizes
+    assert not (export.output_dir / "memory_profile.json").exists()
     assert set(XPROF_TABLE_TOOLS).issubset(seen_tools)
     assert "trace_viewer@" in seen_tools
 


### PR DESCRIPTION
Skip empty optional XProf tool payloads instead of writing zero-byte JSON files. Remove a matching stale file when the output directory is reused so later summaries cannot read data from an earlier conversion.

XProf 2.23.1 returns empty optional-tool payloads for some sparse traces.
