### PR TITLE
[zephyr] Retry transient shuffle sidecar reads

### DIFF
--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -51,8 +51,9 @@ import psutil
 import pyarrow as pa
 from iris.env_resources import TaskResources
 from rigging.filesystem.factory import open_url, url_to_fs
+from rigging.filesystem.s3_errors import is_transient_s3_error
 from rigging.filesystem.storage_path import StoragePath
-from rigging.timing import RateLimiter, log_time
+from rigging.timing import RateLimiter, log_time, retry_with_backoff
 
 from zephyr import memory_budget
 from zephyr.parquet_scan import scan_parquet
@@ -312,9 +313,20 @@ class _Sidecar:
     @classmethod
     def read(cls, fs: _SidecarFilesystem, data_path: str) -> "_Sidecar | None":
         """Load one non-empty sidecar, returning ``None`` for an empty writer."""
-        meta_path = fs._strip_protocol(cls.meta_path(data_path))
+        source_path = cls.meta_path(data_path)
+        meta_path = fs._strip_protocol(source_path)
         # Avoid buffered-file overhead for these small payloads.
-        data = cls._decoder.decode(fs.cat_file(meta_path))
+        try:
+            payload = retry_with_backoff(
+                lambda: fs.cat_file(meta_path),
+                retryable=is_transient_s3_error,
+                max_attempts=4,
+                operation=f"read scatter sidecar {source_path}",
+            )
+        except Exception as error:
+            error.add_note(f"while reading scatter sidecar {source_path}")
+            raise
+        data = cls._decoder.decode(payload)
         files = data.get(cls._files_field, [])
         if not files:
             return None

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -17,6 +17,7 @@ import fsspec
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
+from botocore.exceptions import EndpointConnectionError
 from fsspec.implementations.local import LocalFileSystem
 from iris.env_resources import TaskResources
 from rigging.filesystem.storage_path import StoragePath
@@ -806,6 +807,42 @@ class _CountingFileSystem(LocalFileSystem):
     @classmethod
     def _strip_protocol(cls, path):
         return super()._strip_protocol(str(path).removeprefix("counting://"))
+
+
+class _SequencedSidecarFileSystem:
+    def __init__(self, responses: list[bytes | Exception]):
+        self._responses = responses
+        self.reads: list[str] = []
+
+    @staticmethod
+    def _strip_protocol(path: str) -> str:
+        return path.removeprefix("s3://")
+
+    def cat_file(self, path: str) -> bytes:
+        self.reads.append(path)
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def test_sidecar_read_retries_transient_s3_error(monkeypatch):
+    monkeypatch.setattr("rigging.timing.time.sleep", lambda _: None)
+    payload = _Sidecar._encoder.encode({"files": [], "shard_bytes": {}, "shard_rows": {}})
+    fs = _SequencedSidecarFileSystem([EndpointConnectionError(endpoint_url="https://bucket.example.com"), payload])
+
+    assert _Sidecar.read(fs, "s3://bucket/shard/") is None
+    assert fs.reads == ["bucket/shard/metadata.msgpack"] * 2
+
+
+def test_sidecar_read_does_not_retry_permanent_error():
+    fs = _SequencedSidecarFileSystem([FileNotFoundError("missing")])
+
+    with pytest.raises(FileNotFoundError, match="missing") as exc_info:
+        _Sidecar.read(fs, "s3://bucket/shard/")
+
+    assert fs.reads == ["bucket/shard/metadata.msgpack"]
+    assert "s3://bucket/shard/metadata.msgpack" in "\n".join(getattr(exc_info.value, "__notes__", []))
 
 
 def test_sidecar_reads_build_one_client(tmp_path):


### PR DESCRIPTION
Make at most four attempts to read a shuffle sidecar when the existing S3 error classifier identifies a transient failure. A failed read currently aborts the reducer, so a task retry repeats sidecar reads that already succeeded.

MessagePack decoding stays outside this retry. Permanent read failures are attempted once. Exhausted retries re-raise the original exception with the sidecar path attached.

Fixes #8389
