### PR TITLE
[grug] Run only the dropless eval on the ragged hero rungs

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -268,6 +268,8 @@ def build_diagnostic_run(
                 GrugEvalConfig(
                     steps_per_eval=eval_every,
                     eval_batch_size=HERO_EP_EXPERT_AXIS_SIZE * dp_racks,
+                    # Matches the ladder; see `GrugEvalConfig.eval_current`.
+                    eval_current=False,
                     eval_ema=False,
                     compute_bpb=True,
                     dropless_eval=True,

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -268,7 +268,7 @@ def build_diagnostic_run(
                 GrugEvalConfig(
                     steps_per_eval=eval_every,
                     eval_batch_size=HERO_EP_EXPERT_AXIS_SIZE * dp_racks,
-                    eval_current=False,  # see #8861
+                    eval_current=False,  # matches the ladder; see #8861
                     eval_ema=False,
                     compute_bpb=True,
                     dropless_eval=True,

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -268,8 +268,7 @@ def build_diagnostic_run(
                 GrugEvalConfig(
                     steps_per_eval=eval_every,
                     eval_batch_size=HERO_EP_EXPERT_AXIS_SIZE * dp_racks,
-                    # Matches the ladder; see `GrugEvalConfig.eval_current`.
-                    eval_current=False,
+                    eval_current=False,  # see #8861
                     eval_ema=False,
                     compute_bpb=True,
                     dropless_eval=True,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -145,8 +145,8 @@ def build_ladder_run(
     """One scaling-ladder rung at width ``size`` on ``LADDER_RACKS[size]`` GB200 racks.
 
     ``num_steps`` defaults to the steps needed to train ``TOKENS_PER_ACTIVE_PARAM`` tokens per active
-    parameter at the rung's (rack-scaled) batch. Every eval scores the held-out set both as-trained
-    and dropless. The narrow rungs eval every 5% of the run and keep only the forced final
+    parameter at the rung's (rack-scaled) batch. Every eval scores the held-out set dropless. The
+    narrow rungs eval every 5% of the run and keep only the forced final
     checkpoint; the d6144 hero evals every 3000 steps and keeps a permanent checkpoint every 6000.
     ``checkpoint_every`` overrides that cadence for any rung. A rolling temporary checkpoint every
     ``RESUME_SAVE_INTERVAL`` on region-local storage covers a crash or a preemption, and a rung
@@ -290,8 +290,8 @@ def build_ladder_run(
             eval=GrugEvalConfig(
                 steps_per_eval=steps_per_eval,
                 eval_batch_size=eval_batch_size,
-                # The capacity-limited eval breaks the ragged train step's NCCL windows at d6144;
-                # see `GrugEvalConfig.eval_current`. The dropless eval is the reported metric.
+                # The capacity-limited eval breaks the ragged train step at d6144 (#8861). The
+                # dropless eval is the reported metric.
                 eval_current=False,
                 eval_ema=False,
                 compute_bpb=True,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -290,6 +290,9 @@ def build_ladder_run(
             eval=GrugEvalConfig(
                 steps_per_eval=steps_per_eval,
                 eval_batch_size=eval_batch_size,
+                # The capacity-limited eval breaks the ragged train step's NCCL windows at d6144;
+                # see `GrugEvalConfig.eval_current`. The dropless eval is the reported metric.
+                eval_current=False,
                 eval_ema=False,
                 compute_bpb=True,
                 dropless_eval=True,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -308,6 +308,11 @@ class GrugEvalConfig:
     steps_per_eval: int | None = 1000
     max_eval_batches: int | None = None
     prefix: str = "eval"
+    # Evaluate with the training MoE backend (capacity-limited, with drops). Under the ragged
+    # all-to-all backend this compiles a second ragged program on the training clique whose
+    # smaller all-to-all buffers leave NCCL symmetric-memory windows registered at addresses the
+    # train step reuses; the next train step then fails with `ncclGroupEnd() invalid argument`
+    # at hero width. Ragged runs set this False and keep `dropless_eval`, which has no all-to-all.
     eval_current: bool = True
     eval_ema: bool = True
     compute_bpb: bool = True
@@ -1091,14 +1096,17 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         if evaluator is not None and eval_cfg is not None:
             interval = eval_cfg.steps_per_eval
             eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
-            if eval_cfg.eval_current or eval_ema:
-                tagged_eval_hook = cb_tagged_evaluate(
-                    evaluator,
-                    prefix=eval_cfg.prefix,
-                    eval_current=eval_cfg.eval_current,
-                    eval_ema=eval_ema,
-                )
-                eval_hooks: list[Callable[..., None]] = [tagged_eval_hook]
+            if eval_cfg.eval_current or eval_ema or dropless_evaluator is not None:
+                eval_hooks: list[Callable[..., None]] = []
+                if eval_cfg.eval_current or eval_ema:
+                    eval_hooks.append(
+                        cb_tagged_evaluate(
+                            evaluator,
+                            prefix=eval_cfg.prefix,
+                            eval_current=eval_cfg.eval_current,
+                            eval_ema=eval_ema,
+                        )
+                    )
                 if dropless_evaluator is not None and dropless_eval_mesh is not None:
                     # The training loop runs under `set_mesh(mesh)` (expert-parallel). The dropless
                     # evaluator runs under the expert-collapsed mesh, so the model params -- sharded on

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -308,17 +308,14 @@ class GrugEvalConfig:
     steps_per_eval: int | None = 1000
     max_eval_batches: int | None = None
     prefix: str = "eval"
-    # Evaluate with the training MoE backend (capacity-limited, with drops). Under the ragged
-    # all-to-all backend this compiles a second ragged program on the training clique whose
-    # smaller all-to-all buffers leave NCCL symmetric-memory windows registered at addresses the
-    # train step reuses; the next train step then fails with `ncclGroupEnd() invalid argument`
-    # at hero width. Ragged runs set this False and keep `dropless_eval`, which has no all-to-all.
+    # Evaluate with the training MoE backend (capacity-limited, with drops): `eval_current` scores
+    # the live parameters and `eval_ema` the EMA parameters; either one schedules the
+    # training-mesh evaluator.
     eval_current: bool = True
     eval_ema: bool = True
     compute_bpb: bool = True
-    # For expert-parallel runs, also evaluate under the dropless local backend on an
-    # expert-collapsed mesh, logging a separate `eval_dropless` macro loss alongside the
-    # as-trained (with-drop) eval. No-op when the mesh has no expert parallelism.
+    # For expert-parallel runs, evaluate under the dropless local backend on an expert-collapsed
+    # mesh, logging an `eval_dropless` macro loss. No-op when the mesh has no expert parallelism.
     dropless_eval: bool = False
     # Local MoE kernel used after collapsing the expert axis. ``sonic`` is the Hopper Triton path;
     # ``sonic_cute`` is the Blackwell QuACK/CUTLASS path.
@@ -1009,18 +1006,23 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         evaluator = None
         dropless_evaluator = None
         dropless_eval_mesh = None
+        eval_ema = False
         if eval_cfg is not None:
-            evaluator = build_tagged_evaluator(
-                data_config=config.data,
-                max_seq_len=config.model.max_seq_len,
-                mesh=mesh,
-                eval_cfg=eval_cfg,
-                mp=trainer.mp,
-            )
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            train_mesh_eval = eval_cfg.eval_current or eval_ema
+            dropless = eval_cfg.dropless_eval and mesh.shape["expert"] > 1
+            if train_mesh_eval:
+                evaluator = build_tagged_evaluator(
+                    data_config=config.data,
+                    max_seq_len=config.model.max_seq_len,
+                    mesh=mesh,
+                    eval_cfg=eval_cfg,
+                    mp=trainer.mp,
+                )
             # Expert-parallel runs drop tokens over capacity; a second evaluator scores the same
             # weights dropless under the local backend on an expert-collapsed mesh (expert folded
             # into `data`), which the local backend requires. FSDP runs already have expert=1.
-            if eval_cfg.dropless_eval and mesh.shape["expert"] > 1:
+            if dropless:
                 dropless_eval_mesh = compact_grug_mesh(
                     expert_axis_size=1,
                     replica_axis_size=mesh.shape["replica_dcn"],
@@ -1093,61 +1095,64 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         if train_dataset is not None:
             state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
         state_callbacks.add_hook(log_device_memory, every=1)
-        if evaluator is not None and eval_cfg is not None:
+        if eval_cfg is not None:
             interval = eval_cfg.steps_per_eval
-            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
-            if eval_cfg.eval_current or eval_ema or dropless_evaluator is not None:
-                eval_hooks: list[Callable[..., None]] = []
-                if eval_cfg.eval_current or eval_ema:
-                    eval_hooks.append(
-                        cb_tagged_evaluate(
-                            evaluator,
-                            prefix=eval_cfg.prefix,
-                            eval_current=eval_cfg.eval_current,
-                            eval_ema=eval_ema,
-                        )
+            eval_hooks: list[Callable[..., None]] = []
+            if evaluator is not None:
+                eval_hooks.append(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
                     )
-                if dropless_evaluator is not None and dropless_eval_mesh is not None:
-                    # The training loop runs under `set_mesh(mesh)` (expert-parallel). The dropless
-                    # evaluator runs under the expert-collapsed mesh, so the model params -- sharded on
-                    # the train mesh -- must be resharded onto the eval mesh before its eval jit (JAX
-                    # does not auto-reshard across explicit meshes), then the local backend sees
-                    # expert=1. PGLE is disabled for the eval module as in `cb_tagged_evaluate`.
-                    dropless_prefix = f"{eval_cfg.prefix}_dropless"
+                )
+            if dropless_evaluator is not None and dropless_eval_mesh is not None:
+                # The training loop runs under `set_mesh(mesh)` (expert-parallel). The dropless
+                # evaluator runs under the expert-collapsed mesh, so the model params -- sharded on
+                # the train mesh -- must be resharded onto the eval mesh before its eval jit (JAX
+                # does not auto-reshard across explicit meshes), then the local backend sees
+                # expert=1. PGLE is disabled for the eval module as in `cb_tagged_evaluate`.
+                dropless_prefix = f"{eval_cfg.prefix}_dropless"
+                # The forced end-of-run callback pass revisits the last step; skip it when the
+                # periodic cadence already scored that step, as `cb_tagged_evaluate` does.
+                last_dropless_eval_step: int | None = None
 
-                    def dropless_eval_hook(
-                        step, *args, _mesh=dropless_eval_mesh, _ev=dropless_evaluator, _prefix=dropless_prefix, **kwargs
-                    ):
-                        step_count = int(step.step)
-                        if step_count < 0:
-                            return
-                        # `model` must stay a local. The eval mesh has expert=1, so a leaf sharded on
-                        # the expert axis lands replicated, and the copy is much larger than the
-                        # train-mesh params. The train step needs almost the whole device budget for
-                        # its temporary buffer, thus this copy must die before the next step.
-                        with set_mesh(_mesh):
-                            model = _reshard_tree_to_mesh(step.model, _mesh)
-                            with jax_config.enable_pgle(False):
-                                log_dict = eval_model(_ev, model, prefix=_prefix)
-                            levanter.tracker.log(log_dict, step=step_count)
+                def dropless_eval_hook(
+                    step, *args, _mesh=dropless_eval_mesh, _ev=dropless_evaluator, _prefix=dropless_prefix, **kwargs
+                ):
+                    nonlocal last_dropless_eval_step
+                    step_count = int(step.step)
+                    if step_count < 0 or step_count == last_dropless_eval_step:
+                        return
+                    last_dropless_eval_step = step_count
+                    # `model` must stay a local. The eval mesh has expert=1, so a leaf sharded on
+                    # the expert axis lands replicated, and the copy is much larger than the
+                    # train-mesh params. The train step needs almost the whole device budget for
+                    # its temporary buffer, thus this copy must die before the next step.
+                    with set_mesh(_mesh):
+                        model = _reshard_tree_to_mesh(step.model, _mesh)
+                        with jax_config.enable_pgle(False):
+                            log_dict = eval_model(_ev, model, prefix=_prefix)
+                        levanter.tracker.log(log_dict, step=step_count)
 
-                    eval_hooks.append(dropless_eval_hook)
+                eval_hooks.append(dropless_eval_hook)
 
-                if interval is not None and interval > 0:
-                    for hook in eval_hooks:
-                        state_callbacks.add_hook(hook, every=interval)
+            if interval is not None and interval > 0:
+                for hook in eval_hooks:
+                    state_callbacks.add_hook(hook, every=interval)
 
-                # Baseline point at the start of the loss curve. The periodic cadence first fires at
-                # `steps_per_eval` (step 3000 on the hero), thus a fresh run gets no early point.
-                # These run after the first optimization step, not before it: the first train step
-                # then allocates against a clean pool, and the eval-to-train handoff gets a gate at
-                # step 2 instead of first at step 3000. `every=1` is the only interval that covers
-                # the first step, and `_first_step_only` makes the hook fire once. A resumed run
-                # starts above step 1, thus it never fires. The hooks log at `StepInfo.step`, which
-                # is 0 there, so the point lands at step 0 on the curve.
-                if eval_cfg.eval_at_first_step:
-                    for hook in eval_hooks:
-                        state_callbacks.add_hook(_first_step_only(hook), every=1)
+            # Baseline point at the start of the loss curve. The periodic cadence first fires at
+            # `steps_per_eval` (step 3000 on the hero), thus a fresh run gets no early point.
+            # These run after the first optimization step, not before it: the first train step
+            # then allocates against a clean pool, and the eval-to-train handoff gets a gate at
+            # step 2 instead of first at step 3000. `every=1` is the only interval that covers
+            # the first step, and `_first_step_only` makes the hook fire once. A resumed run
+            # starts above step 1, thus it never fires. The hooks log at `StepInfo.step`, which
+            # is 0 there, so the point lands at step 0 on the curve.
+            if eval_cfg.eval_at_first_step:
+                for hook in eval_hooks:
+                    state_callbacks.add_hook(_first_step_only(hook), every=1)
 
         last_loss: float | jax.Array = 0.0
         last_step_duration = 0.0


### PR DESCRIPTION
The scaling ladder and the diagnostics launcher set `eval_current=False`, so the periodic eval runs the dropless evaluator alone. The train loop no longer requires the capacity-limited evaluator to schedule the dropless one; each hook is added on its own condition, and `eval_at_first_step` covers whichever hooks exist.

On the ragged all-to-all backend at d6144, the first train step after an eval fails with `NCCL operation ncclGroupEnd() failed: invalid argument` on most ranks, deterministically, on one rack restored from the hero's step-48000 checkpoint. The capacity-limited evaluator runs the training MoE path, so it is a second ragged all-to-all program on the training clique. XLA carves each executable's symmetric all-to-all buffers from the start of one collective-memory arena and registers an NCCL window covering that executable's footprint, cached per executable and kept until the executable or the clique is destroyed. An NCCL trace on one rack shows the two train-step executables each registering a window of 20,293,761,024 bytes at the arena base (identical ranges, accepted), then the eval registering 518,436,864 bytes at the same base (accepted), and the next train step failing at launch after a cache hit on its own window. Executables with equal footprints coexist; one with a different footprint corrupts window resolution on the shared base. With the capacity-limited evaluator off, the same run passes through two dropless evals and continues training, and the dropless numbers match the live hero's step-47999 eval (paloma macro 2.257 vs 2.262). The fix that keeps the capacity-limited eval is in XLA: register the arena once per communicator and address executables by offset.

The dropless eval is the metric the reports and the ladder figures use. Part of #8861. The capacity-limited `eval/*` series stops for ragged runs, and the Grafana hero-health `eval_regressed` signal and the Paloma chart read `eval/paloma/macro_loss`; they need to move to `eval_dropless/paloma/macro_loss` in a follow-up.



Validation runs on cw-us-east-08a, one rack, restored from the hero step-48000 checkpoint at main `c13d1ddf27`: `ra2a-rt-c13d1-48k` and `ra2a-evalnccl-c13d1` (both evaluators, fail at the first train step after the eval), `ra2a-evaldl-c13d1` (dropless only, passes two evals and six steps), `ra2a-evalinfo-c13d1` (both evaluators with `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=REG,INIT`, the trace above).
