### PR TITLE
[grafana] Read the dropless Paloma loss for hero health

### DIFF
--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -49,7 +49,7 @@ a training run with no signal that it happened. That is what `iris_state_stale` 
 | `router_bias` | Newest bound over 400 from zero | `train_router_bias_max`, `train_router_bias_min` |
 | `throughput_low` | Most of 15 minutes below 2.0M tokens per second | `throughput_tokens_per_second` |
 | `mfu_low` | Most of 15 minutes below 15% | `throughput_mfu` |
-| `eval_regressed` | Newest evaluation, within 30 minutes, worse than two evaluations ago or over 2% worse than the preceding evaluation | `eval_paloma_macro_loss` |
+| `eval_regressed` | Newest evaluation, within 30 minutes, worse than two evaluations ago or over 2% worse than the preceding evaluation | `eval_dropless_paloma_macro_loss` |
 | `iris_state_stale` | Newest `iris.task_state` row for the root over 5 minutes old | `iris.task_state` |
 | `task_retried` | A controller retry or gang requeue in the last 15 minutes | `iris.task_event` |
 

--- a/infra/grafana/dashboards/runs.json
+++ b/infra/grafana/dashboards/runs.json
@@ -946,7 +946,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, run_id || ' · ' || name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, run_id || ' · ' || name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",

--- a/infra/grafana/dashboards/runs.json
+++ b/infra/grafana/dashboards/runs.json
@@ -946,7 +946,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, run_id || ' · ' || name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, run_id || ' · ' || name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_loss', 'eval_dropless_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -1318,7 +1318,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -1318,7 +1318,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "WITH telemetry AS (SELECT * FROM \"levanter.metrics\") SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, name AS series, AVG(value) AS value FROM telemetry WHERE name IN ('eval_loss', 'eval_macro_loss', 'eval_paloma_macro_loss', 'eval_dropless_loss', 'eval_dropless_macro_loss', 'eval_dropless_paloma_macro_loss') AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -59,7 +59,7 @@ _ROUTER_BIAS_MAX = "train_router_bias_max"
 _ROUTER_BIAS_MIN = "train_router_bias_min"
 _TOKENS_PER_SECOND = "throughput_tokens_per_second"
 _MFU = "throughput_mfu"
-_EVAL_LOSS = "eval_paloma_macro_loss"
+_EVAL_LOSS = "eval_dropless_paloma_macro_loss"
 
 _SIGNAL_METRICS = (
     PHASE_METRIC,

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -32,7 +32,7 @@ _SAMPLES = 800
 
 WANDB_CHARTS = {
     "train-loss": ("Train cross-entropy loss", "train/cross_entropy_loss"),
-    "paloma-macro-loss": ("Paloma macro loss", "eval/paloma/macro_loss"),
+    "paloma-macro-loss": ("Paloma macro loss", "eval_dropless/paloma/macro_loss"),
     "mfu": ("MFU (%)", "throughput/mfu"),
 }
 

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -32,7 +32,7 @@ _SAMPLES = 800
 
 WANDB_CHARTS = {
     "train-loss": ("Train cross-entropy loss", "train/cross_entropy_loss"),
-    "paloma-macro-loss": ("Paloma macro loss", "eval_dropless/paloma/macro_loss"),
+    "paloma-macro-loss": ("Paloma macro loss (dropless)", "eval_dropless/paloma/macro_loss"),
     "mfu": ("MFU (%)", "throughput/mfu"),
 }
 

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -878,7 +878,7 @@ def test_health_alert_reads_routing_throughput_and_evaluation():
             "train_router_bias_max": {"latest": 120.0},
             "throughput_tokens_per_second": {"latest": 1.4e6, "recent_samples": 100, "recent_below_floor": 62},
             "throughput_mfu": {"latest": 31.0, "recent_samples": 100, "recent_below_floor": 4},
-            "eval_paloma_macro_loss": {"latest": 2.31, "previous": 2.17},
+            "eval_dropless_paloma_macro_loss": {"latest": 2.31, "previous": 2.17},
         },
     )
 
@@ -909,7 +909,7 @@ def test_eval_regression_uses_two_eval_history_and_two_percent_jump(
         "previous": previous,
         "two_samples_ago": two_samples_ago,
     }
-    signals = _signals(now, {"eval_paloma_macro_loss": evaluation})
+    signals = _signals(now, {"eval_dropless_paloma_macro_loss": evaluation})
 
     reasons = _reasons(health_alert_rows((_watched(),), signals, pa.table({}), now))
     assert ("eval_regressed" in reasons) is should_alert
@@ -1014,9 +1014,9 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
             ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=9), 4),
             ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=2), 5),
             # Hours apart, so only the eval lookback keeps the comparison history.
-            ("attempt-1", "eval_paloma_macro_loss", 2.19, now - timedelta(hours=12), 9),
-            ("attempt-1", "eval_paloma_macro_loss", 2.17, now - timedelta(hours=6), 6),
-            ("attempt-1", "eval_paloma_macro_loss", 2.31, now - timedelta(minutes=12), 7),
+            ("attempt-1", "eval_dropless_paloma_macro_loss", 2.19, now - timedelta(hours=12), 9),
+            ("attempt-1", "eval_dropless_paloma_macro_loss", 2.17, now - timedelta(hours=6), 6),
+            ("attempt-1", "eval_dropless_paloma_macro_loss", 2.31, now - timedelta(minutes=12), 7),
         ]
     )
 
@@ -1027,7 +1027,7 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
     throughput = signals["throughput_tokens_per_second"]
     assert (throughput.latest, throughput.recent_samples, throughput.recent_below_floor) == (2.6e6, 3, 2)
     assert signals["optim_skipped_step"].recent_total == 2.0
-    evaluation = signals["eval_paloma_macro_loss"]
+    evaluation = signals["eval_dropless_paloma_macro_loss"]
     assert (evaluation.latest, evaluation.previous, evaluation.two_samples_ago) == (2.31, 2.17, 2.19)
 
 


### PR DESCRIPTION
The hero-health `eval_regressed` signal and the scaling-ladder Paloma chart read `eval_dropless/paloma/macro_loss`, and the chart title names the dropless eval. #8859 turns the capacity-limited eval off on the ragged hero rungs, so the with-drop `eval/paloma/macro_loss` series stops for those runs and the signal would otherwise never fire again.

The eval-loss panels on the training and runs dashboards list the dropless loss, macro loss, and Paloma names alongside the with-drop names, since non-ragged runs still log the with-drop series. The hero's regional Finelog deployment already carries `eval_dropless_paloma_macro_loss` on the same cadence as the with-drop name, so the signal has input once the bridge is rolled out.

Part of #8861.
