### PR TITLE
[grug] Name MoE profiling scopes

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -573,60 +573,67 @@ class MoEMLP(eqx.Module):
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         b, s, _ = x.shape
         x_flat = rearrange(x, "b s d -> (b s) d")
-        # Keep the router path in fp32 before top-k, softmax, and QB statistics.
-        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
-        biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
-        router_probs = jax.nn.softmax(router_logits, axis=-1)
-        # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
-        _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
-        qb_alpha = _topk_logits[:, -1:]
-        selected_experts = selected_experts[:, :-1]
-        # Sigmoid combine weights on unbiased logits for selected experts.
-        unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
-        combine_weights_f = jax.nn.sigmoid(unbiased_topk)
-        # Renormalize K combine weights to sum to ``_ROUTING_RENORM_SUM`` (baked in).
-        denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
-        combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
-        combine_weights = combine_weights_f.astype(x.dtype)
-        router_stats = _routing_stats(
-            selected_experts,
-            router_probs,
-            router_logits,
-            num_experts=self.cfg.num_experts,
-            num_experts_per_token=self.cfg.num_experts_per_token,
-        )
-        # Sharded QB: compute beta locally per device, then average.
-        mesh = get_abstract_mesh()
-        s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
-        num_devices = 1
-        for a in _BATCH_AXES:
-            num_devices *= mesh.shape[a]
-        local_tokens = s_minus_alpha.shape[0] // num_devices
-        qb_count = max(1, local_tokens * self.cfg.num_experts_per_token // self.cfg.num_experts)
+        with jax.named_scope("moe_route"):
+            # Keep the router path in fp32 before top-k, softmax, and QB statistics.
+            router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+            biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
+            router_probs = jax.nn.softmax(router_logits, axis=-1)
+            # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
+            _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
+            qb_alpha = _topk_logits[:, -1:]
+            selected_experts = selected_experts[:, :-1]
+            # Sigmoid combine weights on unbiased logits for selected experts.
+            unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
+            combine_weights_f = jax.nn.sigmoid(unbiased_topk)
+            # Renormalize K combine weights to sum to ``_ROUTING_RENORM_SUM`` (baked in).
+            denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
+            combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
+            combine_weights = combine_weights_f.astype(x.dtype)
 
-        def _local_qb_beta(s_ma):
-            topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
-            beta = topk_vals[:, -1]
-            return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+        with jax.named_scope("moe_router_stats"):
+            router_stats = _routing_stats(
+                selected_experts,
+                router_probs,
+                router_logits,
+                num_experts=self.cfg.num_experts,
+                num_experts_per_token=self.cfg.num_experts_per_token,
+            )
 
-        router_stats["qb_beta"] = shard_map(
-            _local_qb_beta,
-            mesh=mesh,
-            in_specs=(P(_BATCH_AXES, None),),
-            out_specs=P(),
-        )(s_minus_alpha)
+        with jax.named_scope("moe_qb_beta"):
+            # Sharded QB: compute beta locally per device, then average.
+            mesh = get_abstract_mesh()
+            s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
+            num_devices = 1
+            for a in _BATCH_AXES:
+                num_devices *= mesh.shape[a]
+            local_tokens = s_minus_alpha.shape[0] // num_devices
+            qb_count = max(1, local_tokens * self.cfg.num_experts_per_token // self.cfg.num_experts)
 
-        routed_flat, capacity_overflow = self.expert_mlp(
-            x_flat,
-            selected_experts.astype(jnp.int32),
-            combine_weights,
-            mesh=get_abstract_mesh(),
-            report_capacity_overflow=True,
-        )
+            def _local_qb_beta(s_ma):
+                topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
+                beta = topk_vals[:, -1]
+                return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+
+            router_stats["qb_beta"] = shard_map(
+                _local_qb_beta,
+                mesh=mesh,
+                in_specs=(P(_BATCH_AXES, None),),
+                out_specs=P(),
+            )(s_minus_alpha)
+
+        with jax.named_scope("moe_experts"):
+            routed_flat, capacity_overflow = self.expert_mlp(
+                x_flat,
+                selected_experts.astype(jnp.int32),
+                combine_weights,
+                mesh=get_abstract_mesh(),
+                report_capacity_overflow=True,
+            )
         router_stats["capacity_overflow"] = capacity_overflow.total.astype(jnp.float32)
 
-        routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
-        routed = reshard(routed, _batch_spec())
+        with jax.named_scope("moe_output"):
+            routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
+            routed = reshard(routed, _batch_spec())
         return routed, router_stats
 
 
@@ -665,12 +672,15 @@ class Block(eqx.Module):
         use_pko: bool = False,
         disable_rope: bool = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
-        attn_in = self.attn_gated_norm(self.rms_attn(x))
-        x = x + self.attn(attn_in, mask, use_pko=use_pko, disable_rope=disable_rope)
-        mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
-        mlp_out, router_stats = self.mlp(mlp_in)
+        with jax.named_scope("attention"):
+            attn_in = self.attn_gated_norm(self.rms_attn(x))
+            x = x + self.attn(attn_in, mask, use_pko=use_pko, disable_rope=disable_rope)
+        with jax.named_scope("routed_moe"):
+            mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
+            mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
-            mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
+            with jax.named_scope("shared_expert"):
+                mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
         x = x + mlp_out
         return x, router_stats
 


### PR DESCRIPTION
Add `jax.named_scope` labels around routing, router statistics, the QB threshold calculation, expert compute, output reshaping, attention, and shared-expert regions in the non-pipeline Grug MoE model. JAX profiler traces can then report these model phases separately.

Part of #7024
