### PR TITLE
[grug] Let a hero relaunch resume another run's checkpoints

### DIFF
--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -105,6 +105,7 @@ def hero_trainer_config(
     checkpointer: CheckpointerConfig,
     progress_watchdog: ProgressWatchdogConfig = ProgressWatchdogConfig(),
     load_checkpoint_path: str | list[str] | None = None,
+    load_checkpoint: bool | None = None,
     master_param_mode: MasterParamMode = HERO_MASTER_PARAM_MODE,
 ) -> TrainerConfig:
     """Set the Levanter options that affect the compiled hero step."""
@@ -122,6 +123,7 @@ def hero_trainer_config(
         require_accelerator=True,
         allow_nondivisible_batch_size=False,
         load_checkpoint_path=load_checkpoint_path,
+        load_checkpoint=load_checkpoint,
         checkpointer=checkpointer,
     )
 

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -141,6 +141,7 @@ def build_ladder_run(
     num_steps: int | None = None,
     checkpoint_every: int | None = None,
     version: str | None = None,
+    initialize_from_path: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
     """One scaling-ladder rung at width ``size`` on ``LADDER_RACKS[size]`` GB200 racks.
 
@@ -150,7 +151,9 @@ def build_ladder_run(
     checkpoint; the d6144 hero evals every 3000 steps and keeps a permanent checkpoint every 6000.
     ``checkpoint_every`` overrides that cadence for any rung. A rolling temporary checkpoint every
     ``RESUME_SAVE_INTERVAL`` on region-local storage covers a crash or a preemption, and a rung
-    resumes from the newest checkpoint it finds.
+    resumes from the newest checkpoint it finds. ``initialize_from_path`` is another run's output
+    path whose checkpoint roots are appended as resume fallbacks, so a relaunch under a new run id
+    continues that lineage's full state while writing only to its own tree.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
@@ -230,6 +233,13 @@ def build_ladder_run(
         permanent_checkpoint_path = prefix_join(ctx.output_path, "checkpoints")
         temporary_checkpoint_path = temporary_checkpoint_base_path(ctx.output_path)
         data_local_checkpoint_path = data_local_temporary_checkpoint_base_path(ctx.output_path)
+        load_checkpoint_path = [permanent_checkpoint_path, temporary_checkpoint_path, data_local_checkpoint_path]
+        if initialize_from_path is not None:
+            load_checkpoint_path += [
+                prefix_join(initialize_from_path, "checkpoints"),
+                temporary_checkpoint_base_path(initialize_from_path),
+                data_local_temporary_checkpoint_base_path(initialize_from_path),
+            ]
         trainer = hero_trainer_config(
             run_id=run_id,
             seed=0,
@@ -261,11 +271,7 @@ def build_ladder_run(
                 startup_timeout=HERO_STARTUP_TIMEOUT,
             ),
             # Existing 02A temporaries remain valid resume candidates for this lineage.
-            load_checkpoint_path=[
-                permanent_checkpoint_path,
-                temporary_checkpoint_path,
-                data_local_checkpoint_path,
-            ],
+            load_checkpoint_path=load_checkpoint_path,
             # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
             # exists, so a retry after a hardware or memory fault continues the run.
             checkpointer=CheckpointerConfig(
@@ -341,11 +347,27 @@ def build_ladder_run(
     "the rung (6000 at d6144, final only elsewhere). Resume uses the rolling temporary checkpoint "
     "and is not affected by this option.",
 )
+@click.option(
+    "--initialize-from-path",
+    default=None,
+    help="Output path of another run whose checkpoint roots are added as resume fallbacks, to continue "
+    "that lineage under a new --run-id without writing to its tree.",
+)
 @build_options
 def main(
-    run_id: str, size: str, num_steps: int | None, checkpoint_every: int | None
+    run_id: str,
+    size: str,
+    num_steps: int | None,
+    checkpoint_every: int | None,
+    initialize_from_path: str | None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    return build_ladder_run(run_id=run_id, size=size, num_steps=num_steps, checkpoint_every=checkpoint_every)
+    return build_ladder_run(
+        run_id=run_id,
+        size=size,
+        num_steps=num_steps,
+        checkpoint_every=checkpoint_every,
+        initialize_from_path=initialize_from_path,
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -141,7 +141,7 @@ def build_ladder_run(
     num_steps: int | None = None,
     checkpoint_every: int | None = None,
     version: str | None = None,
-    initialize_from_path: str | None = None,
+    initialize_from_checkpoint: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
     """One scaling-ladder rung at width ``size`` on ``LADDER_RACKS[size]`` GB200 racks.
 
@@ -151,9 +151,9 @@ def build_ladder_run(
     checkpoint; the d6144 hero evals every 3000 steps and keeps a permanent checkpoint every 6000.
     ``checkpoint_every`` overrides that cadence for any rung. A rolling temporary checkpoint every
     ``RESUME_SAVE_INTERVAL`` on region-local storage covers a crash or a preemption, and a rung
-    resumes from the newest checkpoint it finds. ``initialize_from_path`` is another run's output
-    path whose checkpoint roots are appended as resume fallbacks, so a relaunch under a new run id
-    continues that lineage's full state while writing only to its own tree.
+    resumes from the newest checkpoint it finds. ``initialize_from_checkpoint`` is another run's
+    checkpoint directory, added as the resume fallback so a relaunch under a new run id continues
+    that lineage's full state from exactly that step while writing only to its own tree.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
@@ -234,12 +234,8 @@ def build_ladder_run(
         temporary_checkpoint_path = temporary_checkpoint_base_path(ctx.output_path)
         data_local_checkpoint_path = data_local_temporary_checkpoint_base_path(ctx.output_path)
         load_checkpoint_path = [permanent_checkpoint_path, temporary_checkpoint_path, data_local_checkpoint_path]
-        if initialize_from_path is not None:
-            load_checkpoint_path += [
-                prefix_join(initialize_from_path, "checkpoints"),
-                temporary_checkpoint_base_path(initialize_from_path),
-                data_local_temporary_checkpoint_base_path(initialize_from_path),
-            ]
+        if initialize_from_checkpoint is not None:
+            load_checkpoint_path.append(initialize_from_checkpoint)
         trainer = hero_trainer_config(
             run_id=run_id,
             seed=0,
@@ -275,7 +271,7 @@ def build_ladder_run(
             # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
             # exists, so a retry after a hardware or memory fault continues the run. Continuing
             # another run requires a checkpoint, so a wrong path fails instead of starting fresh.
-            load_checkpoint=True if initialize_from_path is not None else None,
+            load_checkpoint=True if initialize_from_checkpoint is not None else None,
             checkpointer=CheckpointerConfig(
                 base_path=permanent_checkpoint_path,
                 # Rolling resume checkpoints go to region-local temp storage with a lifecycle TTL.
@@ -350,10 +346,10 @@ def build_ladder_run(
     "and is not affected by this option.",
 )
 @click.option(
-    "--initialize-from-path",
+    "--initialize-from-checkpoint",
     default=None,
-    help="Output path of another run whose checkpoint roots are added as resume fallbacks, to continue "
-    "that lineage under a new --run-id without writing to its tree.",
+    help="Checkpoint directory of another run to resume from under a new --run-id; this run writes only "
+    "to its own tree and later restarts prefer its own, newer checkpoints.",
 )
 @build_options
 def main(
@@ -361,14 +357,14 @@ def main(
     size: str,
     num_steps: int | None,
     checkpoint_every: int | None,
-    initialize_from_path: str | None,
+    initialize_from_checkpoint: str | None,
 ) -> ArtifactStep[HeroThroughputResult]:
     return build_ladder_run(
         run_id=run_id,
         size=size,
         num_steps=num_steps,
         checkpoint_every=checkpoint_every,
-        initialize_from_path=initialize_from_path,
+        initialize_from_checkpoint=initialize_from_checkpoint,
     )
 
 

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -273,7 +273,9 @@ def build_ladder_run(
             # Existing 02A temporaries remain valid resume candidates for this lineage.
             load_checkpoint_path=load_checkpoint_path,
             # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
-            # exists, so a retry after a hardware or memory fault continues the run.
+            # exists, so a retry after a hardware or memory fault continues the run. Continuing
+            # another run requires a checkpoint, so a wrong path fails instead of starting fresh.
+            load_checkpoint=True if initialize_from_path is not None else None,
             checkpointer=CheckpointerConfig(
                 base_path=permanent_checkpoint_path,
                 # Rolling resume checkpoints go to region-local temp storage with a lifecycle TTL.

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,9 +11,9 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
-# This run continues the previous hero's full state from its checkpoint tree without writing to it.
+# This run continues the previous hero's full state from this checkpoint without writing to that run's tree.
 RUN_ID=hero-ragged_a2a-ep-step54k
-PREVIOUS_RUN_PATH=s3://marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2
+HANDOFF_CHECKPOINT=s3://marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2/checkpoints/step-54000
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
 short_uuid=${short_uuid:0:8}
 
@@ -32,7 +32,7 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra
   -e XLA_FLAGS "--xla_gpu_memory_limit_slop_factor=85" \
   -- python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \
     --run-id "$RUN_ID" \
-    --initialize-from-path "$PREVIOUS_RUN_PATH" \
+    --initialize-from-checkpoint "$HANDOFF_CHECKPOINT" \
     --size d6144 \
     --version 2026.08.19.2 \
     --run

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,7 +11,10 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
-RUN_ID=hero-12d8b6f0-dee637
+# The run id changed at the 2026-09-02 ragged all-to-all relaunch (step 54000); the new run continues the
+# old lineage's full state from its checkpoint tree without writing to it.
+RUN_ID=hero-ragged_a2a-ep-step54k
+PREVIOUS_RUN_PATH=s3://marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
 short_uuid=${short_uuid:0:8}
 
@@ -30,6 +33,7 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra
   -e XLA_FLAGS "--xla_gpu_memory_limit_slop_factor=85" \
   -- python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \
     --run-id "$RUN_ID" \
+    --initialize-from-path "$PREVIOUS_RUN_PATH" \
     --size d6144 \
     --version 2026.08.19.2 \
     --run

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,8 +11,7 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
-# The run id changed at the 2026-09-02 ragged all-to-all relaunch (step 54000); the new run continues the
-# old lineage's full state from its checkpoint tree without writing to it.
+# This run continues the previous hero's full state from its checkpoint tree without writing to it.
 RUN_ID=hero-ragged_a2a-ep-step54k
 PREVIOUS_RUN_PATH=s3://marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Add `--initialize-from-checkpoint` to the hero scaling-ladder launcher. The option names another run's checkpoint directory, which is appended to `load_checkpoint_path` as a resume candidate and makes a checkpoint mandatory (`load_checkpoint=True`). The first launch under a new `--run-id` restores the full trainer state (parameters, optimizer, step, and so the data position) from exactly that checkpoint, writes checkpoints only to its own tree, and on every later restart prefers its own, newer checkpoints because candidates are ordered by step across all search paths. A mistyped path fails the launch instead of starting a fresh run. Levanter's `initialize_from` is not used by grug's restore path, and `load_checkpoint_path` was hardcoded to the run's own roots, so there was no way to continue a lineage under a new run id.

The ragged all-to-all deployment needs this: the relaunch continues `hero-12d8b6f0-dee637` from its step-54000 checkpoint but must not append to that run's W&B history (W&B rewind is not enabled for the org, and the tracker refuses steps below the run's last logged step) or mix new-layout checkpoints into its tree, which also keeps a rollback of the old code a plain relaunch. `trigger_hero.sh` now launches `hero-ragged_a2a-ep-step54k` with that checkpoint pinned as the handoff point.

Verified by lowering the config offline: the search list is the new run's three roots followed by the handoff checkpoint, the checkpointer targets only the new tree, and the W&B run id follows the new `--run-id`.
