### PR TITLE
[Design] Add Marina applets, a dynamic app registry

### DIFF
--- a/.agents/projects/marina_applets/design.md
+++ b/.agents/projects/marina_applets/design.md
@@ -1,0 +1,128 @@
+# Marina applets: a dynamic app registry
+
+_Why are we doing this? What's the benefit?_
+
+Marina hosts a small web app once its code is in the repository: an `app.toml`,
+a built `dist/`, a PR, an image build, a deploy. That is the right bar for
+Echo and EvalDash. It is the wrong bar for the table of last week's failed
+evals someone wants during an incident, or the little review page an agent
+builds mid-session. Those should cost what an artifact costs: build the page,
+publish it, share the link. Applets are Marina apps that are published to the
+running service instead of committed, stored in the database, and served,
+listed, and authenticated exactly like the checked-in ones. An agent gets a
+`marina publish` that takes a directory and returns a URL.
+
+## Challenges
+
+_What's hard?_
+
+Static and dynamic apps must feel the same, to people and to the code. Today
+the kernel reads a directory once at startup
+([`discover_apps`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/manifest.py#L68)), installs a route pair per
+app ([`install_app_routes`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L219)), and serves files
+from a local `dist` ([`serve_app_file`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L145)). An
+applet published at 14:02 must be visible at 14:02 on every instance without a
+restart, so app resolution moves from startup to request time.
+
+Applets that only ship files are easy. Applets that want data are the point,
+and the first thing they ask for is the database. Running uploaded Python
+inside the kernel process means arbitrary code under the service account, so
+data access for applets has to come through a surface the kernel owns.
+
+## Costs / Risks
+
+_What's bad about doing this?_
+
+- A second registry and a request-time lookup make the kernel a little less
+  obvious than a directory scan. The two registries share one interface to
+  keep that cost small.
+- Applets are code nobody reviewed, served on the same origin as reviewed apps.
+  CSP per app and same-origin cookies already exist; the query surface is the
+  new attack surface, bounded by Postgres roles and a statement timeout.
+- The database grows a table of bundle bytes. Bundles are small (a Vue build is
+  under a few megabytes) and capped; large data goes to the data root as it
+  does for checked-in apps.
+- Anyone can overwrite anyone's applet, and through it reach that applet's
+  tables. That follows the earlier decision that users can do everything; the
+  owner and publish time are recorded and shown.
+
+## Design
+
+_How are we doing this?_
+
+**One app model, two sources.** An app is a manifest plus a bundle of files
+plus, for checked-in apps only, a Python package. `AppManifest` gains
+`source`, the fsspec URL or database key its files come from, and
+`serve_app_file` reads through that source rather than a `Path`. A
+`Registry` protocol has two implementations: `DirectoryRegistry` over
+`apps/` (what `discover_apps` is now) and `AppletRegistry` over two tables,
+`applets` and `applet_files`, in the kernel's own `marina` schema.
+`create_app` composes them; checked-in names are reserved, so an applet can
+never shadow Echo.
+
+**Resolve at request time.** The per-app route pair becomes one route family,
+`/{app}/...`, registered after the kernel's own routes and the Python apps'
+API mounts, that asks the composed registry for the app and 404s when there
+is none. The directory registry answers from memory; the applet registry
+re-reads the small `applets` table at most every few seconds (unknown names
+included, so a stray `/favicon.ico` is not a query per request) and keeps
+current versions' files in a bounded per-process cache, so a publish is live
+everywhere within one window and bytes are fetched once per version per
+instance. File serving keeps what checked-in apps have: the `.gz` fallback,
+the `index.html` fallback, and now a version-derived ETag. The Shell's
+switcher already reads `/api/marina/apps` and needs no change; the directory
+just grows.
+
+**Publishing.** `POST /api/marina/applets/{name}` takes a tarball of a
+directory shaped like a checked-in app: `app.toml` and `dist/`. The kernel
+validates the manifest with the existing loader, writes one row per file, and
+points `current_version` at the new version. Old versions stay for rollback
+(`PUT .../current`) and are pruned beyond the last five. `marina publish DIR`
+runs the app's `build_command` if `dist/` is missing, then posts; it prints
+the URL. Because an applet's source directory is a valid `apps/<name>/`, the
+same journeys run against it locally before publishing, and promotion to a
+checked-in app is `git mv` plus a PR.
+
+**Data for applets.** Two things cover most applets without any server code.
+The data route already serves `<data root>/<name>/`, so an applet can publish
+a parquet or JSON alongside itself. For live data, `POST /<app>/query` runs one
+SQL statement for the app in the path. Each applet gets a Postgres role that
+owns its own schema, and a shared `marina_reader` role with SELECT on every
+app schema is granted to each of them. The kernel runs the statement in one
+transaction with `SET LOCAL ROLE` and `SET LOCAL search_path`, so the role
+never outlives the request and Postgres, not the kernel, decides what a
+statement may touch: an applet reads Echo's wiki and EvalDash's runs, and
+writes only its own tables. A checked-in app can call the same endpoint and
+gets the reader role, so for it the surface is read-only. Uploaded Python is
+not run in v1 (see Open Questions).
+
+The isolation is against accidents, not adversaries: any signed-in person can
+publish under any applet's name, so any signed-in person can reach any
+applet's tables by publishing there. That is the same trust every other
+Marina action already assumes.
+
+## Testing
+
+Unit tests cover both registries against a throwaway Postgres: publish, list,
+serve a file, roll back, prune, and reject a name that a checked-in app owns.
+The query surface gets tests that prove a SELECT across schemas works, a write
+inside the applet's schema works, a write to another app's schema is refused
+by Postgres, and a long statement hits the timeout. One journey publishes a
+small applet through the API from the test, then opens it in the browser,
+sees it in the switcher, and reads a row it stored through the query endpoint.
+The image smoke from the Marina deploy covers the migration that creates the
+tables and the role.
+
+## Open Questions
+
+- Server code for applets. The two candidates are a restricted query surface
+  only (this proposal) and a generic runner that starts a Cloud Run service per
+  applet from the kernel image with the bundle pulled at boot. The second gives
+  applets real APIs and background work at the cost of a service per applet
+  and a slower publish. Is the query surface enough for the first year?
+- Query role scope. SELECT on every app schema is the simplest useful policy
+  and matches "users can do everything". Should Echo's work log or EvalDash's
+  review tables be excluded by default, with apps opting schemas in?
+- Bundle storage. Rows in Postgres keep one dependency and make an applet a
+  transaction; the bucket would allow larger bundles. Is a 25 MB cap per
+  version acceptable?

--- a/.agents/projects/marina_applets/research.md
+++ b/.agents/projects/marina_applets/research.md
@@ -1,0 +1,71 @@
+# Research: Marina applets
+
+Findings behind [design.md](design.md). Kernel references are pinned to
+`0780825da0fe6b5654717780b9a8349c1e8e6e89` on the `marina-kernel-tasktrove` branch (PR #8867).
+
+## In-repo
+
+- App discovery is a startup directory scan:
+  [`discover_apps`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/manifest.py#L68) returns a list of
+  [`AppManifest`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/manifest.py#L24) (name, title, description,
+  root, connect_src, build_command). `dist` is `root / "dist"` and
+  `path` is `/<name>/`. Unknown manifest keys are rejected, which applets
+  inherit for free.
+- Routes are installed per app at startup by
+  [`install_app_routes`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L219): a redirect for the
+  bare prefix, `/<name>/data/{path}` from the data root, and
+  `/<name>/{path}` from `dist` with an `index.html` fallback.
+  [`serve_app_file`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L145) takes a local `Path`;
+  the data route already reads through `rigging.filesystem.factory.url_to_fs`,
+  so a URL-backed file source has a precedent in the same file.
+- Python apps are imported by package name from the apps directory
+  ([`apps.py`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/apps.py#L46)) and mounted at `/<name>/api/`
+  behind [`AuthenticatedMount`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L193). Their engine
+  comes from [`engine_for`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/db.py), which creates the app's
+  schema and pins `search_path` per connection. The same call gives an
+  applet its schema.
+- The kernel has no schema of its own yet; `marina migrate` runs each app's
+  `migrate(engine)`. The applet tables and the query role need a kernel
+  migration, run first.
+- The Shell reads `/api/marina/apps` ([`Shell.vue`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/web/Shell.vue#L43))
+  and renders whatever is listed; the directory is computed by
+  [`app_directory`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/server.py#L124) from the manifest list.
+- Journeys ([`journey_plugin.py`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/journey_plugin.py)) point a
+  kernel at an apps directory. An applet's source directory is that shape, so
+  the existing runner covers applets before publishing.
+- The CLI ([`cli.py`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/src/marina/cli.py)) already has `build` (runs
+  `build_command`) and reads the apps directory; `publish` composes those.
+- Echo's CLI ([`apps/echo/cli.py`](https://github.com/marin-community/marin/blob/0780825da0fe6b5654717780b9a8349c1e8e6e89/infra/marina/apps/echo/cli.py)) shows the
+  agent-side pattern for calling Marina through IAP with a desktop OAuth
+  token; `marina publish` reuses it.
+- Cloud Run runs up to four instances (`infra/marina/__main__.py`), so any
+  in-process cache must tolerate a publish landing on another instance; a
+  short re-read window on the `applets` table is the coordination.
+
+## Prior art
+
+- Claude artifacts and Observable notebooks: publish is one action, the
+  result is a URL, versions are kept, and there is no build step visible to
+  the author. Applets copy the publish-and-link feel; the build stays on the
+  author's side because Marina apps are compiled Vue.
+- Val Town and Cloudflare Workers run uploaded server code in an isolated
+  runtime per unit. Marina has no such runtime; the design defers server code
+  and offers a query surface instead, which is what Metabase and Grafana do
+  for dashboards over a shared database.
+- Hyperbase (the inspiration for Marina) keeps every site in the repository;
+  applets are the deliberate departure.
+
+## Surprises
+
+- Nothing in the kernel depends on apps being local except `serve_app_file`
+  and the per-app route installation. Request-time resolution is a smaller
+  change than expected.
+- Per-app schemas plus `search_path` already give applets state isolation; the
+  only new database concept is a role with cross-schema SELECT.
+
+## Unclear
+
+- Whether applets need server code at all in the first year, and if so whether
+  a Cloud Run service per applet is acceptable operationally.
+- Whether every app schema should be readable through the query surface by
+  default (design assumes yes, per the earlier "users can do everything" call).

--- a/.agents/projects/marina_applets/spec.md
+++ b/.agents/projects/marina_applets/spec.md
@@ -1,0 +1,225 @@
+# Spec: Marina applets
+
+Contracts for [design.md](design.md). Paths are under `infra/marina/`.
+
+## Registry
+
+`src/marina/registry.py`
+
+```python
+class Registry(Protocol):
+    def apps(self) -> list[AppManifest]:
+        """Every app this registry serves, ordered by name. Cheap; may be cached."""
+
+    def app(self, name: str) -> AppManifest | None:
+        """The current manifest for ``name``, or None."""
+
+    def read(self, app: AppManifest, path: str) -> bytes | None:
+        """The bytes of ``path`` (relative, already cleaned) in the app's bundle, or None."""
+
+
+@dataclass(frozen=True)
+class DirectoryRegistry:
+    """Checked-in apps under ``apps_dir``; the current ``discover_apps`` behind the protocol."""
+    apps_dir: Path
+
+
+@dataclass
+class AppletRegistry:
+    """Applets published to the ``applets`` tables, read through ``engine``.
+
+    ``apps()`` and ``app()`` re-read the ``applets`` table (one indexed SELECT, in the
+    request path) when the last read is older than ``refresh`` seconds; between reads
+    they answer from the last list, unknown names included. If the read fails the last
+    good list stands and the failure is logged. ``read()`` caches file bytes per
+    ``(name, version, path)`` in an LRU bounded by ``cache_bytes``.
+    """
+    engine: Engine
+    refresh: float = 5.0
+    cache_bytes: int = 256 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ComposedRegistry:
+    """Directory apps by name, then applets by name; an applet whose name a directory app
+    owns is never listed. ``landing_page``, ``/healthz``, and ``/api/marina/apps`` all use
+    this order."""
+    registries: tuple[Registry, ...]
+```
+
+`AppManifest` becomes `(name, title, description, connect_src, build_command, source,
+version, package)`: `source` is the directory path for a checked-in app or
+`applet:<name>@<version>`; `version` is 0 for directory apps; `package` is the directory
+holding `__init__.py` for a Python app and `None` otherwise (`is_python_app`, `_module`,
+`cli.build`, and `cli.check` use it instead of `root`). `AppManifest.dist` is removed;
+every file read goes through `Registry.read`. `load_manifest(app_dir)` splits into
+`parse_manifest(name, text)` (used by publish) and the directory wrapper.
+
+`MarinaConfig` gains nothing. `create_app` builds
+`ComposedRegistry((DirectoryRegistry(apps_dir), AppletRegistry(engine)))` when a database
+is configured, else the directory registry alone. Route order: the kernel's `/healthz`,
+`/`, `/api/marina/*`, then each Python app's `/<name>/api` mount (still installed at
+startup), then `/{app}/data/{path}`, then `/{app}/{path}` and `/{app}`. An unknown app is
+a 404 JSON body `{"error": "no app"}`.
+
+## File serving
+
+`serve_app_file(registry, app, path)` cleans `path` with `clean_relative_path`, then tries
+`read(app, path)`, `read(app, path + ".gz")` (served with `Content-Encoding: gzip`), and
+finally `read(app, "index.html")`. Responses carry the app's CSP, an `ETag` of
+`"<name>-<version>-<path>"`, and `Cache-Control: private, max-age=31536000, immutable`
+for hashed assets under `static/` or `Cache-Control: no-cache` otherwise. Directory apps
+keep `FileResponse` semantics through a `DirectoryRegistry.read` that reads the file; the
+gzip and index fallbacks are the same code for both registries.
+
+## Persisted shapes
+
+Kernel migration `src/marina/migrations/m0001_applets.py`, run by `marina migrate` before
+any app's own migration, in schema `marina`.
+
+```sql
+CREATE TABLE applets (
+    name            TEXT PRIMARY KEY CHECK (name ~ '^[a-z][a-z0-9-]{1,39}$'),
+    current_version INTEGER NOT NULL,
+    title           TEXT NOT NULL,
+    description     TEXT NOT NULL,
+    connect_src     TEXT[] NOT NULL DEFAULT '{}',
+    published_by    TEXT NOT NULL,
+    published_at    TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE applet_versions (
+    name         TEXT NOT NULL REFERENCES applets(name) ON DELETE CASCADE,
+    version      INTEGER NOT NULL,
+    manifest     JSONB NOT NULL,          -- the parsed app.toml
+    published_by TEXT NOT NULL,
+    published_at TIMESTAMPTZ NOT NULL,
+    byte_size    BIGINT NOT NULL,
+    PRIMARY KEY (name, version)
+);
+
+CREATE TABLE applet_files (
+    name    TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    path    TEXT NOT NULL,                -- relative to dist/, forward slashes
+    bytes   BYTEA NOT NULL,
+    PRIMARY KEY (name, version, path),
+    FOREIGN KEY (name, version) REFERENCES applet_versions(name, version) ON DELETE CASCADE
+);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'marina_reader') THEN
+        CREATE ROLE marina_reader NOLOGIN;
+    END IF;
+END $$;
+```
+
+The `name` check matches `manifest.APP_NAME_PATTERN`, which is tightened to the same
+expression. Limits: 25 MB per version (sum of `bytes`), 2,000 files per version, the last
+5 versions kept per applet (older versions deleted on publish).
+
+Roles. The migrating identity is the service account, which must hold `CREATEROLE`
+(granted once in Cloud SQL by an operator; the `marin` stack notes it) and owns every app
+schema, so `ALTER DEFAULT PRIVILEGES` issued by it covers future tables. After each app's
+migration, `marina migrate` runs for that schema:
+
+```sql
+GRANT USAGE ON SCHEMA "<app>" TO marina_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA "<app>" TO marina_reader;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA "<app>" TO marina_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<app>" GRANT SELECT ON TABLES TO marina_reader;
+```
+
+The kernel's own `marina` schema and `public` are not granted, and
+`REVOKE CREATE ON SCHEMA public FROM PUBLIC` runs once. First publish of an applet
+creates role `applet_<name>` (`NOLOGIN`, `IN ROLE marina_reader`), grants it to the
+service account so `SET ROLE` is allowed, and creates schema `applet_<name>` (hyphens to
+underscores) with `AUTHORIZATION applet_<name>`. Delete drops the schema and the role.
+
+## HTTP surface
+
+All under the existing kernel authentication; the caller is the verified identity.
+
+| Method and path | Body | Result |
+| --- | --- | --- |
+| `GET /api/marina/apps` | | unchanged shape, now includes applets with `"kind": "applet"`, `"published_by"`, `"version"` |
+| `POST /api/marina/applets/{name}` | `application/x-tar` (gzip allowed) with `app.toml` and `dist/` at the top | `201 {"name", "version", "path"}`; `400` for a bad manifest, missing `dist/index.html`, over-limit bundle, or a name a directory app owns; `409` when `name` is being published concurrently |
+| `GET /api/marina/applets/{name}` | | `{"name", "current_version", "versions": [{"version", "published_by", "published_at", "byte_size"}]}` |
+| `PUT /api/marina/applets/{name}/current` | `{"version": int}` | `200`; `404` for an unknown version |
+| `DELETE /api/marina/applets/{name}` | | `204`; drops rows and the applet schema |
+| `POST /{app}/query` | `{"sql": str, "params": {..}}` | `200 {"columns": [..], "rows": [[..]], "truncated": bool}`; `400` for more than one statement, a parse error, or a top-level `SET`, `RESET`, `BEGIN`, `COMMIT`, `ROLLBACK`; `404` for an unknown app; `422` with `sqlstate` and message for a permission or statement error; `504` on `sqlstate 57014` (timeout) |
+
+Tarball contract: entries `app.toml` and `dist/**`, with or without a leading `./`, or
+all under one uniform top-level directory that is stripped. Regular files only; symlinks,
+hard links, absolute paths, `..`, and devices are rejected with `400`. Caps apply to
+uncompressed bytes (25 MB total, 8 MB per file). `build_command` in the manifest is
+ignored. Publish takes `pg_advisory_xact_lock(hashtext(name))`; a concurrent publisher
+gets `409`. The new version is `max(version) + 1`.
+
+Query execution runs on a dedicated engine (pool of 2) as one transaction:
+`BEGIN; SET LOCAL ROLE applet_<app>; SET LOCAL search_path TO applet_<app>, public;
+SET LOCAL statement_timeout = 10000; <statement>; COMMIT`, with `marina_reader` and
+`search_path = <app>, public` for a directory app. `SET LOCAL` ends with the transaction
+whichever way it ends, so no connection returns to the pool carrying a role. Parameters
+bind through SQLAlchemy `text()` over pg8000's extended protocol, which is what refuses a
+second statement in the string; the kernel additionally rejects the listed top-level
+commands by their first keyword. A `DO` block is one statement and is bounded by the
+timeout only. Rows are capped at 10,000 with `truncated: true`. Every call is logged with
+the caller, app, `sqlstate` if any, and duration.
+
+## CLI
+
+`src/marina/cli.py`
+
+```
+marina publish DIR [--name NAME] [--url URL] [--build/--no-build] [--dry-run] [--json]
+    Build DIR (its build_command) unless dist/ exists or --no-build, tar app.toml and
+    dist/, POST to URL (default MARINA_URL or https://marina.oa.dev) with the desktop
+    OAuth token (Echo's bearer_token() moves into marina.client), print the applet URL
+    (URL + path). --name defaults to DIR's basename. --dry-run validates and prints the
+    tarball listing without posting; --json prints the server's response body. Exit 1
+    with the server's error text on 4xx.
+marina applets list [--url URL]
+    name, current version, publisher, published at.
+marina applets rollback NAME VERSION [--url URL]
+marina applets delete NAME [--url URL]
+```
+
+`marina check`, `marina build`, `marina dev`, and `marina journey` accept an applet's
+source directory in `apps/` unchanged.
+
+## Shell
+
+`web/Shell.vue` shows applets in the switcher after the checked-in apps, with the
+publisher's email as the entry's title attribute. No other change.
+
+## Errors
+
+- `AppletTooLarge(name, byte_size)`: bundle over 25 MB or 2,000 files; `400`.
+- `AppletNameReserved(name)`: a directory app owns the name; `400`.
+- `AppletNotFound(name)`: `404` on rollback, delete, and info.
+- `QueryRefused(reason)`: multiple statements or a refused top-level command; `400`.
+- `AppletBundleInvalid(reason)`: a bad tarball entry or manifest; `400`.
+- Postgres permission and statement errors pass through as `422` with `sqlstate` and message.
+
+## Out of scope
+
+- Running uploaded Python in the kernel or in a per-applet service.
+- Vanity hosts for applets; they live at `https://marina.oa.dev/<name>/` only.
+- Per-user or per-app authorization; every signed-in person can publish, roll back,
+  delete, and query, as with every other Marina action.
+- Data-root uploads for applets (use `gsutil` as for checked-in apps) and a bucket
+  store for bundles.
+- Build-on-server; the publisher builds.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `src/marina/registry.py` | `Registry`, `DirectoryRegistry`, `AppletRegistry`, `ComposedRegistry` |
+| `src/marina/applets.py` | bundle validation, publish/rollback/delete, the applets routes |
+| `src/marina/query.py` | the query endpoint and role handling |
+| `src/marina/migrations/m0001_applets.py` | tables and the role |
+| `src/marina/cli.py` | `publish`, `applets` |
+| `tests/test_registry.py`, `tests/test_applets.py`, `tests/test_query.py` | unit tests on a throwaway Postgres |
+| `tests/journeys/test_applets.py` | the publish-then-visit journey; `journey_plugin` gains `--journey-app NAME` for specs outside `apps/<name>/journeys/`, and `Journey.app` is settable so the spec names the applet it just published; needs `MARINA_DATABASE_URL` |


### PR DESCRIPTION
Marina apps today are checked in: an app.toml, a built dist, a PR, an image, a deploy. That is right for Echo and EvalDash and wrong for the one-off table someone wants during an incident or the review page an agent builds mid-session. This proposes applets: apps published to the running Marina service with one command, stored in the marina database, and served, listed, and authenticated exactly like checked-in apps. A Registry protocol with a directory and an applet implementation makes the two indistinguishable to the kernel and the Shell; resolution moves from startup to request time so a publish is live on every instance without a restart. Applets get data through the existing data route and a per-app SQL endpoint bounded by Postgres roles: each applet owns its schema and reads every app's schema through a shared reader role, with the role set locally per transaction. Uploaded server code is out of scope for v1.

- [design.md](https://github.com/marin-community/marin/blob/design/marina_applets/.agents/projects/marina_applets/design.md)
- [research.md](https://github.com/marin-community/marin/blob/design/marina_applets/.agents/projects/marina_applets/research.md)
- [spec.md](https://github.com/marin-community/marin/blob/design/marina_applets/.agents/projects/marina_applets/spec.md)

Depends on #8867 for the kernel it extends.

https://claude.ai/code/session_01X99FW86Cjf3XhEUMHGWeVX