### PR TITLE
[dependencies] Advance MarinSkyRL runtime

### DIFF
--- a/config/external/MarinSkyRL/uv.lock
+++ b/config/external/MarinSkyRL/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 [[package]]
 name = "marinskyrl"
 version = "0.1.0"
-source = { git = "https://github.com/marin-community/MarinSkyRL.git?branch=main#b69d22cebfa5824745df0d4b2d5c57c55bb74b35" }
+source = { git = "https://github.com/marin-community/MarinSkyRL.git?branch=main#8266072d8e4b4a06f77fc6ea73af87d38c365222" }
 dependencies = [
     { name = "boto3" },
     { name = "datasets" },

--- a/lib/marin/src/marin/external_dependencies.py
+++ b/lib/marin/src/marin/external_dependencies.py
@@ -75,7 +75,7 @@ MARIN_SKYRL = ExternalDependency(
     distribution="marinskyrl",
     repository="https://github.com/marin-community/MarinSkyRL.git",
     version="0.1.0",
-    commit="b69d22cebfa5824745df0d4b2d5c57c55bb74b35",
+    commit="8266072d8e4b4a06f77fc6ea73af87d38c365222",
     runtime_requirements=(),
 )
 


### PR DESCRIPTION
Advance the isolated MarinSkyRL runtime from `b69d22cebfa5` to `8266072d8e4b`. The 37-commit range includes MarinSkyRL #460, which replaces separate Prometheus bucket rows with one typed histogram snapshot produced through the callback telemetry contract.

Five-minute production samples attributed 70% of RNO2A MarinSkyRL rows and 54% of USE02A rows to classic histogram buckets. New launches use the advanced runtime; running jobs retain their bundled older revision until resubmitted.

The generated-pin check passed. The affected safe test selection passed 187 tests with 2 skips.

Part of #8563.
