### PR TITLE
[evaluation] Add SFT coverage-ratio reduction

### DIFF
--- a/lib/marin/src/marin/evaluation/coverage_ratio.py
+++ b/lib/marin/src/marin/evaluation/coverage_ratio.py
@@ -1,0 +1,124 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""TailSFT-style coverage changes between evaluation checkpoints.
+
+The diagnostic in issue #8876 estimates each problem's pass@1 from repeated binary
+attempts, transforms that estimate to pass@k under independent sampling, and compares
+checkpoint pairs only on problems whose base-model pass@k lies in a fixed open interval.
+
+This module contains only the reduction. Producing repeated samples and loading them
+from an evaluation archive remain responsibilities of the evaluation runner and archive
+adapter respectively.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProblemAttempts:
+    """Binary outcomes summarized for one problem at one checkpoint."""
+
+    successes: int
+    attempts: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.successes, bool) or not isinstance(self.successes, int):
+            raise TypeError("successes must be an integer")
+        if isinstance(self.attempts, bool) or not isinstance(self.attempts, int):
+            raise TypeError("attempts must be an integer")
+        if self.attempts <= 0:
+            raise ValueError("attempts must be positive")
+        if not 0 <= self.successes <= self.attempts:
+            raise ValueError("successes must be between zero and attempts")
+
+    @property
+    def pass_at_1(self) -> float:
+        """The per-attempt empirical success rate."""
+        return self.successes / self.attempts
+
+
+@dataclass(frozen=True)
+class CoverageRatio:
+    """Loss and gain over the base-reachable problem set for one transition."""
+
+    reachable_problem_ids: tuple[str, ...]
+    loss: float
+    gain: float
+    ratio: float | None
+    mean_pass_at_k_change: float | None
+
+
+def pass_at_k(pass_at_1: float, k: int) -> float:
+    """Transform a per-attempt success probability to independent-sampling pass@k.
+
+    This is the ``1 - (1 - p)^k`` plug-in transform specified by issue #8876, not
+    the finite-sample unbiased pass@k estimator.
+    """
+    if isinstance(k, bool) or not isinstance(k, int) or k <= 0:
+        raise ValueError("k must be a positive integer")
+    if isinstance(pass_at_1, bool) or not isinstance(pass_at_1, (int, float)):
+        raise TypeError("pass_at_1 must be a number")
+    if not math.isfinite(pass_at_1) or not 0.0 <= pass_at_1 <= 1.0:
+        raise ValueError("pass_at_1 must be finite and between zero and one")
+    return 1.0 - (1.0 - pass_at_1) ** k
+
+
+def tail_sft_coverage_ratio(
+    base: Mapping[str, ProblemAttempts],
+    before: Mapping[str, ProblemAttempts],
+    after: Mapping[str, ProblemAttempts],
+    *,
+    k: int = 16,
+    expected_attempts: int = 16,
+    reachable_lower: float = 0.05,
+    reachable_upper: float = 0.95,
+) -> CoverageRatio:
+    """Compare one checkpoint transition on the base-reachable problem set.
+
+    The reachable interval is open. Every supplied problem must have the fixed number
+    of attempts so a transition cannot silently mix evaluation budgets. ``ratio`` is
+    ``None`` when gain is zero, and the mean change is ``None`` when the reachable set
+    is empty.
+    """
+    if isinstance(expected_attempts, bool) or not isinstance(expected_attempts, int) or expected_attempts <= 0:
+        raise ValueError("expected_attempts must be a positive integer")
+    if not 0.0 <= reachable_lower < reachable_upper <= 1.0:
+        raise ValueError("reachable bounds must satisfy 0 <= lower < upper <= 1")
+
+    for checkpoint, problems in (("base", base), ("before", before), ("after", after)):
+        mismatched = sorted(problem_id for problem_id, value in problems.items() if value.attempts != expected_attempts)
+        if mismatched:
+            raise ValueError(f"{checkpoint} problems do not have exactly {expected_attempts} attempts: {mismatched}")
+
+    reachable = tuple(
+        sorted(
+            problem_id
+            for problem_id, attempts in base.items()
+            if reachable_lower < pass_at_k(attempts.pass_at_1, k) < reachable_upper
+        )
+    )
+    missing_before = sorted(set(reachable).difference(before))
+    missing_after = sorted(set(reachable).difference(after))
+    if missing_before or missing_after:
+        raise ValueError(
+            "base-reachable problems are missing from a transition: " f"before={missing_before}, after={missing_after}"
+        )
+
+    changes = [
+        pass_at_k(after[problem_id].pass_at_1, k) - pass_at_k(before[problem_id].pass_at_1, k)
+        for problem_id in reachable
+    ]
+    loss = math.fsum(max(-change, 0.0) for change in changes)
+    gain = math.fsum(max(change, 0.0) for change in changes)
+    return CoverageRatio(
+        reachable_problem_ids=reachable,
+        loss=loss,
+        gain=gain,
+        ratio=loss / gain if gain > 0.0 else None,
+        mean_pass_at_k_change=math.fsum(changes) / len(changes) if changes else None,
+    )

--- a/tests/evaluation/test_coverage_ratio.py
+++ b/tests/evaluation/test_coverage_ratio.py
@@ -1,0 +1,108 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.evaluation.coverage_ratio import ProblemAttempts, pass_at_k, tail_sft_coverage_ratio
+
+
+def test_pass_at_k_applies_the_issue_defined_independent_draw_transform():
+    assert pass_at_k(0.0, 16) == 0.0
+    assert pass_at_k(1.0, 16) == 1.0
+    assert pass_at_k(0.5, 2) == pytest.approx(0.75)
+
+
+@pytest.mark.parametrize(
+    ("successes", "attempts"),
+    [(-1, 16), (17, 16), (0, 0)],
+)
+def test_problem_attempts_rejects_invalid_counts(successes, attempts):
+    with pytest.raises(ValueError):
+        ProblemAttempts(successes=successes, attempts=attempts)
+
+
+def test_coverage_ratio_reports_loss_gain_ratio_and_mean_change():
+    base = {
+        "loss": ProblemAttempts(2, 4),
+        "gain": ProblemAttempts(2, 4),
+        "never": ProblemAttempts(0, 4),
+        "always": ProblemAttempts(4, 4),
+    }
+    before = {
+        "loss": ProblemAttempts(3, 4),
+        "gain": ProblemAttempts(1, 4),
+        "never": ProblemAttempts(0, 4),
+        "always": ProblemAttempts(4, 4),
+    }
+    after = {
+        "loss": ProblemAttempts(1, 4),
+        "gain": ProblemAttempts(2, 4),
+        "never": ProblemAttempts(0, 4),
+        "always": ProblemAttempts(4, 4),
+    }
+
+    result = tail_sft_coverage_ratio(base, before, after, k=2, expected_attempts=4)
+
+    assert result.reachable_problem_ids == ("gain", "loss")
+    assert result.loss == pytest.approx(0.5)
+    assert result.gain == pytest.approx(0.3125)
+    assert result.ratio == pytest.approx(1.6)
+    assert result.mean_pass_at_k_change == pytest.approx(-0.09375)
+
+
+def test_coverage_ratio_uses_open_reachable_bounds():
+    base = {
+        "lower": ProblemAttempts(1, 4),
+        "middle": ProblemAttempts(2, 4),
+        "upper": ProblemAttempts(3, 4),
+    }
+
+    result = tail_sft_coverage_ratio(
+        base,
+        base,
+        base,
+        k=1,
+        expected_attempts=4,
+        reachable_lower=0.25,
+        reachable_upper=0.75,
+    )
+
+    assert result.reachable_problem_ids == ("middle",)
+
+
+def test_coverage_ratio_rejects_a_mixed_attempt_budget():
+    base = {"p": ProblemAttempts(8, 16)}
+    before = {"p": ProblemAttempts(7, 15)}
+    after = {"p": ProblemAttempts(8, 16)}
+
+    with pytest.raises(ValueError, match="before problems do not have exactly 16 attempts"):
+        tail_sft_coverage_ratio(base, before, after)
+
+
+def test_coverage_ratio_rejects_missing_reachable_problems():
+    base = {"p": ProblemAttempts(1, 16)}
+
+    with pytest.raises(ValueError, match=r"before=\['p'\]"):
+        tail_sft_coverage_ratio(base, {}, base)
+
+
+def test_coverage_ratio_marks_zero_gain_as_undefined():
+    base = {"p": ProblemAttempts(1, 16)}
+    after = {"p": ProblemAttempts(0, 16)}
+
+    result = tail_sft_coverage_ratio(base, base, after)
+
+    assert result.loss > 0.0
+    assert result.gain == 0.0
+    assert result.ratio is None
+
+
+def test_coverage_ratio_reports_an_empty_reachable_set():
+    base = {"never": ProblemAttempts(0, 16), "always": ProblemAttempts(16, 16)}
+
+    result = tail_sft_coverage_ratio(base, base, base)
+
+    assert result.reachable_problem_ids == ()
+    assert result.loss == 0.0
+    assert result.gain == 0.0
+    assert result.ratio is None
+    assert result.mean_pass_at_k_change is None


### PR DESCRIPTION
Add an import-light reduction for the fixed-budget TailSFT diagnostic in #8876. It estimates per-problem pass@1 from binary attempt counts, applies the issue-defined `1 - (1 - p)^k` transform, selects the base-reachable set, and reports loss, gain, their ratio, and mean pass@k change for a checkpoint transition.

The reduction rejects mixed attempt budgets and missing reachable problems. Zero gain and an empty reachable set produce an undefined ratio instead of a misleading numeric value.

The focused test file passes 10 synthetic cases under Python 3.12. Ruff 0.14.3 and Black 25.9.0 pass on both changed files. Repeated-sample generation, archive loading, Snowball inference runs, and the cold-start recipe change remain outside this draft.

The draft leaves two choices for review: whether the issue intends the plug-in transform instead of a finite-sample pass@k estimator, and whether this reduction should remain separate from `eval_stats.py`.

Part of #8876
