### PR TITLE
[grug] Fall back to the pooled-wave transport for the EP hero

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -16,21 +16,24 @@ data-parallel rack uses one 64-device expert mesh.
   diagnostic uses 1024 sequences.
 - Router: top-8 quantile balancing uses a global histogram with 10,000 bins. It has next-step,
   stop-gradient expert biases and no auxiliary balancing loss.
-- MoE backend: `ragged_all_to_all`. One update carries each (peer, local expert) pair, so rows
-  arrive grouped by expert, and local experts run in two chunks that share the 1.15 receiver
-  capacity. The transport reaches XLA's device-initiated (NCCL LSA) kernel, which needs Marin's patched
-  PJRT build, installed on GB200 through the `gpu` extra (`lib/marin/pyproject.toml`); a run that
-  reaches the stock plugin fails at startup.
+- MoE backend: `fixed_pooled_wave_all_to_all`, as a temporary fallback. Each sender uses one fixed
+  pool per destination and stripes it over three static waves. The receiver runs all six local
+  experts in each wave and drops rows above the fixed expert capacity. Expert IDs travel in the
+  activation payload, so the method does not use a metadata collective. The receiver and sender
+  capacity factors are 1.15. `ragged_all_to_all` is the intended default and takes the hero back
+  once it stops hanging an 11-rack run after a watch step
+  ([#8870](https://github.com/marin-community/marin/issues/8870)): one update carries each (peer,
+  local expert) pair, so rows arrive grouped by expert, and it reaches XLA's device-initiated
+  (NCCL LSA) kernel, which needs Marin's patched PJRT build, installed on GB200 through the `gpu`
+  extra (`lib/marin/pyproject.toml`).
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
 - Weights: fp32 on device with bf16 compute. A checkpoint written with a pinned-host fp32 master
   migrates in process on restore: its stored fp32 master is read directly into the run's params
   (the bf16 compute copy goes unread), and the next save writes the new layout. The reverse
   (synthesizing a master) is refused.
 - Runtime: Each GPU has one JAX process. The recipe uses `cuda_async`, no PGLE, and no GPU
-  command buffers. The ragged transport stages each layer's residual carry on pinned host, which
-  frees the HBM the latency-hiding scheduler needs to run. Collective overlap stays at 1: the
-  offload, the scheduler, and a higher limit corrupt training together, though no pair of them
-  does.
+  command buffers. The layer carry stays in HBM, which only the ragged transport offloads. Inline
+  watch uses collective overlap limit 1. A disabled watch uses limit 4.
 - Resources: Each four-GPU worker requests 120 CPU, 890 GB of RAM, and 1 TB of disk.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -27,10 +27,11 @@ data-parallel rack uses one 64-device expert mesh.
   (NCCL LSA) kernel, which needs Marin's patched PJRT build, installed on GB200 through the `gpu`
   extra (`lib/marin/pyproject.toml`).
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Weights: fp32 on device with bf16 compute. A checkpoint written with a pinned-host fp32 master
-  migrates in process on restore: its stored fp32 master is read directly into the run's params
-  (the bf16 compute copy goes unread), and the next save writes the new layout. The reverse
-  (synthesizing a master) is refused.
+- Weights: bf16 on device with a pinned-host fp32 master, which the pooled-wave device peak needs.
+  A checkpoint written with a master restores natively here. A master-less checkpoint, which the
+  hero writes when it keeps fp32 weights on device under the ragged transport, cannot restore into
+  this mode: synthesizing a master is refused. The reverse direction migrates in process, so a
+  master-bearing checkpoint reaches either mode.
 - Runtime: Each GPU has one JAX process. The recipe uses `cuda_async`, no PGLE, and no GPU
   command buffers. The layer carry stays in HBM, which only the ragged transport offloads. Inline
   watch uses collective overlap limit 1. A disabled watch uses limit 4.

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -38,8 +38,12 @@ HERO_NODE_CPU = 120
 HERO_NODE_RAM = "890g"
 HERO_NODE_DISK = "1t"
 HERO_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
-# The hero keeps fp32 weights on device; the diagnostics, soak, and benchmarks follow it.
-HERO_MASTER_PARAM_MODE = MasterParamMode.DEVICE
+# The pooled-wave transport peaks at 149.9 GiB of device memory with fp32 weights on device
+# (#8549), above the 138.2 GiB `cuda_async` release threshold, so this fallback keeps the fp32
+# master on pinned host and leaves the device copy in bf16. The mode is part of the checkpoint
+# layout: a master-less checkpoint cannot restore into it, because synthesizing a master is
+# refused. The diagnostics, soak, and benchmarks follow the hero.
+HERO_MASTER_PARAM_MODE = MasterParamMode.FP32_PINNED_HOST
 # An fp32 master keeps the device copy in bf16; without one the device weights are the fp32 copy.
 HERO_MIXED_PRECISION_BY_MASTER_PARAM_MODE = {
     MasterParamMode.FP32_PINNED_HOST: HERO_MIXED_PRECISION,

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -9,8 +9,9 @@ pairs it with the fixed hero model spec so a launcher gets both configs back fro
 ``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
 
 The hero model is d6144 with 48 layers and 384 routed experts. Each expert has width 3,072, and
-the router selects eight experts per token. Expert parallelism moves tokens with the ragged
-all-to-all transport at a 1.15 receiver capacity factor.
+the router selects eight experts per token. Expert parallelism moves tokens with the pooled-wave
+all-to-all transport at 1.15 sender and receiver capacity factors, until the ragged transport is
+fit to take the default back.
 """
 
 import math
@@ -105,9 +106,11 @@ HERO_MODEL = GrugModelConfig(
     qk_mult=1.3,
     sconv=True,
     attention_implementation="gpu_fa4_cute_wide",
-    moe_implementation="ragged_all_to_all",
-    pooled_transport_capacity_factor=1.15,  # pooled-wave only
-    num_expert_waves=3,  # pooled-wave only
+    # Temporary fallback while the ragged transport is debugged: it hangs an 11-rack hero after
+    # a watch step (#8870). `ragged_all_to_all` takes this back once that is fixed.
+    moe_implementation="fixed_pooled_wave_all_to_all",
+    pooled_transport_capacity_factor=1.15,
+    num_expert_waves=3,
     expert_chunks=1,
     report_capacity_overflow=True,
     rope_fused=True,

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -9,7 +9,7 @@ This run puts the same hooks on a one-step cadence on up to two GB200 trays, so 
 100 checkpoints, tagged evaluations, and dropless evaluations.
 
 The shape is downsized but the memory-relevant machinery is the hero's: MuonH optimizer state
-offloaded to pinned host memory, and the ragged all-to-all transport. Those decide what the
+offloaded to pinned host memory, and the hero's all-to-all transport. Those decide what the
 checkpoint path has to move through host memory, which is what the soak measures.
 
 Checkpoints go to a one-day temporary prefix, never to the hero's own checkpoint root.

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -72,7 +72,7 @@ def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
         1.15,
         1.15,
         3,
-        "ragged_all_to_all",
+        "fixed_pooled_wave_all_to_all",
         model.QbEstimator.HIST,
         10_000,
         1024,

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -80,9 +80,9 @@ def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
         4,
         10,
         1_000_000_000,
-        jnp.float32,
         jnp.bfloat16,
-        train.MasterParamMode.DEVICE,
+        jnp.bfloat16,
+        train.MasterParamMode.FP32_PINNED_HOST,
     )
 
 


### PR DESCRIPTION
The d6144 EP hero moves tokens with `fixed_pooled_wave_all_to_all` again, at the 1.15 sender and receiver capacity factors over 3 waves that the spec already carries. The ragged transport hung an 11-rack hero on the step after a watch step, twice, and a one-rack restore does not reproduce it (#8870).

The backend field decides the rest of the recipe. The run no longer needs Marin's patched `jax-cuda13-pjrt` build, keeps the layer carry in HBM instead of offloading it, runs the latency-hiding scheduler, and takes collective overlap 4 with the watch disabled. Against the paired one-rack measurement in #8549, pooled-wave costs 0.16 MFU (22.71% against 22.87%), drops 2.67% of assignments against 0.018%, and peaks at 149.9 GiB of device memory against 137.9 GiB. That peak is above the 138.2 GiB `cuda_async` release threshold that `XLA_PYTHON_CLIENT_MEM_FRACTION=0.75` sets, so the pool may unmap every step.

The fp32 master moves back to pinned host with it, leaving the device copy in bf16. With fp32 weights on device the pooled peak sits above the release threshold, so the pool unmaps every step and can fail an allocation the step already sized (#8490). The mode is part of the checkpoint layout: a master-bearing checkpoint restores into either mode, so the live hero's checkpoints reach this one, while a master-less checkpoint written with fp32 weights on device restores only into the device mode, because synthesizing a master is refused.

The narrow scaling-ladder rungs keep their own ragged selection; only the d6144 rung follows the hero spec. Ragged all-to-all takes the default back once #8870 is fixed.

Part of #8870.

https://claude.ai/code/session_01JapZ8ynxnfzk8fZ7qbW312
