### PR TITLE
[grug] Hand the hero relaunch off from the checkpoint it was paused at

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -24,7 +24,7 @@ Changelog:
     2026-09-02 (#8818, PR #8833): decoupled weight decay on the attn_gate and router weights is on by
         default (0.02, annealed linearly to 0 over training and read from the Adam step count so it
         resumes at the right step); pass ``--gate-router-weight-decay 0`` to opt out.
-        hero-wd-gate-router-p02-step54k forks hero-12d8b6f0-dee637 at step 54000 on the pooled-wave transport
+        hero-wd-gate-router-p02-step58k forks hero-12d8b6f0-dee637 at step 58014 on the pooled-wave transport
         (see ``trigger_hero.sh``).
 """
 

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,10 +11,10 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
-# Gate/router weight-decay continuation: forks the hero's full state from its step-54000 checkpoint
+# Gate/router weight-decay continuation: forks the hero's full state from its step-58014 checkpoint
 # under its own run id and tree, and trains with the decay on by default (0.02, annealed).
-RUN_ID=hero-wd-gate-router-p02-step54k
-HANDOFF_CHECKPOINT=s3://marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2/checkpoints/step-54000
+RUN_ID=hero-wd-gate-router-p02-step58k
+HANDOFF_CHECKPOINT=s3://hero-checkpoints/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2/checkpoints/step-58014
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
 short_uuid=${short_uuid:0:8}
 


### PR DESCRIPTION
The launcher still pointed at `step-54000`, which predates the 2026-09-03 pause. The hero was cancelled at step 58014 to free eleven racks for the #8870 debugging window, and relaunching from `step-54000` would silently discard the ~4,000 steps trained since — about a day of training on 704 GPUs.

`step-58014` was forced through the training-control endpoint immediately before the cancel, so the pause itself cost about one step rather than the up-to-an-hour gap a scheduled temporary checkpoint would have left. It is verified complete: `manifest.json`, `manifest.ocdbt` and `metadata.json` all present, `{"step": 58014, "timestamp": "2026-09-03T23:13:13.777258", "is_temporary": true}`, with 28,098 objects totalling 5.36 TB under `d/`.

It is a temporary checkpoint, which restore treats identically to a permanent one. Both kinds are written by the same call in the same format; `is_temporary` is read only by the deletion policy, never by restore, and `_scan_checkpoint_root` accepts any directory containing `metadata.json`, sorting all roots by step descending. `metadata.json` is written last and only after the global commit barrier, so a torn checkpoint is invisible to discovery rather than loadable-but-wrong. A permanent checkpoint could not be used instead: the newest is `step-54000`, the next is `step-60000` (~11.5 h away), and a permanent one cannot be forced — `request_checkpoint()` sets only `should_save`, while `save_permanent_ckpt` follows `force`, which is true only on clean training completion.

The run id keeps its existing form and moves to the step it now forks from: `hero-wd-gate-router-p02-step58k`.

Note for #8833: the gate/router weight-decay run now starts from 58014 rather than 54000, so its control is the paused hero's own trajectory rather than the step-54000 one.
