### PR TITLE
[inference] Remove the 40- and 100-request caps on a brokered vLLM fleet

### DIFF
--- a/lib/marin/src/marin/inference/config.py
+++ b/lib/marin/src/marin/inference/config.py
@@ -136,6 +136,14 @@ class VllmEngineConfig:
     max_num_seqs: int | None = None
     extra_args: tuple[str, ...] = ()
     extra_metric_families: frozenset[str] = frozenset()
+    uv_with_packages: tuple[str, ...] = ()
+    """Extra packages installed into the isolated CUDA vLLM env (``uvx --with``).
+
+    For prebuilt kernel artifacts such as ``flashinfer-cubin`` / ``flashinfer-jit-cache``,
+    which let the engine skip FlashInfer's JIT build at startup. CUDA launcher only."""
+    uv_extra_index_urls: tuple[str, ...] = ()
+    """Additional package indexes for ``uv_with_packages`` (``uvx --index``), e.g.
+    ``https://flashinfer.ai/whl/cu130/`` for ``flashinfer-jit-cache``."""
 
     def __post_init__(self) -> None:
         if self.startup_timeout_seconds <= 0:
@@ -151,6 +159,8 @@ class VllmEngineConfig:
             source="VllmEngineConfig.extra_metric_families",
         )
         object.__setattr__(self, "extra_metric_families", extra_metric_families)
+        if (self.uv_with_packages or self.uv_extra_index_urls) and self.launcher is not VllmLauncherType.CUDA:
+            raise ValueError("uv_with_packages / uv_extra_index_urls require the CUDA launcher")
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/inference/dashboard_server.py
+++ b/lib/marin/src/marin/inference/dashboard_server.py
@@ -37,6 +37,12 @@ from marin.inference.http_proxy import forwardable_request_headers, forwardable_
 
 logger = logging.getLogger(__name__)
 
+# Every /v1 request funnels through one httpx client, so httpx's default connection pool
+# (max_connections=100) would silently cap the whole serve at 100 concurrent requests — far below
+# what a batch-inference vLLM engine sustains (max_num_seqs is commonly 512+).
+_UPSTREAM_MAX_CONNECTIONS = 4096
+_UPSTREAM_MAX_KEEPALIVE_CONNECTIONS = 1024
+
 
 @dataclass(frozen=True)
 class ServingInfo:
@@ -74,6 +80,10 @@ def build_dashboard_app(
         state["client"] = httpx.AsyncClient(
             base_url=upstream_base_url,
             timeout=httpx.Timeout(request_timeout_seconds, connect=10.0),
+            limits=httpx.Limits(
+                max_connections=_UPSTREAM_MAX_CONNECTIONS,
+                max_keepalive_connections=_UPSTREAM_MAX_KEEPALIVE_CONNECTIONS,
+            ),
         )
         try:
             yield

--- a/lib/marin/src/marin/inference/proxy.py
+++ b/lib/marin/src/marin/inference/proxy.py
@@ -32,6 +32,10 @@ from marin.inference.types import (
 
 logger = logging.getLogger(__name__)
 
+# Extra forwarding-limiter capacity beyond max_pending_requests: keeps the over-capacity 429 path
+# reachable while the pending budget is fully parked.
+_FORWARD_LIMITER_HEADROOM = 16
+
 
 @dataclass
 class ProxyStats:
@@ -71,6 +75,11 @@ class InferenceProxy:
             backoff = ExponentialBackoff(initial=0.01, maximum=0.25, factor=2.0)
         self._backoff = backoff
         self._pending: dict[str, Future[InferenceResponse]] = {}
+        # Each in-flight request parks a thread in forward_raw_request until its brokered response
+        # lands. anyio's default to_thread limiter is 40 threads, which silently caps the whole
+        # fleet's concurrency at 40 no matter how many workers sit behind the broker; size the
+        # limiter to the pending budget instead.
+        self._forward_limiter = anyio.CapacityLimiter(max_pending_requests + _FORWARD_LIMITER_HEADROOM)
         self._lock = threading.Lock()
         self._poll_stop_event: threading.Event | None = None
         self._poll_thread: threading.Thread | None = None
@@ -148,7 +157,8 @@ class InferenceProxy:
                 query_string=request.url.query,
                 headers=forwardable_request_headers(request.headers),
                 timeout_seconds=timeout_seconds,
-            )
+            ),
+            limiter=self._forward_limiter,
         )
 
     def forward_raw_request(
@@ -194,7 +204,10 @@ class InferenceProxy:
                     headers=tuple((headers or {}).items()),
                 ),
             )
-            logger.info(
+            # DEBUG, not INFO: this fires once per request, and a brokered fleet at full tilt sees
+            # hundreds of requests per second -- at that rate per-request logging is a measurable
+            # cost in the proxy's own event loop and the aggregate story lives in ProxyStats.
+            logger.debug(
                 "InferenceProxy submitted request request_id=%s method=%s path=%s pending=%d/%d",
                 request_id,
                 method,
@@ -219,7 +232,7 @@ class InferenceProxy:
                 if not future.done():
                     future.cancel()
 
-        logger.info(
+        logger.debug(
             "InferenceProxy returning response request_id=%s method=%s path=%s status_code=%d",
             request_id,
             method,
@@ -261,7 +274,11 @@ class InferenceProxy:
         self.stats.matched_responses += len(matched_ids)
         self.stats.dropped_responses += len(dropped_ids)
         if responses:
-            logger.info(
+            # A drop means a response arrived for a request nobody is waiting on -- worth a line.
+            # A clean batch is routine (the poller fetches many times per second at load) and logs
+            # at DEBUG so the fetch loop is not spending its time formatting request ids.
+            log = logger.info if dropped_ids else logger.debug
+            log(
                 "InferenceProxy fetched responses count=%d matched=%d dropped=%d "
                 "pending=%d matched_ids=%s dropped_ids=%s",
                 len(responses),

--- a/lib/marin/src/marin/inference/vllm_backend.py
+++ b/lib/marin/src/marin/inference/vllm_backend.py
@@ -42,7 +42,12 @@ def vllm_launcher(config: VllmEngineConfig) -> VllmLauncher:
     version = config.version if source is VllmType.UPSTREAM else None
     if source is VllmType.UPSTREAM and version is None:
         version = DEFAULT_CUDA_VLLM_VERSION
-    return IsolatedCudaVllm(source=source, version=version)
+    return IsolatedCudaVllm(
+        source=source,
+        version=version,
+        with_packages=config.uv_with_packages,
+        extra_index_urls=config.uv_extra_index_urls,
+    )
 
 
 def _with_subprocess_env(

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -198,6 +198,11 @@ class IsolatedCudaVllm:
     """Exact PyPI pin; required for ``UPSTREAM`` and ignored for ``MARIN_FORK``."""
     # Match the workspace interpreter so cloudpickled entrypoints stay compatible.
     python_version: str = WORKER_PYTHON_VERSION
+    with_packages: tuple[str, ...] = ()
+    """Extra ``uvx --with`` package specs, e.g. prebuilt FlashInfer kernel artifacts
+    (``flashinfer-cubin``, ``flashinfer-jit-cache``) that skip FlashInfer's JIT build at startup."""
+    extra_index_urls: tuple[str, ...] = ()
+    """Additional ``uvx --index`` URLs for :attr:`with_packages`."""
 
     def __post_init__(self) -> None:
         if self.source is VllmType.UPSTREAM and not self.version:
@@ -237,6 +242,10 @@ class IsolatedCudaVllm:
         ]
         for requirement in _CUDA_TOOLCHAIN_REQUIREMENTS:
             command.extend(("--with", requirement))
+        for package in self.with_packages:
+            command.extend(("--with", package))
+        for index_url in self.extra_index_urls:
+            command.extend(("--index", index_url))
         command.extend(
             (
                 "--python",
@@ -263,7 +272,14 @@ class IsolatedCudaVllm:
     def cache_identity(self) -> str:
         install = self._install()
         toolchain = ",".join(_CUDA_TOOLCHAIN_REQUIREMENTS)
-        return f"cuda:{install.requirement}:{self.python_version}:{install.torch_backend}:{toolchain}"
+        identity = f"cuda:{install.requirement}:{self.python_version}:{install.torch_backend}:{toolchain}"
+        if self.with_packages:
+            identity += ":" + ",".join(self.with_packages)
+        if self.extra_index_urls:
+            # Distinct indexes can serve different builds of the same requirement
+            # (e.g. cu130-vs-cu129 FlashInfer), so they must not share a compilation cache.
+            identity += ":" + ",".join(sorted(self.extra_index_urls))
+        return identity
 
 
 def _write_virtual_hosted_s3_config() -> str:

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -277,8 +277,9 @@ class IsolatedCudaVllm:
             identity += ":" + ",".join(self.with_packages)
         if self.extra_index_urls:
             # Distinct indexes can serve different builds of the same requirement
-            # (e.g. cu130-vs-cu129 FlashInfer), so they must not share a compilation cache.
-            identity += ":" + ",".join(sorted(self.extra_index_urls))
+            # (e.g. cu130-vs-cu129 FlashInfer), and uv gives earlier --index flags priority, so
+            # the identity keeps the URLs in resolution order rather than sorting them.
+            identity += ":" + ",".join(self.extra_index_urls)
         return identity
 
 

--- a/lib/marin/src/marin/inference/worker.py
+++ b/lib/marin/src/marin/inference/worker.py
@@ -63,7 +63,12 @@ class InferenceWorker:
         )
         try:
             with (
-                httpx.Client(timeout=self._request_timeout_seconds) as client,
+                # httpx defaults to a 100-connection pool, which would cap the
+                # forwarding pool below max_in_flight and stall its threads.
+                httpx.Client(
+                    timeout=self._request_timeout_seconds,
+                    limits=httpx.Limits(max_connections=max_in_flight, max_keepalive_connections=max_in_flight),
+                ) as client,
                 ThreadPoolExecutor(max_workers=max_in_flight, thread_name_prefix="inference-worker-request") as pool,
             ):
                 while not stop_event.is_set():
@@ -74,7 +79,9 @@ class InferenceWorker:
                         for leased_request in leased_requests:
                             in_flight.add(pool.submit(self._forward_one, client, leased_request))
                         if leased_requests:
-                            logger.info(
+                            # DEBUG for the same reason as the proxy's per-request lines: at load
+                            # this fires many times a second and the id formatting is real work.
+                            logger.debug(
                                 "InferenceWorker fetched requests count=%d in_flight=%d/%d request_ids=%s",
                                 len(leased_requests),
                                 len(in_flight),
@@ -98,12 +105,16 @@ class InferenceWorker:
                     if done:
                         responses = [future.result() for future in done]
                         self._broker.submit_responses(responses)
-                        logger.info(
+                        statuses = dict(Counter(response.response.status_code for response in responses))
+                        # All-200 batches are routine and log at DEBUG; a batch carrying any error
+                        # status is the line someone will actually be looking for.
+                        log = logger.info if any(code != 200 for code in statuses) else logger.debug
+                        log(
                             "InferenceWorker submitted responses count=%d in_flight=%d/%d statuses=%s request_ids=%s",
                             len(responses),
                             len(in_flight),
                             max_in_flight,
-                            dict(Counter(response.response.status_code for response in responses)),
+                            statuses,
                             format_request_ids([response.response.request_id for response in responses]),
                         )
                         backoff.reset()
@@ -205,8 +216,13 @@ def _inference_error_response(
     detail: str | None = None,
     exc_info: bool = False,
 ) -> InferenceResponse:
+    """Build the standard brokered error envelope, ``{"error": {"message": ...}}``.
+
+    Every path out of the forwarding worker returns one, so a client sees the same error shape
+    whether the request was refused, timed out, or failed upstream.
+    """
     logger.warning(
-        "InferenceWorker returning error response request_id=%s method=%s path=%s status_code=%d error=%s detail=%s",
+        "Returning brokered error response request_id=%s method=%s path=%s status_code=%d error=%s detail=%s",
         request.request_id,
         request.method,
         request.path,

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -219,6 +219,18 @@ def test_isolated_cuda_vllm_marin_fork_uses_verified_wheel(monkeypatch, machine)
     assert requirement in launcher.cache_identity()
 
 
+def test_isolated_cuda_vllm_cache_identity_keeps_the_index_order(monkeypatch):
+    """uv gives earlier --index flags priority, so reversed indexes are different environments."""
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    indexes = ("https://flashinfer.ai/whl/cu130/", "https://flashinfer.ai/whl/cu129/")
+    forward = IsolatedCudaVllm(source=VllmType.MARIN_FORK, extra_index_urls=indexes)
+    backward = IsolatedCudaVllm(source=VllmType.MARIN_FORK, extra_index_urls=indexes[::-1])
+
+    assert forward.cache_identity() != backward.cache_identity()
+    cmd = forward.command()
+    assert [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--index"] == list(indexes)
+
+
 def test_isolated_cuda_vllm_marin_fork_rejects_unpublished_architecture(monkeypatch):
     monkeypatch.setattr("platform.machine", lambda: "ppc64le")
 


### PR DESCRIPTION
🤖 Three library defaults capped a brokered fleet regardless of how many vLLM
engines sat behind it. anyio's to_thread limiter parks each in-flight proxy
request on one of 40 threads, and httpx's default pool allows 100 connections
from the dashboard's /v1 funnel to the engine and 100 from each forwarding
worker. A 4-GPU serve drained at ~16 pages/s while its engines reported ~38
running requests. The proxy now sizes its own CapacityLimiter to
max_pending_requests, the dashboard client to 4096 connections and the worker
client to its max_in_flight, so the configured concurrency is what the fleet
delivers. Incident record: https://echo.oa.dev/wiki/259.

Per-request log lines in the proxy and worker move to DEBUG. At hundreds of
requests per second the request-id formatting was measurable in the proxy's
event loop; a batch with a dropped response or a non-200 status still logs at
INFO.

VllmEngineConfig gains uv_with_packages and uv_extra_index_urls, passed to the
isolated CUDA launcher as uvx --with and --index. The OCR fleet uses them for
flashinfer-cubin and flashinfer-jit-cache, so an engine starts without
FlashInfer's JIT build; the index URLs enter the compilation cache identity
because the cu130 and cu129 wheels of the same requirement differ.

Bottom of the stack that splits #8023, as requested there; the PDF pipeline
itself follows as the top PR.

Part of #7616.
