### PR TITLE
[storage] Avoid R2 verification downloads

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -87,16 +87,17 @@ Extra destination files remain by default. `--delete` removes them after all cop
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
 
-`verified-copy` hashes each source object while uploading it, reads the destination object back,
-and records the verified SHA-256 plus source object identity under a sibling
-`<DST>.verified-copy-status` prefix. A retry skips the source read when the source identity,
-destination path and size, verified record, and destination hash still match. Sources without stable
-generation, version, checksum, ETag, or modification metadata are read again. The command writes
-`<DST>/.verified-copy-manifest.json` after every object verifies;
-consumers should treat that manifest as the prefix's readiness marker. R2 uploads use fixed-size
-multipart parts. An existing completion manifest makes the destination immutable: the command
-returns immediately when source paths and sizes still match and fails if they changed. Use a fresh
-destination prefix for a changed export.
+`verified-copy` hashes each source object while uploading it. For S3-compatible destinations, it
+uses fixed-size multipart parts, calculates the corresponding content-derived ETag, and compares
+that value with destination metadata after the upload. Other destinations are read back and checked
+against the source SHA-256. The command records the SHA-256 and source and destination identities
+under a sibling `<DST>.verified-copy-status` prefix. A retry skips both object reads when those
+identities, the destination path and size, and the verified record still match. Sources without
+stable generation, version, checksum, ETag, or modification metadata are read again. The command
+writes `<DST>/.verified-copy-manifest.json` after every object verifies; consumers should treat that
+manifest as the prefix's readiness marker. An existing completion manifest makes the destination
+immutable: the command returns immediately when source paths and sizes still match and fails if they
+changed. Use a fresh destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -87,17 +87,17 @@ Extra destination files remain by default. `--delete` removes them after all cop
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
 
-`verified-copy` hashes each source object while uploading it. For S3-compatible destinations, it
-uses fixed-size multipart parts, calculates the corresponding content-derived ETag, and compares
-that value with destination metadata after the upload. Other destinations are read back and checked
-against the source SHA-256. The command records the SHA-256 and source and destination identities
-under a sibling `<DST>.verified-copy-status` prefix. A retry skips both object reads when those
-identities, the destination path and size, and the verified record still match. Sources without
-stable generation, version, checksum, ETag, or modification metadata are read again. The command
-writes `<DST>/.verified-copy-manifest.json` after every object verifies; consumers should treat that
-manifest as the prefix's readiness marker. An existing completion manifest makes the destination
-immutable: the command returns immediately when source paths and sizes still match and fails if they
-changed. Use a fresh destination prefix for a changed export.
+`verified-copy` hashes each source object while uploading it. For configured S3-compatible
+destinations such as R2, it uses fixed-size multipart parts, calculates the corresponding
+content-derived ETag, and compares that value with destination metadata after the upload. Other
+destinations are read back and checked against the source SHA-256. The command records the SHA-256
+and source and destination identities under a sibling `<DST>.verified-copy-status` prefix. A retry
+skips both object reads when those identities, the destination path and size, and the verified record
+still match. Sources without stable generation, version, checksum, ETag, or modification metadata
+are read again. The command writes `<DST>/.verified-copy-manifest.json` after every object verifies;
+consumers should treat that manifest as the prefix's readiness marker. An existing completion
+manifest makes the destination immutable: the command returns immediately when source paths and
+sizes still match and fails if they changed. Use a fresh destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -57,6 +57,13 @@ class _DestinationFile:
 
 
 @dataclass(frozen=True)
+class _CopiedFile:
+    sha256: str
+    size: int
+    expected_etag: str | None
+
+
+@dataclass(frozen=True)
 class _ResumeMarker:
     source_path: str
     source_identity: str | None
@@ -240,8 +247,8 @@ def _copy_or_resume(
         ):
             return expected, False
 
-    sha256, copied_size, expected_etag = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
-    if copied_size != source.size:
+    copied = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    if copied.size != source.size:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source size changed while copying {source.path}")
     current_info = source_fs.info(source.source_path)
@@ -255,13 +262,13 @@ def _copy_or_resume(
             destination_fs,
             destination_path,
             expected_size=source.size,
-            expected_sha256=sha256,
-            expected_etag=expected_etag,
+            expected_sha256=copied.sha256,
+            expected_etag=copied.expected_etag,
         )
     except VerifiedCopyError:
         destination_fs.rm(destination_path)
         raise
-    verified = VerifiedFile(source.path, source.size, sha256, source.identity)
+    verified = VerifiedFile(source.path, source.size, copied.sha256, source.identity)
     _write_json_atomic(
         status_fs,
         marker_path,
@@ -271,7 +278,7 @@ def _copy_or_resume(
                 source.identity,
                 source.path,
                 source.size,
-                sha256,
+                copied.sha256,
                 destination_identity,
             )
         ),
@@ -284,7 +291,7 @@ def _copy_with_hash(
     source_path: str,
     destination_fs: AbstractFileSystem,
     destination_path: str,
-) -> tuple[str, int, str | None]:
+) -> _CopiedFile:
     parent, separator, _ = destination_path.rpartition("/")
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
@@ -303,7 +310,7 @@ def _copy_with_hash(
             destination.write(chunk)
             copied_size += len(chunk)
     expected_etag = multipart_etag.etag(copied_size) if multipart_etag is not None else None
-    return digest.hexdigest(), copied_size, expected_etag
+    return _CopiedFile(digest.hexdigest(), copied_size, expected_etag)
 
 
 def _verify_destination(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -296,7 +296,7 @@ def _copy_with_hash(
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
     digest = hashlib.sha256()
-    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _is_s3(destination_fs) else None
+    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _has_fixed_s3_uploads(destination_fs) else None
     copied_size = 0
     destination_options = {"block_size": S3_UPLOAD_PART_BYTES} if multipart_etag is not None else {}
     with (
@@ -469,11 +469,13 @@ def _etag(info: dict[str, Any]) -> str | None:
     return str(value).strip('"')
 
 
-def _is_s3(filesystem: AbstractFileSystem) -> bool:
+def _has_fixed_s3_uploads(filesystem: AbstractFileSystem) -> bool:
     protocol = filesystem.protocol
     if isinstance(protocol, str):
-        return protocol == "s3"
-    return "s3" in protocol
+        is_s3 = protocol == "s3"
+    else:
+        is_s3 = "s3" in protocol
+    return is_s3 and bool(getattr(filesystem, "fixed_upload_size", False))
 
 
 def _result(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -16,6 +16,7 @@ from rigging.filesystem.buckets import filesystem_for
 from rigging.fsutil.transfer import _join_path, _join_url, _relative_path
 
 COPY_CHUNK_BYTES = 8 * 1024 * 1024
+S3_UPLOAD_PART_BYTES = 50 * 1024 * 1024
 COMPLETION_MANIFEST = ".verified-copy-manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
 
@@ -50,12 +51,50 @@ class _SourceFile:
 
 
 @dataclass(frozen=True)
+class _DestinationFile:
+    size: int
+    identity: str | None
+
+
+@dataclass(frozen=True)
 class _ResumeMarker:
     source_path: str
     source_identity: str | None
     path: str
     size: int
     sha256: str
+    destination_identity: str
+
+
+class _MultipartEtag:
+    """Hash a byte stream using the content-derived S3/R2 multipart ETag rules."""
+
+    def __init__(self, part_size: int):
+        self.part_size = part_size
+        self.part_hashes: list[bytes] = []
+        self.current_hash = hashlib.md5(usedforsecurity=False)
+        self.current_size = 0
+
+    def update(self, data: bytes) -> None:
+        offset = 0
+        while offset < len(data):
+            length = min(self.part_size - self.current_size, len(data) - offset)
+            self.current_hash.update(data[offset : offset + length])
+            self.current_size += length
+            offset += length
+            if self.current_size == self.part_size:
+                self.part_hashes.append(self.current_hash.digest())
+                self.current_hash = hashlib.md5(usedforsecurity=False)
+                self.current_size = 0
+
+    def etag(self, total_size: int) -> str:
+        if total_size < self.part_size:
+            return self.current_hash.hexdigest()
+        part_hashes = [*self.part_hashes]
+        if self.current_size:
+            part_hashes.append(self.current_hash.digest())
+        digest = hashlib.md5(b"".join(part_hashes), usedforsecurity=False).hexdigest()
+        return f"{digest}-{len(part_hashes)}"
 
 
 def verified_copy_prefix(
@@ -68,7 +107,7 @@ def verified_copy_prefix(
     """Copy and verify a prefix before publishing its completion manifest.
 
     Verified per-object records allow retries to reuse destination objects when
-    their source identity and content hash still match.
+    their source and destination identities still match.
     """
     if workers < 1:
         raise VerifiedCopyError("workers must be at least 1")
@@ -116,7 +155,7 @@ def verified_copy_prefix(
                 destination_root=destination_root,
                 status_fs=status_fs,
                 status_root=status_root,
-                destination_size=destination_files.get(source.path),
+                destination=destination_files.get(source.path),
             ): source.path
             for source in sources
         }
@@ -150,13 +189,16 @@ def _source_files(filesystem: AbstractFileSystem, root: str) -> list[_SourceFile
     return files
 
 
-def _destination_files(filesystem: AbstractFileSystem, root: str) -> dict[str, int]:
+def _destination_files(filesystem: AbstractFileSystem, root: str) -> dict[str, _DestinationFile]:
     if not filesystem.exists(root):
         return {}
     if not filesystem.isdir(root):
         raise VerifiedCopyError(f"destination is not a directory: {root}")
     return {
-        _relative_path(path, root): int(info.get("size") or 0)
+        _relative_path(path, root): _DestinationFile(
+            size=int(info.get("size") or 0),
+            identity=_destination_identity(info),
+        )
         for path, info in _find_files(filesystem, root).items()
         if _relative_path(path, root) != COMPLETION_MANIFEST
     }
@@ -177,23 +219,28 @@ def _copy_or_resume(
     destination_root: str,
     status_fs: AbstractFileSystem,
     status_root: str,
-    destination_size: int | None,
+    destination: _DestinationFile | None,
 ) -> tuple[VerifiedFile, bool]:
     destination_path = _join_path(destination_root, source.path)
     marker_path = _join_path(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
     marker = _resume_marker(status_fs, marker_path)
-    if destination_size == source.size and source.identity is not None and marker is not None:
+    if (
+        destination is not None
+        and destination.size == source.size
+        and source.identity is not None
+        and marker is not None
+    ):
         expected = VerifiedFile(source.path, source.size, marker.sha256, source.identity)
         if (
             marker.source_path == source.source_path
             and marker.source_identity == source.identity
             and marker.path == source.path
             and marker.size == source.size
-            and _sha256(destination_fs, destination_path) == marker.sha256
+            and _destination_matches_marker(destination_fs, destination_path, destination, marker)
         ):
             return expected, False
 
-    sha256, copied_size = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    sha256, copied_size, expected_etag = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
     if copied_size != source.size:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source size changed while copying {source.path}")
@@ -203,15 +250,31 @@ def _copy_or_resume(
     if current_size != source.size or current_identity != source.identity:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source identity changed while copying {source.path}")
-    destination_sha256 = _sha256(destination_fs, destination_path)
-    if destination_sha256 != sha256:
+    try:
+        destination_identity = _verify_destination(
+            destination_fs,
+            destination_path,
+            expected_size=source.size,
+            expected_sha256=sha256,
+            expected_etag=expected_etag,
+        )
+    except VerifiedCopyError:
         destination_fs.rm(destination_path)
-        raise VerifiedCopyError(f"destination hash mismatch for {source.path}")
+        raise
     verified = VerifiedFile(source.path, source.size, sha256, source.identity)
     _write_json_atomic(
         status_fs,
         marker_path,
-        asdict(_ResumeMarker(source.source_path, source.identity, source.path, source.size, sha256)),
+        asdict(
+            _ResumeMarker(
+                source.source_path,
+                source.identity,
+                source.path,
+                source.size,
+                sha256,
+                destination_identity,
+            )
+        ),
     )
     return verified, True
 
@@ -221,18 +284,60 @@ def _copy_with_hash(
     source_path: str,
     destination_fs: AbstractFileSystem,
     destination_path: str,
-) -> tuple[str, int]:
+) -> tuple[str, int, str | None]:
     parent, separator, _ = destination_path.rpartition("/")
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
     digest = hashlib.sha256()
+    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _is_s3(destination_fs) else None
     copied_size = 0
-    with source_fs.open(source_path, "rb") as source, destination_fs.open(destination_path, "wb") as destination:
+    destination_options = {"block_size": S3_UPLOAD_PART_BYTES} if multipart_etag is not None else {}
+    with (
+        source_fs.open(source_path, "rb") as source,
+        destination_fs.open(destination_path, "wb", **destination_options) as destination,
+    ):
         while chunk := source.read(COPY_CHUNK_BYTES):
             digest.update(chunk)
+            if multipart_etag is not None:
+                multipart_etag.update(chunk)
             destination.write(chunk)
             copied_size += len(chunk)
-    return digest.hexdigest(), copied_size
+    expected_etag = multipart_etag.etag(copied_size) if multipart_etag is not None else None
+    return digest.hexdigest(), copied_size, expected_etag
+
+
+def _verify_destination(
+    filesystem: AbstractFileSystem,
+    path: str,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+    expected_etag: str | None,
+) -> str:
+    filesystem.invalidate_cache(path)
+    info = filesystem.info(path)
+    if int(info.get("size") or 0) != expected_size:
+        raise VerifiedCopyError(f"destination size mismatch for {path}")
+    if expected_etag is None:
+        if _sha256(filesystem, path) != expected_sha256:
+            raise VerifiedCopyError(f"destination hash mismatch for {path}")
+        return _destination_identity(info) or f"sha256={expected_sha256}"
+
+    actual_etag = _etag(info)
+    if actual_etag != expected_etag:
+        raise VerifiedCopyError(f"destination ETag mismatch for {path}")
+    return f"etag={actual_etag}"
+
+
+def _destination_matches_marker(
+    filesystem: AbstractFileSystem,
+    path: str,
+    destination: _DestinationFile,
+    marker: _ResumeMarker,
+) -> bool:
+    if marker.destination_identity.startswith("sha256="):
+        return _sha256(filesystem, path) == marker.destination_identity.removeprefix("sha256=")
+    return destination.identity == marker.destination_identity
 
 
 def _sha256(filesystem: AbstractFileSystem, path: str) -> str:
@@ -254,6 +359,7 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
             path=str(data["path"]),
             size=int(data["size"]),
             sha256=str(data["sha256"]),
+            destination_identity=str(data["destination_identity"]),
         )
     except (KeyError, TypeError, ValueError, json.JSONDecodeError):
         return None
@@ -336,6 +442,31 @@ def _source_identity(info: dict[str, Any]) -> str | None:
         if value is not None:
             return f"{key}={value!s}"
     return None
+
+
+def _destination_identity(info: dict[str, Any]) -> str | None:
+    etag = _etag(info)
+    if etag is not None:
+        return f"etag={etag}"
+    for key in ("ChecksumSHA256", "checksum", "md5Hash", "crc32c", "version_id", "VersionId"):
+        value = info.get(key)
+        if value is not None:
+            return f"{key}={value!s}"
+    return None
+
+
+def _etag(info: dict[str, Any]) -> str | None:
+    value = info.get("etag") or info.get("ETag")
+    if value is None:
+        return None
+    return str(value).strip('"')
+
+
+def _is_s3(filesystem: AbstractFileSystem) -> bool:
+    protocol = filesystem.protocol
+    if isinstance(protocol, str):
+        return protocol == "s3"
+    return "s3" in protocol
 
 
 def _result(

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,6 +360,39 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
+class _EtagDestination:
+    protocol = "s3"
+
+    def __init__(self, filesystem, etag, *, fixed_upload_size, allow_reads):
+        self.filesystem = filesystem
+        self.etag = etag
+        self.fixed_upload_size = fixed_upload_size
+        self.allow_reads = allow_reads
+
+    def __getattr__(self, name):
+        return getattr(self.filesystem, name)
+
+    def open(self, path, mode, **kwargs):
+        if mode == "rb" and path.endswith("weights.bin") and not self.allow_reads:
+            raise AssertionError("S3 verification must not download the destination object")
+        kwargs.pop("block_size", None)
+        return self.filesystem.open(path, mode, **kwargs)
+
+    def info(self, path):
+        info = self.filesystem.info(path)
+        if path.endswith("weights.bin"):
+            info["ETag"] = f'"{self.etag}"'
+        return info
+
+    def find(self, path, *, detail):
+        found = self.filesystem.find(path, detail=detail)
+        if detail:
+            for name, info in found.items():
+                if name.endswith("weights.bin"):
+                    info["ETag"] = f'"{self.etag}"'
+        return found
+
+
 @pytest.mark.parametrize(
     ("contents", "etag"),
     [
@@ -375,36 +408,16 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
 
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
-
-    class EtagDestination:
-        protocol = "s3"
-
-        def __getattr__(self, name):
-            return getattr(destination_filesystem, name)
-
-        def open(self, path, mode, **kwargs):
-            if mode == "rb" and path.endswith("weights.bin"):
-                raise AssertionError("S3 verification must not download the destination object")
-            kwargs.pop("block_size", None)
-            return destination_filesystem.open(path, mode, **kwargs)
-
-        def info(self, path):
-            info = destination_filesystem.info(path)
-            if path.endswith("weights.bin"):
-                info["ETag"] = f'"{etag}"'
-            return info
-
-        def find(self, path, *, detail):
-            found = destination_filesystem.find(path, detail=detail)
-            if detail:
-                for name, info in found.items():
-                    if name.endswith("weights.bin"):
-                        info["ETag"] = f'"{etag}"'
-            return found
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        etag,
+        fixed_upload_size=True,
+        allow_reads=False,
+    )
 
     def routed_filesystem(url, *, fixed_upload_size=False):
         if url == str(destination):
-            return EtagDestination(), destination_path
+            return etag_destination, destination_path
         return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
@@ -427,25 +440,16 @@ def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
 
-    class WrongEtagDestination:
-        protocol = "s3"
-
-        def __getattr__(self, name):
-            return getattr(destination_filesystem, name)
-
-        def open(self, path, mode, **kwargs):
-            kwargs.pop("block_size", None)
-            return destination_filesystem.open(path, mode, **kwargs)
-
-        def info(self, path):
-            info = destination_filesystem.info(path)
-            if path.endswith("weights.bin"):
-                info["ETag"] = '"00000000000000000000000000000000-3"'
-            return info
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        "00000000000000000000000000000000-3",
+        fixed_upload_size=True,
+        allow_reads=True,
+    )
 
     def routed_filesystem(url, *, fixed_upload_size=False):
         if url == str(destination):
-            return WrongEtagDestination(), destination_path
+            return etag_destination, destination_path
         return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
@@ -456,6 +460,35 @@ def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
 
     assert not (destination / "weights.bin").exists()
     assert not (destination / COMPLETION_MANIFEST).exists()
+
+
+def test_verified_copy_reads_destination_when_s3_part_sizes_are_not_fixed(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        "00000000000000000000000000000000-3",
+        fixed_upload_size=False,
+        allow_reads=True,
+    )
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return etag_destination, destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert (destination / COMPLETION_MANIFEST).exists()
 
 
 @pytest.mark.parametrize(("command", "destination"), [(["cp", "-r"], "copy"), (["rsync"], "sync")])

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,11 +360,18 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
-def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("contents", "etag"),
+    [
+        (b"abc", "900150983cd24fb0d6963f7d28e17f72"),
+        (b"abcdefghij", "446feba4c1b5cc7ad93bf4d44a0e36ac-3"),
+    ],
+)
+def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch, contents, etag):
     source = tmp_path / "source"
     destination = tmp_path / "destination"
     source.mkdir()
-    (source / "weights.bin").write_bytes(b"abcdefghij")
+    (source / "weights.bin").write_bytes(contents)
 
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
@@ -384,7 +391,7 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
         def info(self, path):
             info = destination_filesystem.info(path)
             if path.endswith("weights.bin"):
-                info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+                info["ETag"] = f'"{etag}"'
             return info
 
         def find(self, path, *, detail):
@@ -392,7 +399,7 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
             if detail:
                 for name, info in found.items():
                     if name.endswith("weights.bin"):
-                        info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+                        info["ETag"] = f'"{etag}"'
             return found
 
     def routed_filesystem(url, *, fixed_upload_size=False):

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,6 +360,97 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
+def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class EtagDestination:
+        protocol = "s3"
+
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def open(self, path, mode, **kwargs):
+            if mode == "rb" and path.endswith("weights.bin"):
+                raise AssertionError("S3 verification must not download the destination object")
+            kwargs.pop("block_size", None)
+            return destination_filesystem.open(path, mode, **kwargs)
+
+        def info(self, path):
+            info = destination_filesystem.info(path)
+            if path.endswith("weights.bin"):
+                info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+            return info
+
+        def find(self, path, *, detail):
+            found = destination_filesystem.find(path, detail=detail)
+            if detail:
+                for name, info in found.items():
+                    if name.endswith("weights.bin"):
+                        info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+            return found
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return EtagDestination(), destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    first = verified_copy_prefix(str(source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+    second = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert first.copied_files == 1
+    assert second.resumed_files == 1
+
+
+def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class WrongEtagDestination:
+        protocol = "s3"
+
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def open(self, path, mode, **kwargs):
+            kwargs.pop("block_size", None)
+            return destination_filesystem.open(path, mode, **kwargs)
+
+        def info(self, path):
+            info = destination_filesystem.info(path)
+            if path.endswith("weights.bin"):
+                info["ETag"] = '"00000000000000000000000000000000-3"'
+            return info
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return WrongEtagDestination(), destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    with pytest.raises(VerifiedCopyError, match="destination ETag mismatch"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert not (destination / "weights.bin").exists()
+    assert not (destination / COMPLETION_MANIFEST).exists()
+
+
 @pytest.mark.parametrize(("command", "destination"), [(["cp", "-r"], "copy"), (["rsync"], "sync")])
 def test_recursive_transfers_accept_relative_local_directories(tmp_path, monkeypatch, command, destination):
     source = tmp_path / "source"


### PR DESCRIPTION
Verify S3-compatible destinations using the content-derived ETag calculated while streaming the source. Fixed 50 MiB parts make the multipart ETag deterministic. This removes the 125 GiB destination download from each Grug checkpoint copy while retaining one GCS source read, source generation checks, the SHA-256 manifest, and manifest-last publication. Other destination backends retain the SHA-256 reread path.

Record the destination ETag in each status marker so interrupted transfers can resume from metadata checks without reading completed objects. This is stacked on #8706, which introduces `verified-copy`.

Part of #8702
