### PR TITLE
[iris] Isolate XLA autotune caches by process

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -169,7 +169,14 @@ def _enable_xla_autotune_cache() -> None:
     if any(flag.partition("=")[0] == _XLA_AUTOTUNE_CACHE_DIR_FLAG for flag in xla_flags.split()):
         return
 
+    # A multigpu task runs one Python process per GPU on the same node-local mount. XLA moves
+    # temporary entries into the cache as it autotunes, so concurrent writers in one directory can
+    # race and leave another process with NOT_FOUND for its temporary file. Isolate the writers;
+    # repeating autotuning per process is cheaper than losing the distributed job.
     autotune_dir = f"{SCRATCH_CACHE_PATH}/{_XLA_AUTOTUNE_CACHE_SUBDIR}"
+    process_index = os.environ.get(IRIS_MULTIGPU_PROCESS_INDEX_ENV)
+    if process_index is not None:
+        autotune_dir = f"{autotune_dir}/process-{process_index}"
     try:
         os.makedirs(autotune_dir, exist_ok=True)
     except OSError as exc:

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -483,8 +483,6 @@ def test_multigpu_task_fetches_autotune_cache_once_per_node(tmp_path, process_in
     autotune_dir = f"{scratch_cache_dir}/xla/per-fusion-autotune/process-{process_index}"
     assert f"--xla_gpu_per_fusion_autotune_cache_dir={autotune_dir}" in configured_xla_flags.split()
     assert len(fetches) == expected_fetches
-    if fetches:
-        assert fetches == [(jax_init_module._XLA_AUTOTUNE_REMOTE_PREFIX, autotune_dir)]
     assert uploads == []
 
 

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -467,7 +467,7 @@ def test_multigpu_task_fetches_autotune_cache_once_per_node(tmp_path, process_in
     fetches: list[tuple[str, str]] = []
     uploads: list[tuple[str, str]] = []
 
-    with _isolated_jax_cache_config(), _gpu_task(tmp_path):
+    with _isolated_jax_cache_config(), _gpu_task(tmp_path) as scratch_cache_dir:
         os.environ["MARIN_PROVENANCE"] = "{}"
         os.environ[jax_init_module.IRIS_MULTIGPU_PROCESS_COUNT_ENV] = "16"
         os.environ[jax_init_module.IRIS_MULTIGPU_PROCESS_INDEX_ENV] = str(process_index)
@@ -478,8 +478,13 @@ def test_multigpu_task_fetches_autotune_cache_once_per_node(tmp_path, process_in
             patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"),
         ):
             configure_jax_compilation_cache()
+            configured_xla_flags = os.environ["XLA_FLAGS"]
 
+    autotune_dir = f"{scratch_cache_dir}/xla/per-fusion-autotune/process-{process_index}"
+    assert f"--xla_gpu_per_fusion_autotune_cache_dir={autotune_dir}" in configured_xla_flags.split()
     assert len(fetches) == expected_fetches
+    if fetches:
+        assert fetches == [(jax_init_module._XLA_AUTOTUNE_REMOTE_PREFIX, autotune_dir)]
     assert uploads == []
 
 


### PR DESCRIPTION
Give each multigpu process its own node-local XLA per-fusion autotune directory. The hero continuation failed while saving checkpoint step 58,181 because three ranks sharing `/cache/xla/per-fusion-autotune` lost their temporary `.textproto` files during XLA cache insertion. The other ranks then aborted through JAX fate sharing, and Iris retried the 176-task gang.

This reapplies [commit 61742bfa](https://github.com/marin-community/marin/commit/61742bfa2a512daff91cbd91e9e769197151dfde), developed during [MoK EP64 debugging](https://github.com/marin-community/marin/issues/8244#issuecomment-5290127992), to the current FineStore-backed cache implementation. Disabling the cache previously left a rack compiling for fifteen minutes without reaching a step, so the cache remains enabled and writers are isolated by global process index.

The JAX-init test file passes all 27 cases, including separate paths for a node's local leader and sibling rank. The broader affected-test selection passes 524 tests with 5 skips.

Part of #8244
