### PR TITLE
[storage] Add resumable verified cross-backend copies

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -87,16 +87,17 @@ Extra destination files remain by default. `--delete` removes them after all cop
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
 
-`verified-copy` hashes each source object while uploading it, reads the destination object back,
-and records the verified SHA-256 plus source object identity under a sibling
-`<DST>.verified-copy-status` prefix. A retry skips the source read when the source identity,
-destination path and size, verified record, and destination hash still match. Sources without stable
-generation, version, checksum, ETag, or modification metadata are read again. The command writes
-`<DST>/.verified-copy-manifest.json` after every object verifies;
-consumers should treat that manifest as the prefix's readiness marker. R2 uploads use fixed-size
-multipart parts. An existing completion manifest makes the destination immutable: the command
-returns immediately when source paths and sizes still match and fails if they changed. Use a fresh
-destination prefix for a changed export.
+`verified-copy` hashes each source object while uploading it. For S3-compatible destinations, it
+uses fixed-size multipart parts, calculates the corresponding content-derived ETag, and compares
+that value with destination metadata after the upload. Other destinations are read back and checked
+against the source SHA-256. The command records the SHA-256 and source and destination identities
+under a sibling `<DST>.verified-copy-status` prefix. A retry skips both object reads when those
+identities, the destination path and size, and the verified record still match. Sources without
+stable generation, version, checksum, ETag, or modification metadata are read again. The command
+writes `<DST>/.verified-copy-manifest.json` after every object verifies; consumers should treat that
+manifest as the prefix's readiness marker. An existing completion manifest makes the destination
+immutable: the command returns immediately when source paths and sizes still match and fails if they
+changed. Use a fresh destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -18,6 +18,7 @@ uv run fsutil usage s3://marin-us-east-02a -o usage-report.md
 uv run fsutil cp -r s3://marin-us-east-02a/iris/my-job/logs /tmp/logs
 uv run fsutil mv /tmp/run.json gs://marin-us-central2/archive/
 uv run fsutil rsync --dry-run --delete /tmp/checkpoints gs://marin-us-central2/checkpoints
+uv run fsutil verified-copy gs://marin-us-central2/exports/model s3://marin-na/marin/exports/model
 uv run fsutil hash gs://marin-us-central2/archive/run.json
 uv run fsutil rm -R s3://marin-us-east-02a/tmp/expired-prefix s3://marin-us-east-02a/tmp/old-prefix
 ```
@@ -64,6 +65,7 @@ that touch its buckets; the rest keep working.
 | `cp SRC ... DST [-r] [-n]` | Copy one or more sources between any backends. `-r` includes directories; `-n` preserves existing destination files |
 | `mv SRC ... DST [-r]` | Move or rename one or more sources. Sources are removed after every copy succeeds |
 | `rsync SRC DST [--delete] [--dry-run] [--checksum]` | Synchronize the files beneath two directories or prefixes |
+| `verified-copy SRC DST [--workers N] [--status-prefix URL]` | Resume and verify a cross-backend prefix copy, then publish a completion manifest |
 | `hash URL ... [--hex]` | Stream complete files and print MD5 digests in base64 or hexadecimal |
 | `rm URL ... [-r] [--workers N]` | Remove one or more objects. `-r` or `-R` recursively removes every prefix; remote prefixes delete while they list and show progress |
 | `browse [URL]` | The interactive browser |
@@ -84,6 +86,17 @@ neither side supplies comparable timestamps or digests, equal sizes are treated 
 Extra destination files remain by default. `--delete` removes them after all copies succeed.
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
+
+`verified-copy` hashes each source object while uploading it, reads the destination object back,
+and records the verified SHA-256 plus source object identity under a sibling
+`<DST>.verified-copy-status` prefix. A retry skips the source read when the source identity,
+destination path and size, verified record, and destination hash still match. Sources without stable
+generation, version, checksum, ETag, or modification metadata are read again. The command writes
+`<DST>/.verified-copy-manifest.json` after every object verifies;
+consumers should treat that manifest as the prefix's readiness marker. R2 uploads use fixed-size
+multipart parts. An existing completion manifest makes the destination immutable: the command
+returns immediately when source paths and sizes still match and fails if they changed. Use a fresh
+destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -87,17 +87,17 @@ Extra destination files remain by default. `--delete` removes them after all cop
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
 
-`verified-copy` hashes each source object while uploading it. For S3-compatible destinations, it
-uses fixed-size multipart parts, calculates the corresponding content-derived ETag, and compares
-that value with destination metadata after the upload. Other destinations are read back and checked
-against the source SHA-256. The command records the SHA-256 and source and destination identities
-under a sibling `<DST>.verified-copy-status` prefix. A retry skips both object reads when those
-identities, the destination path and size, and the verified record still match. Sources without
-stable generation, version, checksum, ETag, or modification metadata are read again. The command
-writes `<DST>/.verified-copy-manifest.json` after every object verifies; consumers should treat that
-manifest as the prefix's readiness marker. An existing completion manifest makes the destination
-immutable: the command returns immediately when source paths and sizes still match and fails if they
-changed. Use a fresh destination prefix for a changed export.
+`verified-copy` hashes each source object while uploading it. For configured S3-compatible
+destinations such as R2, it uses fixed-size multipart parts, calculates the corresponding
+content-derived ETag, and compares that value with destination metadata after the upload. Other
+destinations are read back and checked against the source SHA-256. The command records the SHA-256
+and source and destination identities under a sibling `<DST>.verified-copy-status` prefix. A retry
+skips both object reads when those identities, the destination path and size, and the verified record
+still match. Sources without stable generation, version, checksum, ETag, or modification metadata
+are read again. The command writes `<DST>/.verified-copy-manifest.json` after every object verifies;
+consumers should treat that manifest as the prefix's readiness marker. An existing completion
+manifest makes the destination immutable: the command returns immediately when source paths and
+sizes still match and fails if they changed. Use a fresh destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -65,7 +65,7 @@ that touch its buckets; the rest keep working.
 | `cp SRC ... DST [-r] [-n]` | Copy one or more sources between any backends. `-r` includes directories; `-n` preserves existing destination files |
 | `mv SRC ... DST [-r]` | Move or rename one or more sources. Sources are removed after every copy succeeds |
 | `rsync SRC DST [--delete] [--dry-run] [--checksum]` | Synchronize the files beneath two directories or prefixes |
-| `verified-copy SRC DST [--workers N] [--status-prefix URL]` | Resume and verify a cross-backend prefix copy, then publish a completion manifest |
+| `verified-copy SRC DST [--workers N] [--status-prefix URL]` | Publish a verified, restartable prefix with an explicit readiness marker |
 | `hash URL ... [--hex]` | Stream complete files and print MD5 digests in base64 or hexadecimal |
 | `rm URL ... [-r] [--workers N]` | Remove one or more objects. `-r` or `-R` recursively removes every prefix; remote prefixes delete while they list and show progress |
 | `browse [URL]` | The interactive browser |
@@ -87,17 +87,27 @@ Extra destination files remain by default. `--delete` removes them after all cop
 `--dry-run` prints the same copy and delete plan without changing the destination. Source and
 destination directories may not overlap.
 
-`verified-copy` hashes each source object while uploading it. For configured S3-compatible
+Use `verified-copy` when consumers require a complete, verified prefix, especially for large
+cross-backend artifacts such as checkpoint exports where the transfer may be interrupted. Use
+`cp -r` for ordinary recursive copies where partial destination contents are acceptable, or
+`rsync` when the destination should track later source changes.
+
+`verified-copy` leaves objects at their final names and writes the completion manifest last.
+Object stores cannot atomically rename a prefix: promoting a temporary prefix would copy its
+objects into the final prefix one at a time, expose another partial prefix during promotion, and
+add a second object-copy pass. Consumers must check for `<DST>/.verified-copy-manifest.json`
+before using the destination.
+
+The command hashes each source object while uploading it. For configured S3-compatible
 destinations such as R2, it uses fixed-size multipart parts, calculates the corresponding
 content-derived ETag, and compares that value with destination metadata after the upload. Other
 destinations are read back and checked against the source SHA-256. The command records the SHA-256
 and source and destination identities under a sibling `<DST>.verified-copy-status` prefix. A retry
 skips both object reads when those identities, the destination path and size, and the verified record
 still match. Sources without stable generation, version, checksum, ETag, or modification metadata
-are read again. The command writes `<DST>/.verified-copy-manifest.json` after every object verifies;
-consumers should treat that manifest as the prefix's readiness marker. An existing completion
-manifest makes the destination immutable: the command returns immediately when source paths and
-sizes still match and fails if they changed. Use a fresh destination prefix for a changed export.
+are read again. An existing completion manifest makes the destination immutable: the command
+returns immediately when source paths and sizes still match and fails if they changed. Use a fresh
+destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -92,22 +92,23 @@ cross-backend artifacts such as checkpoint exports where the transfer may be int
 `cp -r` for ordinary recursive copies where partial destination contents are acceptable, or
 `rsync` when the destination should track later source changes.
 
-`verified-copy` leaves objects at their final names and writes the completion manifest last.
-Object stores cannot atomically rename a prefix: promoting a temporary prefix would copy its
-objects into the final prefix one at a time, expose another partial prefix during promotion, and
-add a second object-copy pass. Consumers must check for `<DST>/.verified-copy-manifest.json`
-before using the destination.
+`verified-copy` uploads objects under a sibling `<DST>.verified-copy-staging` prefix. After every
+object has been verified, it promotes them to `<DST>` with within-store copies, removes the staged
+objects, and writes `<DST>/.verified-copy-manifest.json` last. Promotion adds an internal object-copy
+pass and briefly stores two copies, but it does not send the data through the client or back to the
+source store. Object stores cannot atomically rename a prefix, so consumers may still see final
+objects appear one at a time and must check for the manifest before using the destination.
 
 The command hashes each source object while uploading it. For configured S3-compatible
 destinations such as R2, it uses fixed-size multipart parts, calculates the corresponding
 content-derived ETag, and compares that value with destination metadata after the upload. Other
 destinations are read back and checked against the source SHA-256. The command records the SHA-256
-and source and destination identities under a sibling `<DST>.verified-copy-status` prefix. A retry
-skips both object reads when those identities, the destination path and size, and the verified record
-still match. Sources without stable generation, version, checksum, ETag, or modification metadata
-are read again. An existing completion manifest makes the destination immutable: the command
-returns immediately when source paths and sizes still match and fails if they changed. Use a fresh
-destination prefix for a changed export.
+and source and staging identities under a sibling `<DST>.verified-copy-status` prefix. A retry skips
+both object reads when those identities, the path and size of either the staged or already promoted
+object, and the verified record still match. Sources without stable generation, version, checksum,
+ETag, or modification metadata are read again. An existing completion manifest makes the
+destination immutable: the command returns immediately when source paths and sizes still match and
+fails if they changed. Use a fresh destination prefix for a changed export.
 
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.

--- a/lib/rigging/src/rigging/filesystem/buckets.py
+++ b/lib/rigging/src/rigging/filesystem/buckets.py
@@ -41,7 +41,7 @@ class MissingCredentials(Exception):
     """A bucket's backend has no usable credentials in the environment."""
 
 
-def filesystem_for(url: str) -> tuple[Any, str]:
+def filesystem_for(url: str, *, fixed_upload_size: bool = False) -> tuple[Any, str]:
     """Return ``(fs, path)`` for *url*, routed by the bucket's declared backend.
 
     An ``s3://`` URL naming a bucket declared as R2 or CoreWeave gets a dedicated
@@ -66,7 +66,7 @@ def filesystem_for(url: str) -> tuple[Any, str]:
         fs, path = url_to_fs(url)
         return _with_object_store_operations(fs), path
 
-    return _with_object_store_operations(_s3_filesystem(spec)), _s3_path(parsed)
+    return _with_object_store_operations(_s3_filesystem(spec, fixed_upload_size=fixed_upload_size)), _s3_path(parsed)
 
 
 def _with_object_store_operations(fs: Any) -> Any:
@@ -78,7 +78,7 @@ def _s3_path(parsed: StoragePath) -> str:
     return f"{parsed.bucket}/{parsed.key}" if parsed.key else parsed.bucket
 
 
-def _s3_filesystem(spec: BucketSpec) -> s3fs.S3FileSystem:
+def _s3_filesystem(spec: BucketSpec, *, fixed_upload_size: bool) -> s3fs.S3FileSystem:
     """Build (or reuse) the S3 filesystem serving *spec*'s backend.
 
     The signing region is the bucket's own for CoreWeave, whose endpoint routes on it, and
@@ -99,4 +99,5 @@ def _s3_filesystem(spec: BucketSpec) -> s3fs.S3FileSystem:
         # ``fsspec_s3_conf`` is the JSON-safe env shape, so it carries the
         # endpoint's addressing style but not the whole-request deadline.
         config_kwargs={**conf["config_kwargs"], **s3_python_config_kwargs()},
+        fixed_upload_size=fixed_upload_size,
     )

--- a/lib/rigging/src/rigging/filesystem/buckets.py
+++ b/lib/rigging/src/rigging/filesystem/buckets.py
@@ -17,6 +17,7 @@ still apply where they already did.
 """
 
 import logging
+from enum import StrEnum
 from typing import Any
 
 import s3fs
@@ -41,7 +42,16 @@ class MissingCredentials(Exception):
     """A bucket's backend has no usable credentials in the environment."""
 
 
-def filesystem_for(url: str, *, fixed_upload_size: bool = False) -> tuple[Any, str]:
+class S3UploadPolicy(StrEnum):
+    STANDARD = "standard"
+    FIXED_PARTS = "fixed_parts"
+
+
+def filesystem_for(
+    url: str,
+    *,
+    s3_upload_policy: S3UploadPolicy = S3UploadPolicy.STANDARD,
+) -> tuple[Any, str]:
     """Return ``(fs, path)`` for *url*, routed by the bucket's declared backend.
 
     An ``s3://`` URL naming a bucket declared as R2 or CoreWeave gets a dedicated
@@ -66,7 +76,7 @@ def filesystem_for(url: str, *, fixed_upload_size: bool = False) -> tuple[Any, s
         fs, path = url_to_fs(url)
         return _with_object_store_operations(fs), path
 
-    return _with_object_store_operations(_s3_filesystem(spec, fixed_upload_size=fixed_upload_size)), _s3_path(parsed)
+    return _with_object_store_operations(_s3_filesystem(spec, s3_upload_policy)), _s3_path(parsed)
 
 
 def _with_object_store_operations(fs: Any) -> Any:
@@ -78,7 +88,7 @@ def _s3_path(parsed: StoragePath) -> str:
     return f"{parsed.bucket}/{parsed.key}" if parsed.key else parsed.bucket
 
 
-def _s3_filesystem(spec: BucketSpec, *, fixed_upload_size: bool) -> s3fs.S3FileSystem:
+def _s3_filesystem(spec: BucketSpec, upload_policy: S3UploadPolicy) -> s3fs.S3FileSystem:
     """Build (or reuse) the S3 filesystem serving *spec*'s backend.
 
     The signing region is the bucket's own for CoreWeave, whose endpoint routes on it, and
@@ -99,5 +109,5 @@ def _s3_filesystem(spec: BucketSpec, *, fixed_upload_size: bool) -> s3fs.S3FileS
         # ``fsspec_s3_conf`` is the JSON-safe env shape, so it carries the
         # endpoint's addressing style but not the whole-request deadline.
         config_kwargs={**conf["config_kwargs"], **s3_python_config_kwargs()},
-        fixed_upload_size=fixed_upload_size,
+        fixed_upload_size=upload_policy is S3UploadPolicy.FIXED_PARTS,
     )

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -58,6 +58,7 @@ from rigging.fsutil.usage import (
     render_usage_report,
     scan_usage,
 )
+from rigging.fsutil.verified_copy import VerifiedCopyError, verified_copy_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -371,6 +372,24 @@ def rsync(source: str, destination: str, delete: bool, dry_run: bool, checksum: 
         click.echo(f"delete {action.location.url}")
 
 
+@click.command("verified-copy")
+@click.argument("source")
+@click.argument("destination")
+@click.option("--status-prefix", default=None, help="Sibling prefix for verified per-object resume records.")
+@click.option("--workers", default=4, show_default=True, type=click.IntRange(min=1, max=64))
+def verified_copy(source: str, destination: str, status_prefix: str | None, workers: int) -> None:
+    """Copy and verify a prefix, publishing its completion manifest last."""
+    try:
+        result = verified_copy_prefix(source, destination, status_url=status_prefix, workers=workers)
+    except VerifiedCopyError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(
+        f"verified {result.total_files} files ({result.total_bytes} bytes): "
+        f"{result.copied_files} copied, {result.resumed_files} resumed"
+    )
+    click.echo(result.manifest_url)
+
+
 @click.command("hash")
 @click.argument("urls", nargs=-1, required=True)
 @click.option("--hex", "hexadecimal", is_flag=True, help="Print hexadecimal digests instead of base64.")
@@ -548,6 +567,7 @@ _COMMANDS = (
     cp,
     mv,
     rsync,
+    verified_copy,
     hash_command,
     rm,
     browse,

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -58,7 +58,7 @@ from rigging.fsutil.usage import (
     render_usage_report,
     scan_usage,
 )
-from rigging.fsutil.verified_copy import VerifiedCopyError, verified_copy_prefix
+from rigging.fsutil.verified_copy import DEFAULT_VERIFIED_COPY_WORKERS, VerifiedCopyError, verified_copy_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -376,7 +376,12 @@ def rsync(source: str, destination: str, delete: bool, dry_run: bool, checksum: 
 @click.argument("source")
 @click.argument("destination")
 @click.option("--status-prefix", default=None, help="Sibling prefix for verified per-object resume records.")
-@click.option("--workers", default=4, show_default=True, type=click.IntRange(min=1, max=64))
+@click.option(
+    "--workers",
+    default=DEFAULT_VERIFIED_COPY_WORKERS,
+    show_default=True,
+    type=click.IntRange(min=1, max=64),
+)
 def verified_copy(source: str, destination: str, status_prefix: str | None, workers: int) -> None:
     """Copy and verify a prefix, publishing its completion manifest last."""
     try:

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -383,7 +383,7 @@ def rsync(source: str, destination: str, delete: bool, dry_run: bool, checksum: 
     type=click.IntRange(min=1, max=64),
 )
 def verified_copy(source: str, destination: str, status_prefix: str | None, workers: int) -> None:
-    """Copy and verify a prefix, publishing its completion manifest last."""
+    """Stage and verify a prefix, then publish its completion manifest last."""
     try:
         result = verified_copy_prefix(source, destination, status_url=status_prefix, workers=workers)
     except VerifiedCopyError as error:

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -57,6 +57,13 @@ class _DestinationFile:
 
 
 @dataclass(frozen=True)
+class _CopiedFile:
+    sha256: str
+    size: int
+    expected_etag: str | None
+
+
+@dataclass(frozen=True)
 class _ResumeMarker:
     source_path: str
     source_identity: str | None
@@ -240,8 +247,8 @@ def _copy_or_resume(
         ):
             return expected, False
 
-    sha256, copied_size, expected_etag = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
-    if copied_size != source.size:
+    copied = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    if copied.size != source.size:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source size changed while copying {source.path}")
     current_info = source_fs.info(source.source_path)
@@ -255,13 +262,13 @@ def _copy_or_resume(
             destination_fs,
             destination_path,
             expected_size=source.size,
-            expected_sha256=sha256,
-            expected_etag=expected_etag,
+            expected_sha256=copied.sha256,
+            expected_etag=copied.expected_etag,
         )
     except VerifiedCopyError:
         destination_fs.rm(destination_path)
         raise
-    verified = VerifiedFile(source.path, source.size, sha256, source.identity)
+    verified = VerifiedFile(source.path, source.size, copied.sha256, source.identity)
     _write_json_atomic(
         status_fs,
         marker_path,
@@ -271,7 +278,7 @@ def _copy_or_resume(
                 source.identity,
                 source.path,
                 source.size,
-                sha256,
+                copied.sha256,
                 destination_identity,
             )
         ),
@@ -284,7 +291,7 @@ def _copy_with_hash(
     source_path: str,
     destination_fs: AbstractFileSystem,
     destination_path: str,
-) -> tuple[str, int, str | None]:
+) -> _CopiedFile:
     parent, separator, _ = destination_path.rpartition("/")
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
@@ -303,7 +310,7 @@ def _copy_with_hash(
             destination.write(chunk)
             copied_size += len(chunk)
     expected_etag = multipart_etag.etag(copied_size) if multipart_etag is not None else None
-    return digest.hexdigest(), copied_size, expected_etag
+    return _CopiedFile(digest.hexdigest(), copied_size, expected_etag)
 
 
 def _verify_destination(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -296,7 +296,7 @@ def _copy_with_hash(
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
     digest = hashlib.sha256()
-    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _is_s3(destination_fs) else None
+    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _has_fixed_s3_uploads(destination_fs) else None
     copied_size = 0
     destination_options = {"block_size": S3_UPLOAD_PART_BYTES} if multipart_etag is not None else {}
     with (
@@ -469,11 +469,13 @@ def _etag(info: dict[str, Any]) -> str | None:
     return str(value).strip('"')
 
 
-def _is_s3(filesystem: AbstractFileSystem) -> bool:
+def _has_fixed_s3_uploads(filesystem: AbstractFileSystem) -> bool:
     protocol = filesystem.protocol
     if isinstance(protocol, str):
-        return protocol == "s3"
-    return "s3" in protocol
+        is_s3 = protocol == "s3"
+    else:
+        is_s3 = "s3" in protocol
+    return is_s3 and bool(getattr(filesystem, "fixed_upload_size", False))
 
 
 def _result(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 from fsspec import AbstractFileSystem
 
 from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.buckets import filesystem_for
+from rigging.filesystem.buckets import S3UploadPolicy, filesystem_for
 from rigging.fsutil.transfer import (
     COPY_CHUNK_BYTES,
     TransferLocation,
@@ -156,11 +156,11 @@ def verified_copy_prefix(
     if workers < 1:
         raise VerifiedCopyError("workers must be at least 1")
 
-    source = _resolved_location(source_url, fixed_upload_size=False)
-    destination = _resolved_location(destination_url, fixed_upload_size=True)
+    source = _resolved_location(source_url, S3UploadPolicy.STANDARD)
+    destination = _resolved_location(destination_url, S3UploadPolicy.FIXED_PARTS)
     status = _resolved_location(
         status_url or f"{destination.url}.verified-copy-status",
-        fixed_upload_size=True,
+        S3UploadPolicy.FIXED_PARTS,
     )
     _validate_disjoint_locations(source, destination, status)
 
@@ -412,8 +412,8 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
         return None
 
 
-def _resolved_location(url: str, *, fixed_upload_size: bool) -> TransferLocation:
-    filesystem, path = filesystem_for(url, fixed_upload_size=fixed_upload_size)
+def _resolved_location(url: str, upload_policy: S3UploadPolicy) -> TransferLocation:
+    filesystem, path = filesystem_for(url, s3_upload_policy=upload_policy)
     location = TransferLocation.from_path(url, filesystem, path)
     if _backend(location) == "file":
         path = os.path.realpath(os.path.abspath(path))

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -13,6 +13,7 @@ from fsspec import AbstractFileSystem
 
 from rigging.filesystem.atomic import atomic_rename
 from rigging.filesystem.buckets import filesystem_for
+from rigging.fsutil.transfer import _join_path, _join_url, _relative_path
 
 COPY_CHUNK_BYTES = 8 * 1024 * 1024
 COMPLETION_MANIFEST = ".verified-copy-manifest.json"
@@ -64,12 +65,10 @@ def verified_copy_prefix(
     status_url: str | None = None,
     workers: int = 4,
 ) -> VerifiedCopyResult:
-    """Copy a prefix, verify every destination object, then publish a manifest.
+    """Copy and verify a prefix before publishing its completion manifest.
 
-    Verified per-object records live in a sibling status prefix. A retry hashes
-    the destination object and skips its GCS read when the recorded path, size,
-    and SHA-256 still match. The completion manifest is written into the
-    destination only after every object has verified.
+    Verified per-object records allow retries to reuse destination objects when
+    their source identity and content hash still match.
     """
     if workers < 1:
         raise VerifiedCopyError("workers must be at least 1")
@@ -89,8 +88,8 @@ def verified_copy_prefix(
     if any(source.path == COMPLETION_MANIFEST for source in sources):
         raise VerifiedCopyError(f"source prefix reserves {COMPLETION_MANIFEST!r}")
 
-    manifest_path = _join(destination_root, COMPLETION_MANIFEST)
-    manifest_url = _join(destination_url, COMPLETION_MANIFEST)
+    manifest_path = _join_path(destination_root, COMPLETION_MANIFEST)
+    manifest_url = _join_url(destination_url, COMPLETION_MANIFEST)
     if destination_fs.exists(manifest_path):
         manifest = _read_json(destination_fs, manifest_path)
         verified = _verified_files_from_manifest(manifest, source_url, destination_url)
@@ -180,8 +179,8 @@ def _copy_or_resume(
     status_root: str,
     destination_size: int | None,
 ) -> tuple[VerifiedFile, bool]:
-    destination_path = _join(destination_root, source.path)
-    marker_path = _join(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
+    destination_path = _join_path(destination_root, source.path)
+    marker_path = _join_path(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
     marker = _resume_marker(status_fs, marker_path)
     if destination_size == source.size and source.identity is not None and marker is not None:
         expected = VerifiedFile(source.path, source.size, marker.sha256, source.identity)
@@ -353,15 +352,3 @@ def _result(
         total_files=len(files),
         total_bytes=sum(file.size for file in files),
     )
-
-
-def _relative_path(path: str, root: str) -> str:
-    root = root.rstrip("/")
-    prefix = f"{root}/"
-    if not path.startswith(prefix):
-        raise VerifiedCopyError(f"unexpected object {path!r} outside {root!r}")
-    return path[len(prefix) :]
-
-
-def _join(parent: str, child: str) -> str:
-    return f"{parent.rstrip('/')}/{child}"

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -100,6 +100,16 @@ class _ResumeMarker:
     destination_identity: str
 
 
+@dataclass(frozen=True)
+class _CompletionManifest:
+    schema_version: int
+    source: str
+    destination: str
+    total_files: int
+    total_bytes: int
+    files: list[VerifiedFile]
+
+
 class _MultipartEtag:
     """Hash a byte stream using the content-derived S3/R2 multipart ETag rules."""
 
@@ -166,8 +176,8 @@ def verified_copy_prefix(
     manifest_path = _join_path(destination_root, COMPLETION_MANIFEST)
     manifest_url = _join_url(destination_url, COMPLETION_MANIFEST)
     if destination_fs.exists(manifest_path):
-        manifest = _read_json(destination_fs, manifest_path)
-        verified = _verified_files_from_manifest(manifest, source_url, destination_url)
+        manifest = _completion_manifest(_read_json(destination_fs, manifest_path), source_url, destination_url)
+        verified = manifest.files
         _validate_completed_source(source_fs, sources, verified)
         return _result(manifest_url, verified, copied_files=0, resumed_files=len(verified))
 
@@ -202,15 +212,15 @@ def verified_copy_prefix(
             resumed_files += int(outcome.disposition is _CopyDisposition.RESUMED)
 
     verified_files.sort()
-    manifest = {
-        "schema_version": MANIFEST_SCHEMA_VERSION,
-        "source": source_url,
-        "destination": destination_url,
-        "total_files": len(verified_files),
-        "total_bytes": sum(file.size for file in verified_files),
-        "files": [asdict(file) for file in verified_files],
-    }
-    _write_json_atomic(destination_fs, manifest_path, manifest)
+    manifest = _CompletionManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        source=source_url,
+        destination=destination_url,
+        total_files=len(verified_files),
+        total_bytes=sum(file.size for file in verified_files),
+        files=verified_files,
+    )
+    _write_json_atomic(destination_fs, manifest_path, asdict(manifest))
     return _result(manifest_url, verified_files, copied_files=copied_files, resumed_files=resumed_files)
 
 
@@ -444,11 +454,7 @@ def _read_json(filesystem: AbstractFileSystem, path: str) -> dict[str, Any]:
     return value
 
 
-def _verified_files_from_manifest(manifest: dict[str, Any], source_url: str, destination_url: str) -> list[VerifiedFile]:
-    if manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
-        raise VerifiedCopyError("completion manifest has an unsupported schema")
-    if manifest.get("source") != source_url or manifest.get("destination") != destination_url:
-        raise VerifiedCopyError("completion manifest belongs to a different transfer")
+def _completion_manifest(data: dict[str, Any], source_url: str, destination_url: str) -> _CompletionManifest:
     try:
         files = [
             VerifiedFile(
@@ -457,12 +463,26 @@ def _verified_files_from_manifest(manifest: dict[str, Any], source_url: str, des
                 sha256=str(item["sha256"]),
                 source_identity=str(item["source_identity"]) if item.get("source_identity") is not None else None,
             )
-            for item in manifest["files"]
+            for item in data["files"]
         ]
+        manifest = _CompletionManifest(
+            schema_version=int(data["schema_version"]),
+            source=str(data["source"]),
+            destination=str(data["destination"]),
+            total_files=int(data["total_files"]),
+            total_bytes=int(data["total_bytes"]),
+            files=files,
+        )
     except (KeyError, TypeError, ValueError) as error:
         raise VerifiedCopyError("completion manifest has invalid file records") from error
     files.sort()
-    return files
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION:
+        raise VerifiedCopyError("completion manifest has an unsupported schema")
+    if manifest.source != source_url or manifest.destination != destination_url:
+        raise VerifiedCopyError("completion manifest belongs to a different transfer")
+    if manifest.total_files != len(files) or manifest.total_bytes != sum(file.size for file in files):
+        raise VerifiedCopyError("completion manifest totals do not match its file records")
+    return manifest
 
 
 def _validate_completed_source(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -5,9 +5,11 @@
 
 import hashlib
 import json
+import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
+from enum import StrEnum
 from typing import Any, cast
 
 from fsspec import AbstractFileSystem
@@ -15,6 +17,7 @@ from fsspec import AbstractFileSystem
 from rigging.filesystem.atomic import atomic_rename
 from rigging.filesystem.buckets import filesystem_for
 from rigging.fsutil.transfer import (
+    COPY_CHUNK_BYTES,
     TransferLocation,
     _backend,
     _join_path,
@@ -24,10 +27,14 @@ from rigging.fsutil.transfer import (
     _strictly_contains,
 )
 
-COPY_CHUNK_BYTES = 8 * 1024 * 1024
+DEFAULT_VERIFIED_COPY_WORKERS = 4
 S3_UPLOAD_PART_BYTES = 50 * 1024 * 1024
 COMPLETION_MANIFEST = ".verified-copy-manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
+SHA256_IDENTITY_PREFIX = "sha256="
+ETAG_IDENTITY_PREFIX = "etag="
+
+logger = logging.getLogger(__name__)
 
 
 class VerifiedCopyError(ValueError):
@@ -70,6 +77,17 @@ class _CopiedFile:
     sha256: str
     size: int
     expected_etag: str | None
+
+
+class _CopyDisposition(StrEnum):
+    COPIED = "copied"
+    RESUMED = "resumed"
+
+
+@dataclass(frozen=True)
+class _CopyOutcome:
+    file: VerifiedFile
+    disposition: _CopyDisposition
 
 
 @dataclass(frozen=True)
@@ -118,7 +136,7 @@ def verified_copy_prefix(
     destination_url: str,
     *,
     status_url: str | None = None,
-    workers: int = 4,
+    workers: int = DEFAULT_VERIFIED_COPY_WORKERS,
 ) -> VerifiedCopyResult:
     """Copy and verify a prefix before publishing its completion manifest.
 
@@ -178,10 +196,10 @@ def verified_copy_prefix(
             for source in sources
         }
         for future in as_completed(futures):
-            verified, copied = future.result()
-            verified_files.append(verified)
-            copied_files += int(copied)
-            resumed_files += int(not copied)
+            outcome = future.result()
+            verified_files.append(outcome.file)
+            copied_files += int(outcome.disposition is _CopyDisposition.COPIED)
+            resumed_files += int(outcome.disposition is _CopyDisposition.RESUMED)
 
     verified_files.sort()
     manifest = {
@@ -238,7 +256,7 @@ def _copy_or_resume(
     status_fs: AbstractFileSystem,
     status_root: str,
     destination: _DestinationFile | None,
-) -> tuple[VerifiedFile, bool]:
+) -> _CopyOutcome:
     destination_path = _join_path(destination_root, source.path)
     marker_path = _join_path(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
     marker = _resume_marker(status_fs, marker_path)
@@ -256,7 +274,7 @@ def _copy_or_resume(
             and marker.size == source.size
             and _destination_matches_marker(destination_fs, destination_path, destination, marker)
         ):
-            return expected, False
+            return _CopyOutcome(expected, _CopyDisposition.RESUMED)
 
     copied = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
     if copied.size != source.size:
@@ -294,7 +312,7 @@ def _copy_or_resume(
             )
         ),
     )
-    return verified, True
+    return _CopyOutcome(verified, _CopyDisposition.COPIED)
 
 
 def _copy_with_hash(
@@ -339,12 +357,12 @@ def _verify_destination(
     if expected_etag is None:
         if _sha256(filesystem, path) != expected_sha256:
             raise VerifiedCopyError(f"destination hash mismatch for {path}")
-        return _destination_identity(info) or f"sha256={expected_sha256}"
+        return _destination_identity(info) or f"{SHA256_IDENTITY_PREFIX}{expected_sha256}"
 
     actual_etag = _etag(info)
     if actual_etag != expected_etag:
         raise VerifiedCopyError(f"destination ETag mismatch for {path}")
-    return f"etag={actual_etag}"
+    return f"{ETAG_IDENTITY_PREFIX}{actual_etag}"
 
 
 def _destination_matches_marker(
@@ -353,8 +371,8 @@ def _destination_matches_marker(
     destination: _DestinationFile,
     marker: _ResumeMarker,
 ) -> bool:
-    if marker.destination_identity.startswith("sha256="):
-        return _sha256(filesystem, path) == marker.destination_identity.removeprefix("sha256=")
+    if marker.destination_identity.startswith(SHA256_IDENTITY_PREFIX):
+        return _sha256(filesystem, path) == marker.destination_identity.removeprefix(SHA256_IDENTITY_PREFIX)
     return destination.identity == marker.destination_identity
 
 
@@ -379,7 +397,8 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
             sha256=str(data["sha256"]),
             destination_identity=str(data["destination_identity"]),
         )
-    except (KeyError, TypeError, ValueError, VerifiedCopyError):
+    except (KeyError, TypeError, ValueError, VerifiedCopyError) as error:
+        logger.warning("Ignoring invalid verified-copy resume marker %s: %s", path, error)
         return None
 
 
@@ -486,7 +505,7 @@ def _source_identity(info: dict[str, Any]) -> str | None:
 def _destination_identity(info: dict[str, Any]) -> str | None:
     etag = _etag(info)
     if etag is not None:
-        return f"etag={etag}"
+        return f"{ETAG_IDENTITY_PREFIX}{etag}"
     for key in ("ChecksumSHA256", "checksum", "md5Hash", "crc32c", "version_id", "VersionId"):
         value = info.get(key)
         if value is not None:

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from typing import Any, cast
@@ -13,7 +14,15 @@ from fsspec import AbstractFileSystem
 
 from rigging.filesystem.atomic import atomic_rename
 from rigging.filesystem.buckets import filesystem_for
-from rigging.fsutil.transfer import _join_path, _join_url, _relative_path
+from rigging.fsutil.transfer import (
+    TransferLocation,
+    _backend,
+    _join_path,
+    _join_url,
+    _relative_path,
+    _same_location,
+    _strictly_contains,
+)
 
 COPY_CHUNK_BYTES = 8 * 1024 * 1024
 S3_UPLOAD_PART_BYTES = 50 * 1024 * 1024
@@ -119,15 +128,17 @@ def verified_copy_prefix(
     if workers < 1:
         raise VerifiedCopyError("workers must be at least 1")
 
-    source_url = source_url.rstrip("/")
-    destination_url = destination_url.rstrip("/")
-    if source_url == destination_url:
-        raise VerifiedCopyError("source and destination must differ")
-    status_url = (status_url or f"{destination_url}.verified-copy-status").rstrip("/")
+    source = _resolved_location(source_url, fixed_upload_size=False)
+    destination = _resolved_location(destination_url, fixed_upload_size=True)
+    status = _resolved_location(
+        status_url or f"{destination.url}.verified-copy-status",
+        fixed_upload_size=True,
+    )
+    _validate_disjoint_locations(source, destination, status)
 
-    source_fs, source_root = filesystem_for(source_url)
-    destination_fs, destination_root = filesystem_for(destination_url, fixed_upload_size=True)
-    status_fs, status_root = filesystem_for(status_url, fixed_upload_size=True)
+    source_url, source_fs, source_root = source.url, source.filesystem, source.path
+    destination_url, destination_fs, destination_root = destination.url, destination.filesystem, destination.path
+    status_fs, status_root = status.filesystem, status.path
     sources = _source_files(source_fs, source_root)
     if not sources:
         raise VerifiedCopyError(f"source prefix contains no files: {source_url}")
@@ -368,8 +379,29 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
             sha256=str(data["sha256"]),
             destination_identity=str(data["destination_identity"]),
         )
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+    except (KeyError, TypeError, ValueError, VerifiedCopyError):
         return None
+
+
+def _resolved_location(url: str, *, fixed_upload_size: bool) -> TransferLocation:
+    filesystem, path = filesystem_for(url, fixed_upload_size=fixed_upload_size)
+    location = TransferLocation.from_path(url, filesystem, path)
+    if _backend(location) == "file":
+        path = os.path.realpath(os.path.abspath(path))
+        location = TransferLocation.from_path(path, filesystem, path)
+    return location
+
+
+def _validate_disjoint_locations(
+    source: TransferLocation,
+    destination: TransferLocation,
+    status: TransferLocation,
+) -> None:
+    locations = (("source", source), ("destination", destination), ("status", status))
+    for index, (left_name, left) in enumerate(locations):
+        for right_name, right in locations[index + 1 :]:
+            if _same_location(left, right) or _strictly_contains(left, right) or _strictly_contains(right, left):
+                raise VerifiedCopyError(f"{left_name} and {right_name} prefixes overlap")
 
 
 def _write_json_atomic(filesystem: AbstractFileSystem, path: str, value: dict[str, Any]) -> None:

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -16,6 +16,7 @@ from rigging.filesystem.buckets import filesystem_for
 from rigging.fsutil.transfer import _join_path, _join_url, _relative_path
 
 COPY_CHUNK_BYTES = 8 * 1024 * 1024
+S3_UPLOAD_PART_BYTES = 50 * 1024 * 1024
 COMPLETION_MANIFEST = ".verified-copy-manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
 
@@ -50,12 +51,50 @@ class _SourceFile:
 
 
 @dataclass(frozen=True)
+class _DestinationFile:
+    size: int
+    identity: str | None
+
+
+@dataclass(frozen=True)
 class _ResumeMarker:
     source_path: str
     source_identity: str | None
     path: str
     size: int
     sha256: str
+    destination_identity: str
+
+
+class _MultipartEtag:
+    """Hash a byte stream using the content-derived S3/R2 multipart ETag rules."""
+
+    def __init__(self, part_size: int):
+        self.part_size = part_size
+        self.part_hashes: list[bytes] = []
+        self.current_hash = hashlib.md5(usedforsecurity=False)
+        self.current_size = 0
+
+    def update(self, data: bytes) -> None:
+        offset = 0
+        while offset < len(data):
+            length = min(self.part_size - self.current_size, len(data) - offset)
+            self.current_hash.update(data[offset : offset + length])
+            self.current_size += length
+            offset += length
+            if self.current_size == self.part_size:
+                self.part_hashes.append(self.current_hash.digest())
+                self.current_hash = hashlib.md5(usedforsecurity=False)
+                self.current_size = 0
+
+    def etag(self, total_size: int) -> str:
+        if total_size < self.part_size:
+            return self.current_hash.hexdigest()
+        part_hashes = [*self.part_hashes]
+        if self.current_size:
+            part_hashes.append(self.current_hash.digest())
+        digest = hashlib.md5(b"".join(part_hashes), usedforsecurity=False).hexdigest()
+        return f"{digest}-{len(part_hashes)}"
 
 
 def verified_copy_prefix(
@@ -68,7 +107,7 @@ def verified_copy_prefix(
     """Copy and verify a prefix before publishing its completion manifest.
 
     Verified per-object records allow retries to reuse destination objects when
-    their source identity and content hash still match.
+    their source and destination identities still match.
     """
     if workers < 1:
         raise VerifiedCopyError("workers must be at least 1")
@@ -116,7 +155,7 @@ def verified_copy_prefix(
                 destination_root=destination_root,
                 status_fs=status_fs,
                 status_root=status_root,
-                destination_size=destination_files.get(source.path),
+                destination=destination_files.get(source.path),
             ): source.path
             for source in sources
         }
@@ -150,13 +189,16 @@ def _source_files(filesystem: AbstractFileSystem, root: str) -> list[_SourceFile
     return files
 
 
-def _destination_files(filesystem: AbstractFileSystem, root: str) -> dict[str, int]:
+def _destination_files(filesystem: AbstractFileSystem, root: str) -> dict[str, _DestinationFile]:
     if not filesystem.exists(root):
         return {}
     if not filesystem.isdir(root):
         raise VerifiedCopyError(f"destination is not a directory: {root}")
     return {
-        _relative_path(path, root): int(info.get("size") or 0)
+        _relative_path(path, root): _DestinationFile(
+            size=int(info.get("size") or 0),
+            identity=_destination_identity(info),
+        )
         for path, info in _find_files(filesystem, root).items()
         if _relative_path(path, root) != COMPLETION_MANIFEST
     }
@@ -177,23 +219,28 @@ def _copy_or_resume(
     destination_root: str,
     status_fs: AbstractFileSystem,
     status_root: str,
-    destination_size: int | None,
+    destination: _DestinationFile | None,
 ) -> tuple[VerifiedFile, bool]:
     destination_path = _join_path(destination_root, source.path)
     marker_path = _join_path(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
     marker = _resume_marker(status_fs, marker_path)
-    if destination_size == source.size and source.identity is not None and marker is not None:
+    if (
+        destination is not None
+        and destination.size == source.size
+        and source.identity is not None
+        and marker is not None
+    ):
         expected = VerifiedFile(source.path, source.size, marker.sha256, source.identity)
         if (
             marker.source_path == source.source_path
             and marker.source_identity == source.identity
             and marker.path == source.path
             and marker.size == source.size
-            and _sha256(destination_fs, destination_path) == marker.sha256
+            and _destination_matches_marker(destination_fs, destination_path, destination, marker)
         ):
             return expected, False
 
-    sha256, copied_size = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    sha256, copied_size, expected_etag = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
     if copied_size != source.size:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source size changed while copying {source.path}")
@@ -203,15 +250,31 @@ def _copy_or_resume(
     if current_size != source.size or current_identity != source.identity:
         destination_fs.rm(destination_path)
         raise VerifiedCopyError(f"source identity changed while copying {source.path}")
-    destination_sha256 = _sha256(destination_fs, destination_path)
-    if destination_sha256 != sha256:
+    try:
+        destination_identity = _verify_destination(
+            destination_fs,
+            destination_path,
+            expected_size=source.size,
+            expected_sha256=sha256,
+            expected_etag=expected_etag,
+        )
+    except VerifiedCopyError:
         destination_fs.rm(destination_path)
-        raise VerifiedCopyError(f"destination hash mismatch for {source.path}")
+        raise
     verified = VerifiedFile(source.path, source.size, sha256, source.identity)
     _write_json_atomic(
         status_fs,
         marker_path,
-        asdict(_ResumeMarker(source.source_path, source.identity, source.path, source.size, sha256)),
+        asdict(
+            _ResumeMarker(
+                source.source_path,
+                source.identity,
+                source.path,
+                source.size,
+                sha256,
+                destination_identity,
+            )
+        ),
     )
     return verified, True
 
@@ -221,18 +284,60 @@ def _copy_with_hash(
     source_path: str,
     destination_fs: AbstractFileSystem,
     destination_path: str,
-) -> tuple[str, int]:
+) -> tuple[str, int, str | None]:
     parent, separator, _ = destination_path.rpartition("/")
     if separator:
         destination_fs.makedirs(parent, exist_ok=True)
     digest = hashlib.sha256()
+    multipart_etag = _MultipartEtag(S3_UPLOAD_PART_BYTES) if _is_s3(destination_fs) else None
     copied_size = 0
-    with source_fs.open(source_path, "rb") as source, destination_fs.open(destination_path, "wb") as destination:
+    destination_options = {"block_size": S3_UPLOAD_PART_BYTES} if multipart_etag is not None else {}
+    with (
+        source_fs.open(source_path, "rb") as source,
+        destination_fs.open(destination_path, "wb", **destination_options) as destination,
+    ):
         while chunk := source.read(COPY_CHUNK_BYTES):
             digest.update(chunk)
+            if multipart_etag is not None:
+                multipart_etag.update(chunk)
             destination.write(chunk)
             copied_size += len(chunk)
-    return digest.hexdigest(), copied_size
+    expected_etag = multipart_etag.etag(copied_size) if multipart_etag is not None else None
+    return digest.hexdigest(), copied_size, expected_etag
+
+
+def _verify_destination(
+    filesystem: AbstractFileSystem,
+    path: str,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+    expected_etag: str | None,
+) -> str:
+    filesystem.invalidate_cache(path)
+    info = filesystem.info(path)
+    if int(info.get("size") or 0) != expected_size:
+        raise VerifiedCopyError(f"destination size mismatch for {path}")
+    if expected_etag is None:
+        if _sha256(filesystem, path) != expected_sha256:
+            raise VerifiedCopyError(f"destination hash mismatch for {path}")
+        return _destination_identity(info) or f"sha256={expected_sha256}"
+
+    actual_etag = _etag(info)
+    if actual_etag != expected_etag:
+        raise VerifiedCopyError(f"destination ETag mismatch for {path}")
+    return f"etag={actual_etag}"
+
+
+def _destination_matches_marker(
+    filesystem: AbstractFileSystem,
+    path: str,
+    destination: _DestinationFile,
+    marker: _ResumeMarker,
+) -> bool:
+    if marker.destination_identity.startswith("sha256="):
+        return _sha256(filesystem, path) == marker.destination_identity.removeprefix("sha256=")
+    return destination.identity == marker.destination_identity
 
 
 def _sha256(filesystem: AbstractFileSystem, path: str) -> str:
@@ -254,6 +359,7 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
             path=str(data["path"]),
             size=int(data["size"]),
             sha256=str(data["sha256"]),
+            destination_identity=str(data["destination_identity"]),
         )
     except (KeyError, TypeError, ValueError, json.JSONDecodeError):
         return None
@@ -336,6 +442,31 @@ def _source_identity(info: dict[str, Any]) -> str | None:
         if value is not None:
             return f"{key}={value!s}"
     return None
+
+
+def _destination_identity(info: dict[str, Any]) -> str | None:
+    etag = _etag(info)
+    if etag is not None:
+        return f"etag={etag}"
+    for key in ("ChecksumSHA256", "checksum", "md5Hash", "crc32c", "version_id", "VersionId"):
+        value = info.get(key)
+        if value is not None:
+            return f"{key}={value!s}"
+    return None
+
+
+def _etag(info: dict[str, Any]) -> str | None:
+    value = info.get("etag") or info.get("ETag")
+    if value is None:
+        return None
+    return str(value).strip('"')
+
+
+def _is_s3(filesystem: AbstractFileSystem) -> bool:
+    protocol = filesystem.protocol
+    if isinstance(protocol, str):
+        return protocol == "s3"
+    return "s3" in protocol
 
 
 def _result(

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -1,0 +1,367 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resumable, content-verified prefix copies across routed filesystems."""
+
+import hashlib
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Any, cast
+
+from fsspec import AbstractFileSystem
+
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.buckets import filesystem_for
+
+COPY_CHUNK_BYTES = 8 * 1024 * 1024
+COMPLETION_MANIFEST = ".verified-copy-manifest.json"
+MANIFEST_SCHEMA_VERSION = 1
+
+
+class VerifiedCopyError(ValueError):
+    """A verified prefix copy cannot safely continue."""
+
+
+@dataclass(frozen=True, order=True)
+class VerifiedFile:
+    path: str
+    size: int
+    sha256: str
+    source_identity: str | None
+
+
+@dataclass(frozen=True)
+class VerifiedCopyResult:
+    manifest_url: str
+    copied_files: int
+    resumed_files: int
+    total_files: int
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class _SourceFile:
+    path: str
+    source_path: str
+    size: int
+    identity: str | None
+
+
+@dataclass(frozen=True)
+class _ResumeMarker:
+    source_path: str
+    source_identity: str | None
+    path: str
+    size: int
+    sha256: str
+
+
+def verified_copy_prefix(
+    source_url: str,
+    destination_url: str,
+    *,
+    status_url: str | None = None,
+    workers: int = 4,
+) -> VerifiedCopyResult:
+    """Copy a prefix, verify every destination object, then publish a manifest.
+
+    Verified per-object records live in a sibling status prefix. A retry hashes
+    the destination object and skips its GCS read when the recorded path, size,
+    and SHA-256 still match. The completion manifest is written into the
+    destination only after every object has verified.
+    """
+    if workers < 1:
+        raise VerifiedCopyError("workers must be at least 1")
+
+    source_url = source_url.rstrip("/")
+    destination_url = destination_url.rstrip("/")
+    if source_url == destination_url:
+        raise VerifiedCopyError("source and destination must differ")
+    status_url = (status_url or f"{destination_url}.verified-copy-status").rstrip("/")
+
+    source_fs, source_root = filesystem_for(source_url)
+    destination_fs, destination_root = filesystem_for(destination_url, fixed_upload_size=True)
+    status_fs, status_root = filesystem_for(status_url, fixed_upload_size=True)
+    sources = _source_files(source_fs, source_root)
+    if not sources:
+        raise VerifiedCopyError(f"source prefix contains no files: {source_url}")
+    if any(source.path == COMPLETION_MANIFEST for source in sources):
+        raise VerifiedCopyError(f"source prefix reserves {COMPLETION_MANIFEST!r}")
+
+    manifest_path = _join(destination_root, COMPLETION_MANIFEST)
+    manifest_url = _join(destination_url, COMPLETION_MANIFEST)
+    if destination_fs.exists(manifest_path):
+        manifest = _read_json(destination_fs, manifest_path)
+        verified = _verified_files_from_manifest(manifest, source_url, destination_url)
+        _validate_completed_source(source_fs, sources, verified)
+        return _result(manifest_url, verified, copied_files=0, resumed_files=len(verified))
+
+    destination_files = _destination_files(destination_fs, destination_root)
+    expected_paths = {source.path for source in sources}
+    extras = sorted(destination_files.keys() - expected_paths)
+    if extras:
+        sample = ", ".join(extras[:3])
+        raise VerifiedCopyError(f"destination contains {len(extras)} unexpected file(s): {sample}")
+
+    copied_files = 0
+    resumed_files = 0
+    verified_files: list[VerifiedFile] = []
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                _copy_or_resume,
+                source,
+                source_fs=source_fs,
+                destination_fs=destination_fs,
+                destination_root=destination_root,
+                status_fs=status_fs,
+                status_root=status_root,
+                destination_size=destination_files.get(source.path),
+            ): source.path
+            for source in sources
+        }
+        for future in as_completed(futures):
+            verified, copied = future.result()
+            verified_files.append(verified)
+            copied_files += int(copied)
+            resumed_files += int(not copied)
+
+    verified_files.sort()
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "source": source_url,
+        "destination": destination_url,
+        "total_files": len(verified_files),
+        "total_bytes": sum(file.size for file in verified_files),
+        "files": [asdict(file) for file in verified_files],
+    }
+    _write_json_atomic(destination_fs, manifest_path, manifest)
+    return _result(manifest_url, verified_files, copied_files=copied_files, resumed_files=resumed_files)
+
+
+def _source_files(filesystem: AbstractFileSystem, root: str) -> list[_SourceFile]:
+    if not filesystem.exists(root) or not filesystem.isdir(root):
+        raise VerifiedCopyError(f"source is not a directory: {root}")
+    files = []
+    for path, info in _find_files(filesystem, root).items():
+        relative = _relative_path(path, root)
+        files.append(_SourceFile(relative, path, int(info.get("size") or 0), _source_identity(info)))
+    files.sort(key=lambda file: file.path)
+    return files
+
+
+def _destination_files(filesystem: AbstractFileSystem, root: str) -> dict[str, int]:
+    if not filesystem.exists(root):
+        return {}
+    if not filesystem.isdir(root):
+        raise VerifiedCopyError(f"destination is not a directory: {root}")
+    return {
+        _relative_path(path, root): int(info.get("size") or 0)
+        for path, info in _find_files(filesystem, root).items()
+        if _relative_path(path, root) != COMPLETION_MANIFEST
+    }
+
+
+def _find_files(filesystem: AbstractFileSystem, root: str) -> dict[str, dict[str, Any]]:
+    found = cast(dict[str, dict[str, Any]] | list[str], filesystem.find(root, detail=True))
+    if not isinstance(found, dict):
+        return {path: filesystem.info(path) for path in found if not filesystem.isdir(path)}
+    return {path: info for path, info in found.items() if info.get("type") != "directory"}
+
+
+def _copy_or_resume(
+    source: _SourceFile,
+    *,
+    source_fs: AbstractFileSystem,
+    destination_fs: AbstractFileSystem,
+    destination_root: str,
+    status_fs: AbstractFileSystem,
+    status_root: str,
+    destination_size: int | None,
+) -> tuple[VerifiedFile, bool]:
+    destination_path = _join(destination_root, source.path)
+    marker_path = _join(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
+    marker = _resume_marker(status_fs, marker_path)
+    if destination_size == source.size and source.identity is not None and marker is not None:
+        expected = VerifiedFile(source.path, source.size, marker.sha256, source.identity)
+        if (
+            marker.source_path == source.source_path
+            and marker.source_identity == source.identity
+            and marker.path == source.path
+            and marker.size == source.size
+            and _sha256(destination_fs, destination_path) == marker.sha256
+        ):
+            return expected, False
+
+    sha256, copied_size = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    if copied_size != source.size:
+        destination_fs.rm(destination_path)
+        raise VerifiedCopyError(f"source size changed while copying {source.path}")
+    current_info = source_fs.info(source.source_path)
+    current_size = int(current_info.get("size") or 0)
+    current_identity = _source_identity(current_info)
+    if current_size != source.size or current_identity != source.identity:
+        destination_fs.rm(destination_path)
+        raise VerifiedCopyError(f"source identity changed while copying {source.path}")
+    destination_sha256 = _sha256(destination_fs, destination_path)
+    if destination_sha256 != sha256:
+        destination_fs.rm(destination_path)
+        raise VerifiedCopyError(f"destination hash mismatch for {source.path}")
+    verified = VerifiedFile(source.path, source.size, sha256, source.identity)
+    _write_json_atomic(
+        status_fs,
+        marker_path,
+        asdict(_ResumeMarker(source.source_path, source.identity, source.path, source.size, sha256)),
+    )
+    return verified, True
+
+
+def _copy_with_hash(
+    source_fs: AbstractFileSystem,
+    source_path: str,
+    destination_fs: AbstractFileSystem,
+    destination_path: str,
+) -> tuple[str, int]:
+    parent, separator, _ = destination_path.rpartition("/")
+    if separator:
+        destination_fs.makedirs(parent, exist_ok=True)
+    digest = hashlib.sha256()
+    copied_size = 0
+    with source_fs.open(source_path, "rb") as source, destination_fs.open(destination_path, "wb") as destination:
+        while chunk := source.read(COPY_CHUNK_BYTES):
+            digest.update(chunk)
+            destination.write(chunk)
+            copied_size += len(chunk)
+    return digest.hexdigest(), copied_size
+
+
+def _sha256(filesystem: AbstractFileSystem, path: str) -> str:
+    digest = hashlib.sha256()
+    with filesystem.open(path, "rb") as file:
+        while chunk := file.read(COPY_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker | None:
+    if not filesystem.exists(path):
+        return None
+    try:
+        data = _read_json(filesystem, path)
+        return _ResumeMarker(
+            source_path=str(data["source_path"]),
+            source_identity=str(data["source_identity"]) if data.get("source_identity") is not None else None,
+            path=str(data["path"]),
+            size=int(data["size"]),
+            sha256=str(data["sha256"]),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _write_json_atomic(filesystem: AbstractFileSystem, path: str, value: dict[str, Any]) -> None:
+    parent, separator, _ = path.rpartition("/")
+    if separator:
+        filesystem.makedirs(parent, exist_ok=True)
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    with atomic_rename(path, filesystem=filesystem) as temporary_path:
+        with filesystem.open(temporary_path, "wb") as file:
+            file.write(payload)
+
+
+def _read_json(filesystem: AbstractFileSystem, path: str) -> dict[str, Any]:
+    try:
+        with filesystem.open(path, "rb") as file:
+            value = json.load(file)
+    except json.JSONDecodeError as error:
+        raise VerifiedCopyError(f"invalid JSON at {path}") from error
+    if not isinstance(value, dict):
+        raise VerifiedCopyError(f"expected JSON object at {path}")
+    return value
+
+
+def _verified_files_from_manifest(manifest: dict[str, Any], source_url: str, destination_url: str) -> list[VerifiedFile]:
+    if manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise VerifiedCopyError("completion manifest has an unsupported schema")
+    if manifest.get("source") != source_url or manifest.get("destination") != destination_url:
+        raise VerifiedCopyError("completion manifest belongs to a different transfer")
+    try:
+        files = [
+            VerifiedFile(
+                path=str(item["path"]),
+                size=int(item["size"]),
+                sha256=str(item["sha256"]),
+                source_identity=str(item["source_identity"]) if item.get("source_identity") is not None else None,
+            )
+            for item in manifest["files"]
+        ]
+    except (KeyError, TypeError, ValueError) as error:
+        raise VerifiedCopyError("completion manifest has invalid file records") from error
+    files.sort()
+    return files
+
+
+def _validate_completed_source(
+    source_fs: AbstractFileSystem, sources: list[_SourceFile], verified: list[VerifiedFile]
+) -> None:
+    current_inventory = [(file.path, file.size) for file in sources]
+    completed_inventory = [(file.path, file.size) for file in verified]
+    if current_inventory != completed_inventory:
+        raise VerifiedCopyError("source path or size changed after destination completion")
+    for source, completed in zip(sources, verified, strict=True):
+        if source.identity is not None:
+            if source.identity != completed.source_identity:
+                raise VerifiedCopyError(f"source identity changed after destination completion: {source.path}")
+            continue
+        if _sha256(source_fs, source.source_path) != completed.sha256:
+            raise VerifiedCopyError(f"source content changed after destination completion: {source.path}")
+
+
+def _source_identity(info: dict[str, Any]) -> str | None:
+    for key in (
+        "generation",
+        "version_id",
+        "VersionId",
+        "md5Hash",
+        "crc32c",
+        "checksum",
+        "ChecksumSHA256",
+        "etag",
+        "ETag",
+        "updated",
+        "mtime",
+        "LastModified",
+    ):
+        value = info.get(key)
+        if value is not None:
+            return f"{key}={value!s}"
+    return None
+
+
+def _result(
+    manifest_url: str,
+    files: list[VerifiedFile],
+    *,
+    copied_files: int,
+    resumed_files: int,
+) -> VerifiedCopyResult:
+    return VerifiedCopyResult(
+        manifest_url=manifest_url,
+        copied_files=copied_files,
+        resumed_files=resumed_files,
+        total_files=len(files),
+        total_bytes=sum(file.size for file in files),
+    )
+
+
+def _relative_path(path: str, root: str) -> str:
+    root = root.rstrip("/")
+    prefix = f"{root}/"
+    if not path.startswith(prefix):
+        raise VerifiedCopyError(f"unexpected object {path!r} outside {root!r}")
+    return path[len(prefix) :]
+
+
+def _join(parent: str, child: str) -> str:
+    return f"{parent.rstrip('/')}/{child}"

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -112,7 +112,12 @@ class _CompletionManifest:
 
 
 class _MultipartEtag:
-    """Hash a byte stream using the content-derived S3/R2 multipart ETag rules."""
+    """Hash a byte stream using the documented S3/R2 multipart ETag rules.
+
+    This deliberately implements the small streaming calculation locally: none
+    of our S3 dependencies exposes it, and adding a dependency solely for this
+    calculation would not improve correctness.
+    """
 
     def __init__(self, part_size: int):
         self.part_size = part_size

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -116,7 +116,8 @@ class _MultipartEtag:
 
     This deliberately implements the small streaming calculation locally: none
     of our S3 dependencies exposes it, and adding a dependency solely for this
-    calculation would not improve correctness.
+    calculation would not improve correctness. The algorithm is specified at
+    https://developers.cloudflare.com/r2/objects/upload-objects/#etags.
     """
 
     def __init__(self, part_size: int):

--- a/lib/rigging/src/rigging/fsutil/verified_copy.py
+++ b/lib/rigging/src/rigging/fsutil/verified_copy.py
@@ -30,6 +30,7 @@ from rigging.fsutil.transfer import (
 DEFAULT_VERIFIED_COPY_WORKERS = 4
 S3_UPLOAD_PART_BYTES = 50 * 1024 * 1024
 COMPLETION_MANIFEST = ".verified-copy-manifest.json"
+STAGING_SUFFIX = ".verified-copy-staging"
 MANIFEST_SCHEMA_VERSION = 1
 SHA256_IDENTITY_PREFIX = "sha256="
 ETAG_IDENTITY_PREFIX = "etag="
@@ -97,7 +98,7 @@ class _ResumeMarker:
     path: str
     size: int
     sha256: str
-    destination_identity: str
+    staging_identity: str
 
 
 @dataclass(frozen=True)
@@ -158,14 +159,17 @@ def verified_copy_prefix(
 
     source = _resolved_location(source_url, S3UploadPolicy.STANDARD)
     destination = _resolved_location(destination_url, S3UploadPolicy.FIXED_PARTS)
-    status = _resolved_location(
-        status_url or f"{destination.url}.verified-copy-status",
-        S3UploadPolicy.FIXED_PARTS,
+    status = (
+        _resolved_location(status_url, S3UploadPolicy.FIXED_PARTS)
+        if status_url is not None
+        else _sibling_location(destination, ".verified-copy-status")
     )
-    _validate_disjoint_locations(source, destination, status)
+    staging = _sibling_location(destination, STAGING_SUFFIX)
+    _validate_disjoint_locations(source, destination, status, staging)
 
     source_url, source_fs, source_root = source.url, source.filesystem, source.path
     destination_url, destination_fs, destination_root = destination.url, destination.filesystem, destination.path
+    staging_root = staging.path
     status_fs, status_root = status.filesystem, status.path
     sources = _source_files(source_fs, source_root)
     if not sources:
@@ -182,11 +186,16 @@ def verified_copy_prefix(
         return _result(manifest_url, verified, copied_files=0, resumed_files=len(verified))
 
     destination_files = _destination_files(destination_fs, destination_root)
+    staging_files = _destination_files(destination_fs, staging_root)
     expected_paths = {source.path for source in sources}
     extras = sorted(destination_files.keys() - expected_paths)
     if extras:
         sample = ", ".join(extras[:3])
         raise VerifiedCopyError(f"destination contains {len(extras)} unexpected file(s): {sample}")
+    staging_extras = sorted(staging_files.keys() - expected_paths)
+    if staging_extras:
+        sample = ", ".join(staging_extras[:3])
+        raise VerifiedCopyError(f"staging prefix contains {len(staging_extras)} unexpected file(s): {sample}")
 
     copied_files = 0
     resumed_files = 0
@@ -198,10 +207,12 @@ def verified_copy_prefix(
                 source,
                 source_fs=source_fs,
                 destination_fs=destination_fs,
+                staging_root=staging_root,
                 destination_root=destination_root,
                 status_fs=status_fs,
                 status_root=status_root,
-                destination=destination_files.get(source.path),
+                staged=staging_files.get(source.path),
+                published=destination_files.get(source.path),
             ): source.path
             for source in sources
         }
@@ -220,6 +231,26 @@ def verified_copy_prefix(
         total_bytes=sum(file.size for file in verified_files),
         files=verified_files,
     )
+    staging_files = _destination_files(destination_fs, staging_root)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                _promote,
+                file,
+                filesystem=destination_fs,
+                staging_root=staging_root,
+                destination_root=destination_root,
+                status_fs=status_fs,
+                status_root=status_root,
+                staged=staging_files.get(file.path),
+                published=destination_files.get(file.path),
+            ): file.path
+            for file in verified_files
+        }
+        for future in as_completed(futures):
+            future.result()
+    if destination_fs.exists(staging_root):
+        destination_fs.rm(staging_root, recursive=True)
     _write_json_atomic(destination_fs, manifest_path, asdict(manifest))
     return _result(manifest_url, verified_files, copied_files=copied_files, resumed_files=resumed_files)
 
@@ -262,50 +293,54 @@ def _copy_or_resume(
     *,
     source_fs: AbstractFileSystem,
     destination_fs: AbstractFileSystem,
+    staging_root: str,
     destination_root: str,
     status_fs: AbstractFileSystem,
     status_root: str,
-    destination: _DestinationFile | None,
+    staged: _DestinationFile | None,
+    published: _DestinationFile | None,
 ) -> _CopyOutcome:
+    staging_path = _join_path(staging_root, source.path)
     destination_path = _join_path(destination_root, source.path)
     marker_path = _join_path(status_root, f"{hashlib.sha256(source.path.encode()).hexdigest()}.json")
     marker = _resume_marker(status_fs, marker_path)
-    if (
-        destination is not None
-        and destination.size == source.size
-        and source.identity is not None
-        and marker is not None
-    ):
+    if source.identity is not None and marker is not None:
         expected = VerifiedFile(source.path, source.size, marker.sha256, source.identity)
         if (
             marker.source_path == source.source_path
             and marker.source_identity == source.identity
             and marker.path == source.path
             and marker.size == source.size
-            and _destination_matches_marker(destination_fs, destination_path, destination, marker)
         ):
-            return _CopyOutcome(expected, _CopyDisposition.RESUMED)
+            candidates = ((staging_path, staged), (destination_path, published))
+            if any(
+                file is not None
+                and file.size == source.size
+                and _destination_matches_marker(destination_fs, path, file, marker)
+                for path, file in candidates
+            ):
+                return _CopyOutcome(expected, _CopyDisposition.RESUMED)
 
-    copied = _copy_with_hash(source_fs, source.source_path, destination_fs, destination_path)
+    copied = _copy_with_hash(source_fs, source.source_path, destination_fs, staging_path)
     if copied.size != source.size:
-        destination_fs.rm(destination_path)
+        destination_fs.rm(staging_path)
         raise VerifiedCopyError(f"source size changed while copying {source.path}")
     current_info = source_fs.info(source.source_path)
     current_size = int(current_info.get("size") or 0)
     current_identity = _source_identity(current_info)
     if current_size != source.size or current_identity != source.identity:
-        destination_fs.rm(destination_path)
+        destination_fs.rm(staging_path)
         raise VerifiedCopyError(f"source identity changed while copying {source.path}")
     try:
-        destination_identity = _verify_destination(
+        staging_identity = _verify_destination(
             destination_fs,
-            destination_path,
+            staging_path,
             expected_size=source.size,
             expected_sha256=copied.sha256,
             expected_etag=copied.expected_etag,
         )
     except VerifiedCopyError:
-        destination_fs.rm(destination_path)
+        destination_fs.rm(staging_path)
         raise
     verified = VerifiedFile(source.path, source.size, copied.sha256, source.identity)
     _write_json_atomic(
@@ -318,11 +353,65 @@ def _copy_or_resume(
                 source.path,
                 source.size,
                 copied.sha256,
-                destination_identity,
+                staging_identity,
             )
         ),
     )
     return _CopyOutcome(verified, _CopyDisposition.COPIED)
+
+
+def _promote(
+    verified: VerifiedFile,
+    *,
+    filesystem: AbstractFileSystem,
+    staging_root: str,
+    destination_root: str,
+    status_fs: AbstractFileSystem,
+    status_root: str,
+    staged: _DestinationFile | None,
+    published: _DestinationFile | None,
+) -> None:
+    staging_path = _join_path(staging_root, verified.path)
+    destination_path = _join_path(destination_root, verified.path)
+    marker_path = _join_path(status_root, f"{hashlib.sha256(verified.path.encode()).hexdigest()}.json")
+    marker = _resume_marker(status_fs, marker_path)
+    if marker is None or (
+        marker.path != verified.path
+        or marker.size != verified.size
+        or marker.sha256 != verified.sha256
+        or marker.source_identity != verified.source_identity
+    ):
+        raise VerifiedCopyError(f"verified staging record is missing or stale: {verified.path}")
+
+    if (
+        published is not None
+        and published.size == verified.size
+        and _destination_matches_marker(filesystem, destination_path, published, marker)
+    ):
+        if filesystem.exists(staging_path):
+            filesystem.rm(staging_path)
+        return
+    if (
+        staged is None
+        or staged.size != verified.size
+        or not _destination_matches_marker(filesystem, staging_path, staged, marker)
+    ):
+        raise VerifiedCopyError(f"verified staged object is missing or stale: {verified.path}")
+
+    parent, separator, _ = destination_path.rpartition("/")
+    if separator:
+        filesystem.makedirs(parent, exist_ok=True)
+    copy_options = {"preserve_etag": True} if _is_s3(filesystem) else {}
+    filesystem.cp_file(staging_path, destination_path, **copy_options)
+    filesystem.invalidate_cache(destination_path)
+    promoted = _DestinationFile(
+        size=int((info := filesystem.info(destination_path)).get("size") or 0),
+        identity=_destination_identity(info),
+    )
+    if promoted.size != verified.size or not _destination_matches_marker(filesystem, destination_path, promoted, marker):
+        filesystem.rm(destination_path)
+        raise VerifiedCopyError(f"promoted object does not match verified staging object: {verified.path}")
+    filesystem.rm(staging_path)
 
 
 def _copy_with_hash(
@@ -381,9 +470,9 @@ def _destination_matches_marker(
     destination: _DestinationFile,
     marker: _ResumeMarker,
 ) -> bool:
-    if marker.destination_identity.startswith(SHA256_IDENTITY_PREFIX):
-        return _sha256(filesystem, path) == marker.destination_identity.removeprefix(SHA256_IDENTITY_PREFIX)
-    return destination.identity == marker.destination_identity
+    if marker.staging_identity.startswith(SHA256_IDENTITY_PREFIX):
+        return _sha256(filesystem, path) == marker.staging_identity.removeprefix(SHA256_IDENTITY_PREFIX)
+    return destination.identity == marker.staging_identity
 
 
 def _sha256(filesystem: AbstractFileSystem, path: str) -> str:
@@ -405,7 +494,7 @@ def _resume_marker(filesystem: AbstractFileSystem, path: str) -> _ResumeMarker |
             path=str(data["path"]),
             size=int(data["size"]),
             sha256=str(data["sha256"]),
-            destination_identity=str(data["destination_identity"]),
+            staging_identity=str(data["staging_identity"]),
         )
     except (KeyError, TypeError, ValueError, VerifiedCopyError) as error:
         logger.warning("Ignoring invalid verified-copy resume marker %s: %s", path, error)
@@ -421,12 +510,23 @@ def _resolved_location(url: str, upload_policy: S3UploadPolicy) -> TransferLocat
     return location
 
 
+def _sibling_location(location: TransferLocation, suffix: str) -> TransferLocation:
+    if _backend(location) != "file" and "/" not in location.path.rstrip("/"):
+        raise VerifiedCopyError("destination must name a prefix inside an object-store bucket")
+    return TransferLocation(
+        f"{location.url.rstrip('/')}{suffix}",
+        location.filesystem,
+        f"{location.path.rstrip('/')}{suffix}",
+    )
+
+
 def _validate_disjoint_locations(
     source: TransferLocation,
     destination: TransferLocation,
     status: TransferLocation,
+    staging: TransferLocation,
 ) -> None:
-    locations = (("source", source), ("destination", destination), ("status", status))
+    locations = (("source", source), ("destination", destination), ("status", status), ("staging", staging))
     for index, (left_name, left) in enumerate(locations):
         for right_name, right in locations[index + 1 :]:
             if _same_location(left, right) or _strictly_contains(left, right) or _strictly_contains(right, left):
@@ -541,12 +641,14 @@ def _etag(info: dict[str, Any]) -> str | None:
 
 
 def _has_fixed_s3_uploads(filesystem: AbstractFileSystem) -> bool:
+    return _is_s3(filesystem) and bool(getattr(filesystem, "fixed_upload_size", False))
+
+
+def _is_s3(filesystem: AbstractFileSystem) -> bool:
     protocol = filesystem.protocol
     if isinstance(protocol, str):
-        is_s3 = protocol == "s3"
-    else:
-        is_s3 = "s3" in protocol
-    return is_s3 and bool(getattr(filesystem, "fixed_upload_size", False))
+        return protocol == "s3"
+    return "s3" in protocol
 
 
 def _result(

--- a/lib/rigging/tests/test_buckets.py
+++ b/lib/rigging/tests/test_buckets.py
@@ -108,9 +108,3 @@ def test_gcs_is_not_an_s3_backend(config):
     """GCS uses application default credentials, so asking for its S3 settings is an error."""
     with pytest.raises(ValueError, match="stores"):
         cluster_config.store_config(StoreType.GCS)
-
-
-def test_r2_upload_can_require_fixed_multipart_parts(config):
-    filesystem, _ = filesystem_for("s3://marin-na/export/model.safetensors", fixed_upload_size=True)
-
-    assert filesystem.fixed_upload_size is True

--- a/lib/rigging/tests/test_buckets.py
+++ b/lib/rigging/tests/test_buckets.py
@@ -108,3 +108,9 @@ def test_gcs_is_not_an_s3_backend(config):
     """GCS uses application default credentials, so asking for its S3 settings is an error."""
     with pytest.raises(ValueError, match="stores"):
         cluster_config.store_config(StoreType.GCS)
+
+
+def test_r2_upload_can_require_fixed_multipart_parts(config):
+    filesystem, _ = filesystem_for("s3://marin-na/export/model.safetensors", fixed_upload_size=True)
+
+    assert filesystem.fixed_upload_size is True

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -202,7 +202,7 @@ def test_verified_copy_rejects_contained_prefixes(tmp_path, reverse):
 
 
 @pytest.mark.parametrize("marker_payload", ["{", "[]"])
-def test_verified_copy_ignores_malformed_resume_marker(tmp_path, marker_payload):
+def test_verified_copy_ignores_malformed_resume_marker(tmp_path, marker_payload, caplog):
     source = tmp_path / "source"
     destination = tmp_path / "destination"
     source.mkdir()
@@ -217,6 +217,7 @@ def test_verified_copy_ignores_malformed_resume_marker(tmp_path, marker_payload)
     assert result.copied_files == 1
     assert result.resumed_files == 0
     assert (destination / "weights.bin").read_bytes() == b"weights"
+    assert "Ignoring invalid verified-copy resume marker" in caplog.text
 
 
 def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_path, monkeypatch):

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -12,11 +12,13 @@ import lzma
 import os
 import threading
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 import rigging.filesystem.bulk_deletion as bulk_deletion
 import rigging.fsutil.cli as cli_module
 import rigging.fsutil.transfer as transfer_module
+import rigging.fsutil.verified_copy as verified_copy_module
 import rigging.timing as timing
 from botocore.exceptions import EndpointConnectionError
 from click.testing import CliRunner
@@ -34,6 +36,7 @@ from rigging.fsutil.usage import (
     scan_usage,
     threshold_prefix_groups,
 )
+from rigging.fsutil.verified_copy import COMPLETION_MANIFEST, VerifiedCopyError, verified_copy_prefix
 
 
 @pytest.fixture
@@ -114,6 +117,260 @@ def test_cp_no_clobber_preserves_existing_destination(tree, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert (destination / "b.txt").read_text() == "keep"
+
+
+def test_verified_copy_publishes_content_manifest_after_verification(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    (source / "nested").mkdir(parents=True)
+    (source / "config.json").write_bytes(b"config")
+    (source / "nested" / "weights.bin").write_bytes(b"weights")
+
+    result = verified_copy_prefix(str(source), str(destination), workers=2)
+
+    manifest = json.loads((destination / COMPLETION_MANIFEST).read_text())
+    assert result.total_files == 2
+    assert result.copied_files == 2
+    assert result.resumed_files == 0
+    assert {entry["path"]: entry["size"] for entry in manifest["files"]} == {
+        "config.json": 6,
+        "nested/weights.bin": 7,
+    }
+    assert (destination / "config.json").read_bytes() == b"config"
+    assert (destination / "nested" / "weights.bin").read_bytes() == b"weights"
+
+
+def test_verified_copy_retry_uses_verified_objects_without_source_reads(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"weights")
+    verified_copy_prefix(str(source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+
+    source_filesystem, source_path = verified_copy_module.filesystem_for(str(source))
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    status_filesystem, status_path = verified_copy_module.filesystem_for(f"{destination}.verified-copy-status")
+
+    class UnreadableSource:
+        def __getattr__(self, name):
+            return getattr(source_filesystem, name)
+
+        def open(self, _path, _mode):
+            raise AssertionError("a verified resumed object must not reread its source")
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        del fixed_upload_size
+        if url == str(source):
+            return UnreadableSource(), source_path
+        if url == str(destination):
+            return destination_filesystem, destination_path
+        return status_filesystem, status_path
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 0
+    assert result.resumed_files == 1
+    assert (destination / "weights.bin").read_bytes() == b"weights"
+    assert (destination / COMPLETION_MANIFEST).exists()
+
+
+def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "a.bin").write_bytes(b"first")
+    (source / "b.bin").write_bytes(b"second")
+
+    source_filesystem, source_path = verified_copy_module.filesystem_for(str(source))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class FailingSource:
+        def __getattr__(self, name):
+            return getattr(source_filesystem, name)
+
+        def open(self, path, mode):
+            if path.endswith("b.bin") and mode == "rb":
+                raise OSError("injected source failure")
+            return source_filesystem.open(path, mode)
+
+    def failing_route(url, *, fixed_upload_size=False):
+        if url == str(source):
+            return FailingSource(), source_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", failing_route)
+    with pytest.raises(OSError, match="injected source failure"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+    assert not (destination / COMPLETION_MANIFEST).exists()
+    assert (destination / "a.bin").read_bytes() == b"first"
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", original_filesystem_for)
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert result.resumed_files == 1
+    assert (destination / "b.bin").read_bytes() == b"second"
+    assert (destination / COMPLETION_MANIFEST).exists()
+
+
+def test_verified_copy_does_not_reuse_status_from_another_source(tmp_path):
+    first_source = tmp_path / "first-source"
+    second_source = tmp_path / "second-source"
+    destination = tmp_path / "destination"
+    first_source.mkdir()
+    second_source.mkdir()
+    (first_source / "weights.bin").write_bytes(b"first!!")
+    (second_source / "weights.bin").write_bytes(b"second!")
+    verified_copy_prefix(str(first_source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+
+    result = verified_copy_prefix(str(second_source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert result.resumed_files == 0
+    assert (destination / "weights.bin").read_bytes() == b"second!"
+
+
+def test_verified_copy_same_size_source_overwrite_invalidates_resume_marker(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    source_file = source / "weights.bin"
+    source_file.write_bytes(b"first!!")
+    verified_copy_prefix(str(source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+    original_mtime = source_file.stat().st_mtime_ns
+    source_file.write_bytes(b"second!")
+    os.utime(source_file, ns=(original_mtime + 1_000_000_000, original_mtime + 1_000_000_000))
+
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert result.resumed_files == 0
+    assert (destination / "weights.bin").read_bytes() == b"second!"
+
+
+def test_verified_copy_same_size_source_overwrite_invalidates_completion(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    source_file = source / "weights.bin"
+    source_file.write_bytes(b"first!!")
+    verified_copy_prefix(str(source), str(destination), workers=1)
+    original_mtime = source_file.stat().st_mtime_ns
+    source_file.write_bytes(b"second!")
+    os.utime(source_file, ns=(original_mtime + 1_000_000_000, original_mtime + 1_000_000_000))
+
+    with pytest.raises(VerifiedCopyError, match="source identity changed"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert (destination / "weights.bin").read_bytes() == b"first!!"
+
+
+def test_verified_copy_identityless_source_rereads_content_on_completion(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    source_file = source / "weights.bin"
+    source_file.write_bytes(b"first!!")
+
+    source_filesystem, source_path = verified_copy_module.filesystem_for(str(source))
+    original_filesystem_for = verified_copy_module.filesystem_for
+    identity_keys = {
+        "generation",
+        "version_id",
+        "VersionId",
+        "md5Hash",
+        "crc32c",
+        "checksum",
+        "ChecksumSHA256",
+        "etag",
+        "ETag",
+        "updated",
+        "mtime",
+        "LastModified",
+    }
+
+    class IdentitylessSource:
+        def __getattr__(self, name):
+            return getattr(source_filesystem, name)
+
+        def find(self, path, *, detail):
+            found = source_filesystem.find(path, detail=detail)
+            return {
+                name: {key: value for key, value in info.items() if key not in identity_keys}
+                for name, info in found.items()
+            }
+
+        def info(self, path):
+            return {key: value for key, value in source_filesystem.info(path).items() if key not in identity_keys}
+
+    def identityless_route(url, *, fixed_upload_size=False):
+        if url == str(source):
+            return IdentitylessSource(), source_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", identityless_route)
+    verified_copy_prefix(str(source), str(destination), workers=1)
+    source_file.write_bytes(b"second!")
+
+    with pytest.raises(VerifiedCopyError, match="source content changed"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+
+def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"weights")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class CorruptingWriter:
+        def __init__(self, file, path):
+            self.file = file
+            self.path = path
+
+        def __enter__(self):
+            self.file.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            result = self.file.__exit__(exc_type, exc_value, traceback)
+            if exc_type is None:
+                path = Path(self.path)
+                path.write_bytes(b"x" * path.stat().st_size)
+            return result
+
+        def write(self, data):
+            return self.file.write(data)
+
+    class CorruptingDestination:
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def open(self, path, mode):
+            file = destination_filesystem.open(path, mode)
+            if mode == "wb" and path.endswith("weights.bin"):
+                return CorruptingWriter(file, path)
+            return file
+
+    def corrupting_route(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return CorruptingDestination(), destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", corrupting_route)
+
+    with pytest.raises(VerifiedCopyError, match="destination hash mismatch"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert not (destination / "weights.bin").exists()
+    assert not (destination / COMPLETION_MANIFEST).exists()
 
 
 @pytest.mark.parametrize(("command", "destination"), [(["cp", "-r"], "copy"), (["rsync"], "sync")])

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,6 +360,39 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
+class _EtagDestination:
+    protocol = "s3"
+
+    def __init__(self, filesystem, etag, *, fixed_upload_size, allow_reads):
+        self.filesystem = filesystem
+        self.etag = etag
+        self.fixed_upload_size = fixed_upload_size
+        self.allow_reads = allow_reads
+
+    def __getattr__(self, name):
+        return getattr(self.filesystem, name)
+
+    def open(self, path, mode, **kwargs):
+        if mode == "rb" and path.endswith("weights.bin") and not self.allow_reads:
+            raise AssertionError("S3 verification must not download the destination object")
+        kwargs.pop("block_size", None)
+        return self.filesystem.open(path, mode, **kwargs)
+
+    def info(self, path):
+        info = self.filesystem.info(path)
+        if path.endswith("weights.bin"):
+            info["ETag"] = f'"{self.etag}"'
+        return info
+
+    def find(self, path, *, detail):
+        found = self.filesystem.find(path, detail=detail)
+        if detail:
+            for name, info in found.items():
+                if name.endswith("weights.bin"):
+                    info["ETag"] = f'"{self.etag}"'
+        return found
+
+
 @pytest.mark.parametrize(
     ("contents", "etag"),
     [
@@ -375,36 +408,16 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
 
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
-
-    class EtagDestination:
-        protocol = "s3"
-
-        def __getattr__(self, name):
-            return getattr(destination_filesystem, name)
-
-        def open(self, path, mode, **kwargs):
-            if mode == "rb" and path.endswith("weights.bin"):
-                raise AssertionError("S3 verification must not download the destination object")
-            kwargs.pop("block_size", None)
-            return destination_filesystem.open(path, mode, **kwargs)
-
-        def info(self, path):
-            info = destination_filesystem.info(path)
-            if path.endswith("weights.bin"):
-                info["ETag"] = f'"{etag}"'
-            return info
-
-        def find(self, path, *, detail):
-            found = destination_filesystem.find(path, detail=detail)
-            if detail:
-                for name, info in found.items():
-                    if name.endswith("weights.bin"):
-                        info["ETag"] = f'"{etag}"'
-            return found
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        etag,
+        fixed_upload_size=True,
+        allow_reads=False,
+    )
 
     def routed_filesystem(url, *, fixed_upload_size=False):
         if url == str(destination):
-            return EtagDestination(), destination_path
+            return etag_destination, destination_path
         return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
@@ -427,25 +440,16 @@ def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
 
-    class WrongEtagDestination:
-        protocol = "s3"
-
-        def __getattr__(self, name):
-            return getattr(destination_filesystem, name)
-
-        def open(self, path, mode, **kwargs):
-            kwargs.pop("block_size", None)
-            return destination_filesystem.open(path, mode, **kwargs)
-
-        def info(self, path):
-            info = destination_filesystem.info(path)
-            if path.endswith("weights.bin"):
-                info["ETag"] = '"00000000000000000000000000000000-3"'
-            return info
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        "00000000000000000000000000000000-3",
+        fixed_upload_size=True,
+        allow_reads=True,
+    )
 
     def routed_filesystem(url, *, fixed_upload_size=False):
         if url == str(destination):
-            return WrongEtagDestination(), destination_path
+            return etag_destination, destination_path
         return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
@@ -456,6 +460,35 @@ def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
 
     assert not (destination / "weights.bin").exists()
     assert not (destination / COMPLETION_MANIFEST).exists()
+
+
+def test_verified_copy_reads_destination_when_s3_part_sizes_are_not_fixed(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+    etag_destination = _EtagDestination(
+        destination_filesystem,
+        "00000000000000000000000000000000-3",
+        fixed_upload_size=False,
+        allow_reads=True,
+    )
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return etag_destination, destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert (destination / COMPLETION_MANIFEST).exists()
 
 
 @pytest.mark.parametrize(("command", "destination"), [(["cp", "-r"], "copy"), (["rsync"], "sync")])

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,11 +360,18 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
-def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("contents", "etag"),
+    [
+        (b"abc", "900150983cd24fb0d6963f7d28e17f72"),
+        (b"abcdefghij", "446feba4c1b5cc7ad93bf4d44a0e36ac-3"),
+    ],
+)
+def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch, contents, etag):
     source = tmp_path / "source"
     destination = tmp_path / "destination"
     source.mkdir()
-    (source / "weights.bin").write_bytes(b"abcdefghij")
+    (source / "weights.bin").write_bytes(contents)
 
     destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
     original_filesystem_for = verified_copy_module.filesystem_for
@@ -384,7 +391,7 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
         def info(self, path):
             info = destination_filesystem.info(path)
             if path.endswith("weights.bin"):
-                info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+                info["ETag"] = f'"{etag}"'
             return info
 
         def find(self, path, *, detail):
@@ -392,7 +399,7 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
             if detail:
                 for name, info in found.items():
                     if name.endswith("weights.bin"):
-                        info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+                        info["ETag"] = f'"{etag}"'
             return found
 
     def routed_filesystem(url, *, fixed_upload_size=False):

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -360,6 +360,97 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
     assert not (destination / COMPLETION_MANIFEST).exists()
 
 
+def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class EtagDestination:
+        protocol = "s3"
+
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def open(self, path, mode, **kwargs):
+            if mode == "rb" and path.endswith("weights.bin"):
+                raise AssertionError("S3 verification must not download the destination object")
+            kwargs.pop("block_size", None)
+            return destination_filesystem.open(path, mode, **kwargs)
+
+        def info(self, path):
+            info = destination_filesystem.info(path)
+            if path.endswith("weights.bin"):
+                info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+            return info
+
+        def find(self, path, *, detail):
+            found = destination_filesystem.find(path, detail=detail)
+            if detail:
+                for name, info in found.items():
+                    if name.endswith("weights.bin"):
+                        info["ETag"] = '"446feba4c1b5cc7ad93bf4d44a0e36ac-3"'
+            return found
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return EtagDestination(), destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    first = verified_copy_prefix(str(source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+    second = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert first.copied_files == 1
+    assert second.resumed_files == 1
+
+
+def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"abcdefghij")
+
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class WrongEtagDestination:
+        protocol = "s3"
+
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def open(self, path, mode, **kwargs):
+            kwargs.pop("block_size", None)
+            return destination_filesystem.open(path, mode, **kwargs)
+
+        def info(self, path):
+            info = destination_filesystem.info(path)
+            if path.endswith("weights.bin"):
+                info["ETag"] = '"00000000000000000000000000000000-3"'
+            return info
+
+    def routed_filesystem(url, *, fixed_upload_size=False):
+        if url == str(destination):
+            return WrongEtagDestination(), destination_path
+        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+
+    monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
+
+    with pytest.raises(VerifiedCopyError, match="destination ETag mismatch"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert not (destination / "weights.bin").exists()
+    assert not (destination / COMPLETION_MANIFEST).exists()
+
+
 @pytest.mark.parametrize(("command", "destination"), [(["cp", "-r"], "copy"), (["rsync"], "sync")])
 def test_recursive_transfers_accept_relative_local_directories(tmp_path, monkeypatch, command, destination):
     source = tmp_path / "source"

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -279,20 +279,6 @@ def test_verified_copy_identityless_source_rereads_content_on_completion(tmp_pat
 
     source_filesystem, source_path = verified_copy_module.filesystem_for(str(source))
     original_filesystem_for = verified_copy_module.filesystem_for
-    identity_keys = {
-        "generation",
-        "version_id",
-        "VersionId",
-        "md5Hash",
-        "crc32c",
-        "checksum",
-        "ChecksumSHA256",
-        "etag",
-        "ETag",
-        "updated",
-        "mtime",
-        "LastModified",
-    }
 
     class IdentitylessSource:
         def __getattr__(self, name):
@@ -301,12 +287,13 @@ def test_verified_copy_identityless_source_rereads_content_on_completion(tmp_pat
         def find(self, path, *, detail):
             found = source_filesystem.find(path, detail=detail)
             return {
-                name: {key: value for key, value in info.items() if key not in identity_keys}
+                name: {"name": name, "size": info["size"], "type": info.get("type", "file")}
                 for name, info in found.items()
             }
 
         def info(self, path):
-            return {key: value for key, value in source_filesystem.info(path).items() if key not in identity_keys}
+            info = source_filesystem.info(path)
+            return {"name": path, "size": info["size"], "type": info.get("type", "file")}
 
     def identityless_route(url, *, fixed_upload_size=False):
         if url == str(source):

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -177,6 +177,48 @@ def test_verified_copy_retry_uses_verified_objects_without_source_reads(tmp_path
     assert (destination / COMPLETION_MANIFEST).exists()
 
 
+def test_verified_copy_rejects_alias_for_source_as_destination(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    source_file = source / "weights.bin"
+    source_file.write_bytes(b"weights")
+
+    with pytest.raises(VerifiedCopyError, match="source and destination prefixes overlap"):
+        verified_copy_prefix(f"file://{source}", str(source), workers=1)
+
+    assert source_file.read_bytes() == b"weights"
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_verified_copy_rejects_contained_prefixes(tmp_path, reverse):
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    (child / "weights.bin").write_bytes(b"weights")
+    source, destination = (child, parent) if reverse else (parent, child)
+
+    with pytest.raises(VerifiedCopyError, match="source and destination prefixes overlap"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+
+@pytest.mark.parametrize("marker_payload", ["{", "[]"])
+def test_verified_copy_ignores_malformed_resume_marker(tmp_path, marker_payload):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "weights.bin").write_bytes(b"weights")
+    verified_copy_prefix(str(source), str(destination), workers=1)
+    (destination / COMPLETION_MANIFEST).unlink()
+    marker = next(tmp_path.glob("destination.verified-copy-status/*.json"))
+    marker.write_text(marker_payload)
+
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 1
+    assert result.resumed_files == 0
+    assert (destination / "weights.bin").read_bytes() == b"weights"
+
+
 def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_path, monkeypatch):
     source = tmp_path / "source"
     destination = tmp_path / "destination"

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -22,6 +22,7 @@ import rigging.fsutil.verified_copy as verified_copy_module
 import rigging.timing as timing
 from botocore.exceptions import EndpointConnectionError
 from click.testing import CliRunner
+from rigging.filesystem.buckets import S3UploadPolicy
 from rigging.filesystem.cross_region import CrossRegionGuardedFS
 from rigging.filesystem.paged_listing import with_listing
 from rigging.fsutil import deletion, listing
@@ -159,8 +160,8 @@ def test_verified_copy_retry_uses_verified_objects_without_source_reads(tmp_path
         def open(self, _path, _mode):
             raise AssertionError("a verified resumed object must not reread its source")
 
-    def routed_filesystem(url, *, fixed_upload_size=False):
-        del fixed_upload_size
+    def routed_filesystem(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
+        del s3_upload_policy
         if url == str(source):
             return UnreadableSource(), source_path
         if url == str(destination):
@@ -239,10 +240,10 @@ def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_p
                 raise OSError("injected source failure")
             return source_filesystem.open(path, mode)
 
-    def failing_route(url, *, fixed_upload_size=False):
+    def failing_route(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(source):
             return FailingSource(), source_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "filesystem_for", failing_route)
     with pytest.raises(OSError, match="injected source failure"):
@@ -338,10 +339,10 @@ def test_verified_copy_identityless_source_rereads_content_on_completion(tmp_pat
             info = source_filesystem.info(path)
             return {"name": path, "size": info["size"], "type": info.get("type", "file")}
 
-    def identityless_route(url, *, fixed_upload_size=False):
+    def identityless_route(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(source):
             return IdentitylessSource(), source_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "filesystem_for", identityless_route)
     verified_copy_prefix(str(source), str(destination), workers=1)
@@ -389,10 +390,10 @@ def test_verified_copy_hash_mismatch_removes_object_and_withholds_completion(tmp
                 return CorruptingWriter(file, path)
             return file
 
-    def corrupting_route(url, *, fixed_upload_size=False):
+    def corrupting_route(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(destination):
             return CorruptingDestination(), destination_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "filesystem_for", corrupting_route)
 
@@ -411,13 +412,16 @@ class _EtagDestination:
         self.etag = etag
         self.fixed_upload_size = fixed_upload_size
         self.allow_reads = allow_reads
+        self.reads = 0
 
     def __getattr__(self, name):
         return getattr(self.filesystem, name)
 
     def open(self, path, mode, **kwargs):
-        if mode == "rb" and path.endswith("weights.bin") and not self.allow_reads:
-            raise AssertionError("S3 verification must not download the destination object")
+        if mode == "rb" and path.endswith("weights.bin"):
+            self.reads += 1
+            if not self.allow_reads:
+                raise AssertionError("S3 verification must not download the destination object")
         kwargs.pop("block_size", None)
         return self.filesystem.open(path, mode, **kwargs)
 
@@ -458,10 +462,10 @@ def test_verified_copy_uses_s3_etag_without_destination_reads(tmp_path, monkeypa
         allow_reads=False,
     )
 
-    def routed_filesystem(url, *, fixed_upload_size=False):
+    def routed_filesystem(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(destination):
             return etag_destination, destination_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
     monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
@@ -490,10 +494,10 @@ def test_verified_copy_rejects_s3_etag_mismatch(tmp_path, monkeypatch):
         allow_reads=True,
     )
 
-    def routed_filesystem(url, *, fixed_upload_size=False):
+    def routed_filesystem(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(destination):
             return etag_destination, destination_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
     monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
@@ -520,10 +524,10 @@ def test_verified_copy_reads_destination_when_s3_part_sizes_are_not_fixed(tmp_pa
         allow_reads=True,
     )
 
-    def routed_filesystem(url, *, fixed_upload_size=False):
+    def routed_filesystem(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
         if url == str(destination):
             return etag_destination, destination_path
-        return original_filesystem_for(url, fixed_upload_size=fixed_upload_size)
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
 
     monkeypatch.setattr(verified_copy_module, "S3_UPLOAD_PART_BYTES", 4)
     monkeypatch.setattr(verified_copy_module, "filesystem_for", routed_filesystem)
@@ -531,6 +535,7 @@ def test_verified_copy_reads_destination_when_s3_part_sizes_are_not_fixed(tmp_pa
     result = verified_copy_prefix(str(source), str(destination), workers=1)
 
     assert result.copied_files == 1
+    assert etag_destination.reads == 1
     assert (destination / COMPLETION_MANIFEST).exists()
 
 

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -37,7 +37,7 @@ from rigging.fsutil.usage import (
     scan_usage,
     threshold_prefix_groups,
 )
-from rigging.fsutil.verified_copy import COMPLETION_MANIFEST, VerifiedCopyError, verified_copy_prefix
+from rigging.fsutil.verified_copy import COMPLETION_MANIFEST, STAGING_SUFFIX, VerifiedCopyError, verified_copy_prefix
 
 
 @pytest.fixture
@@ -249,7 +249,8 @@ def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_p
     with pytest.raises(OSError, match="injected source failure"):
         verified_copy_prefix(str(source), str(destination), workers=1)
     assert not (destination / COMPLETION_MANIFEST).exists()
-    assert (destination / "a.bin").read_bytes() == b"first"
+    assert not destination.exists()
+    assert Path(f"{destination}{STAGING_SUFFIX}").joinpath("a.bin").read_bytes() == b"first"
 
     monkeypatch.setattr(verified_copy_module, "filesystem_for", original_filesystem_for)
     result = verified_copy_prefix(str(source), str(destination), workers=1)
@@ -258,6 +259,65 @@ def test_verified_copy_interruption_leaves_no_completion_and_retry_resumes(tmp_p
     assert result.resumed_files == 1
     assert (destination / "b.bin").read_bytes() == b"second"
     assert (destination / COMPLETION_MANIFEST).exists()
+    assert not Path(f"{destination}{STAGING_SUFFIX}").exists()
+
+
+def test_verified_copy_interrupted_promotion_resumes_from_staging(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "a.bin").write_bytes(b"first")
+    (source / "b.bin").write_bytes(b"second")
+
+    source_filesystem, source_path = verified_copy_module.filesystem_for(str(source))
+    destination_filesystem, destination_path = verified_copy_module.filesystem_for(str(destination))
+    original_filesystem_for = verified_copy_module.filesystem_for
+
+    class FailingPromotion:
+        def __getattr__(self, name):
+            return getattr(destination_filesystem, name)
+
+        def cp_file(self, source_path, destination_path, **kwargs):
+            if destination_path.endswith("b.bin"):
+                raise OSError("injected promotion failure")
+            return destination_filesystem.cp_file(source_path, destination_path, **kwargs)
+
+    def failing_route(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
+        if url == str(destination):
+            return FailingPromotion(), destination_path
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", failing_route)
+    with pytest.raises(OSError, match="injected promotion failure"):
+        verified_copy_prefix(str(source), str(destination), workers=1)
+
+    staging = Path(f"{destination}{STAGING_SUFFIX}")
+    assert (destination / "a.bin").read_bytes() == b"first"
+    assert not (destination / "b.bin").exists()
+    assert not (staging / "a.bin").exists()
+    assert (staging / "b.bin").read_bytes() == b"second"
+    assert not (destination / COMPLETION_MANIFEST).exists()
+
+    class UnreadableSource:
+        def __getattr__(self, name):
+            return getattr(source_filesystem, name)
+
+        def open(self, _path, _mode):
+            raise AssertionError("promotion retry must reuse verified staged or published objects")
+
+    def retry_route(url, *, s3_upload_policy=S3UploadPolicy.STANDARD):
+        if url == str(source):
+            return UnreadableSource(), source_path
+        return original_filesystem_for(url, s3_upload_policy=s3_upload_policy)
+
+    monkeypatch.setattr(verified_copy_module, "filesystem_for", retry_route)
+    result = verified_copy_prefix(str(source), str(destination), workers=1)
+
+    assert result.copied_files == 0
+    assert result.resumed_files == 2
+    assert (destination / "b.bin").read_bytes() == b"second"
+    assert (destination / COMPLETION_MANIFEST).exists()
+    assert not staging.exists()
 
 
 def test_verified_copy_does_not_reuse_status_from_another_source(tmp_path):


### PR DESCRIPTION
Add `fsutil verified-copy` for publishing large multi-object artifacts across storage providers. GCS exposes CRC32C and sometimes MD5, while multipart R2 ETags encode the MD5 values of individual upload parts. The metadata therefore does not provide one checksum that can be compared directly across the two systems. An ordinary recursive copy also has no atomic prefix-level completion state: a preempted job can leave enough checkpoint files for a loader to mistake a partial checkpoint for a complete one, and a retry can mix source generations.

Bind each object to its source generation and hash source bytes while uploading to a deterministic sibling staging prefix. R2 buckets declared by Marin's storage router use fixed-size multipart uploads; the copy calculates the expected ETag from the same part boundaries and compares it with R2 metadata. Destinations without deterministic ETags are read back and checked against the source SHA-256.

After every file from the initial source listing has a verified staging record, promote objects with server-side within-destination copies using the same multipart boundaries, remove staging, and write `.verified-copy-manifest.json` last. Prefix promotion remains object-at-a-time, so consumers must check the manifest before loading the destination. Records under `<DST>.verified-copy-status` bind the source identity, path, size, SHA-256, and staging identity; retries can use them to reuse either a staged object or one already promoted before an interruption.

For the roughly 125 GiB 67B Grug model exports tracked in #8702, staging adds an internal R2 copy pass and transient duplicate storage. It adds no GCS traffic beyond the original GCS-to-R2 transfer and avoids a full client-side R2 verification read. The original transfer still incurs retail GCS egress.

Part of #8702
