### PR TITLE
[marina] Publish dynamic applets

### DIFF
--- a/.agents/skills/marina-applet/SKILL.md
+++ b/.agents/skills/marina-applet/SKILL.md
@@ -80,20 +80,20 @@ Respect the current package limits: 25 MiB total, 8 MiB per file, and 2,000
 regular files. Keep large data out of the package until Marina gains an object
 store path.
 
-For an end-to-end local check, configure Postgres, migrate Marina, start the
-server, and publish to loopback:
+Run the complete local stack with:
 
 ```bash
-MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina migrate
-MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina dev
-uv run marina publish my-applet --url http://127.0.0.1:8080
+uv run marina publish my-applet --local
 ```
 
-Use Postgres with the `vector` and `pg_trgm` extensions. The migration identity
-must have `CREATEROLE`, or an administrator must have installed
-`marina.provision_applet(uuid)` first. If `uv` cannot write its cache in a
-restricted checkout, use the current checkout's `.venv/bin/marina` executable
-instead of installing or synchronizing dependencies.
+This starts disposable Postgres in Docker, installs Marina's privileged applet
+provisioning, migrates the registry, starts Marina on a free loopback port,
+publishes the applet with its migration, and prints its immutable revision URL.
+It requires a running Docker daemon, binds only to loopback, and does not enable
+IAP authentication. It stays in the foreground. After validation, send Ctrl-C
+and verify that both Marina and the container stop. If `uv` cannot write its
+cache in a restricted checkout, use the current checkout's `.venv/bin/marina`
+executable instead of installing or synchronizing dependencies.
 
 Open the printed immutable revision URL. Exercise the frontend, every backend
 route, caller identity when used, and at least one schema read/write path. For

--- a/.agents/skills/marina-applet/SKILL.md
+++ b/.agents/skills/marina-applet/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: marina-applet
+description: Build, validate, publish, update, inspect, query, roll back, or archive a dynamic Marina applet. Use for Artifact+-style web apps that should run behind Marina authentication, carry small bundled assets or data, use an applet-owned Postgres schema, or add a trusted Python ASGI backend without a Marina image deployment.
+---
+
+# Work with Marina applets
+
+Read the `Publishing an applet` section of `infra/marina/README.md` before
+changing an applet or publishing one. Use
+`infra/marina/examples/problem-set-applet/` as the minimal working package and
+backend reference. Treat those files and `marina --help` as authoritative when
+this skill disagrees with the checkout.
+
+## Choose the applet shape
+
+Ensure the built package contains:
+
+```text
+my-applet/
+  applet.toml
+  dist/index.html
+```
+
+Add browser assets below `dist/`. Use only relative asset, API, and query URLs
+so both `/a/<uuid>/` and `/a/<uuid>/v/<revision>/` work.
+
+The source directory may omit `dist/index.html` only when `applet.toml` has a
+`build_command` that creates it before packaging.
+
+Use the applet's implicit Postgres schema for mutable or queryable data. Do not
+create or attach a separate database. Load simple scalar tables with the CLI,
+or add `server/` when the applet needs parameterized business logic, custom
+responses, or server-side integration.
+
+An optional backend has this shape:
+
+```text
+my-applet/
+  server/__init__.py
+  server/app.py
+```
+
+Declare it in `applet.toml`:
+
+```toml
+title = "Problem sets"
+description = "Browse generated math problem sets."
+python_entrypoint = "server.app:create_api"
+```
+
+Export `create_api(services) -> ASGIApp`. Use `services.engine()` for an engine
+configured with the applet role and schema. Optionally export
+`migrate(connection) -> None`; it runs inside the publish transaction before
+the new revision becomes current. Keep schema changes compatible with retained
+revisions.
+
+Use `get_verified_identity()` from `rigging.server_auth` when a backend needs
+the authenticated caller. Import only packages already declared in
+`infra/marina/pyproject.toml`.
+
+Treat Python applets as trusted plugins. They run inside Marina with its
+filesystem, network, credentials, and process identity. Do not publish code
+from an untrusted source or depend on lifespan events, background workers, or
+local filesystem persistence.
+
+## Build and validate
+
+Inspect existing Marina and repository helpers before introducing a framework
+or dependency. Build frontend output locally; Marina does not install applet
+dependencies. A manifest `build_command` may create `dist/index.html` when
+`marina publish` runs with its default `--build` behavior.
+
+Validate the exact package without changing server state:
+
+```bash
+uv run marina publish my-applet --dry-run
+```
+
+Respect the current package limits: 25 MiB total, 8 MiB per file, and 2,000
+regular files. Keep large data out of the package until Marina gains an object
+store path.
+
+For an end-to-end local check, configure Postgres, migrate Marina, start the
+server, and publish to loopback:
+
+```bash
+MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina migrate
+MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina dev
+uv run marina publish my-applet --url http://127.0.0.1:8080
+```
+
+Use Postgres with the `vector` and `pg_trgm` extensions. The migration identity
+must have `CREATEROLE`, or an administrator must have installed
+`marina.provision_applet(uuid)` first. If `uv` cannot write its cache in a
+restricted checkout, use the current checkout's `.venv/bin/marina` executable
+instead of installing or synchronizing dependencies.
+
+Open the printed immutable revision URL. Exercise the frontend, every backend
+route, caller identity when used, and at least one schema read/write path. For
+Marina code changes, run the focused tests and then:
+
+```bash
+cd infra/marina && uv run pytest
+```
+
+## Use applet data
+
+The applet role owns `applet_<uuid-without-hyphens>` and inherits read access to
+checked-in and other applet schemas. It can write only its own schema. Prefer
+the CLI for small datasets:
+
+```bash
+uv run marina applets table load <uuid> observations rows.parquet --replace
+uv run marina applets sql <uuid> 'SELECT * FROM observations'
+```
+
+Table loading accepts JSON arrays, JSONL, CSV, and Parquet with scalar columns.
+Browser code may post one SQLAlchemy text statement to relative URL `query`.
+Query results are limited in Postgres to 10,000 rows and 5 MiB with a 10-second
+timeout. Transaction and role-control commands, data-modifying `WITH`, and
+mutation statements with `RETURNING` are rejected.
+
+Prefer a Python backend over browser-submitted SQL when inputs need validation,
+authorization, stable response types, or multiple database operations.
+
+## Publish and operate
+
+Run a command that changes server state only when the user explicitly requests
+that external write. This includes first or update publish, table load,
+mutating SQL, rollback, and archive. The default target is
+`https://marina.oa.dev`, and the CLI uses cached `iris login` credentials or
+ambient Google credentials through IAP.
+
+First publish:
+
+```bash
+uv run marina publish my-applet --json
+```
+
+Record the returned UUID, revision, and immutable revision URL. A successful
+publish runs its migration and atomically selects the new revision as current.
+Fetch the stable current URL with:
+
+```bash
+uv run marina applets versions <uuid> --json
+```
+
+Update the same applet with optimistic concurrency:
+
+```bash
+uv run marina publish my-applet --update <uuid> --base-version <current>
+```
+
+Inspect before mutating lifecycle state:
+
+```bash
+uv run marina applets list
+uv run marina applets versions <uuid>
+```
+
+Roll back only to a retained revision:
+
+```bash
+uv run marina applets rollback <uuid> <revision>
+```
+
+Archive an applet with:
+
+```bash
+uv run marina applets archive <uuid>
+```
+
+Archival hides the applet but preserves its schema and retained revisions.
+Marina retains the current revision plus four other recent revisions.
+
+Report the applet UUID, stable URL, immutable revision URL, validation or test
+results, and any trusted-code or schema-compatibility caveat that affects use.

--- a/.agents/skills/marina-applet/agents/openai.yaml
+++ b/.agents/skills/marina-applet/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Marina Applets"
+  short_description: "Build and operate dynamic Marina applets"
+  default_prompt: "Use $marina-applet to build and validate a Marina applet, then publish it when authorized."

--- a/infra/marina/Pulumi.marin-marina.yaml
+++ b/infra/marina/Pulumi.marin-marina.yaml
@@ -1,6 +1,6 @@
 secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 encryptedkey: CiQAKk3j6QtTcc6Iec1XdmlHLA8ymrMXsDFl0jYtcfyWvoS+GysSSQCdtF6i+DeIDDdGiUGfJ9nyAG+rmhGx03VSZETlYvqY9jnZlgulAJm7gQH7M2RdK5ngnYgIdqVXupwxIfj+6hAjc9NGVQI+UDs=
 config:
-  # The oa.dev Cloudflare zone: marina, echo and evaldash CNAMEs are created there and the
-  # three hosts are mapped to the service. Unset to serve only the run.app URL.
+  # The oa.dev Cloudflare zone: marina, applets, echo and evaldash CNAMEs are created there
+  # and mapped to the service. Unset to serve only the run.app URL.
   marin-marina:dns_zone_id: 169959d6aafcbfd77764b8efafa3a509

--- a/infra/marina/README.md
+++ b/infra/marina/README.md
@@ -274,19 +274,26 @@ lifespan events, background workers, or local filesystem persistence.
 Migrations must remain compatible with retained backend revisions because every
 revision observes the same mutable schema.
 
-For local development, configure Postgres, create the registry, and run Marina
-before publishing to the loopback URL:
+For an end-to-end local run:
 
 ```bash
-MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina migrate
-MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina dev
-uv run marina publish infra/marina/examples/problem-set-applet \
-  --url http://127.0.0.1:8080
+uv run marina publish infra/marina/examples/problem-set-applet --local
 ```
 
+`--local` starts a disposable `pgvector/pgvector` Docker container, installs the
+applet provisioning function and Marina registry, starts Marina on a free
+loopback port, runs the applet migration through a normal publish, and prints
+the immutable revision URL. It remains in the foreground so the URL stays live.
+It requires a running Docker daemon, binds only to loopback, and does not enable
+IAP authentication. Ctrl-C stops Marina and removes the container. `--local`
+cannot be combined with `--dry-run`, `--update`, or `--base-version` because
+every run starts with an empty registry.
+
 Open the printed revision URL to exercise the exact published frontend and
-backend. Run `marina applets versions <uuid> --url http://127.0.0.1:8080`
-before choosing a rollback target.
+backend. Use `marina publish ... --url http://127.0.0.1:8080` instead when
+attaching to a separately managed local Marina server. Run
+`marina applets versions <uuid> --url http://127.0.0.1:8080` before choosing a
+rollback target on that persistent server.
 
 On local Postgres, `marina migrate` installs the provisioning function when the
 configured database user has `CREATEROLE`. In production the Marina Pulumi

--- a/infra/marina/README.md
+++ b/infra/marina/README.md
@@ -230,8 +230,10 @@ statement and an optional parameter object. Statements run as the applet's
 generated Postgres role with its schema first on `search_path`. The role owns
 that schema and inherits `marina_reader`, which can select from checked-in and
 other applet schemas. It cannot write outside its own schema. Transaction and
-role-control commands are rejected. Responses are limited to 10,000 rows and
-5 MiB, with a 10-second statement timeout.
+role-control commands, data-modifying `WITH`, and mutation statements with
+`RETURNING` are rejected. Postgres bounds query results before sending them to
+the Marina process. Responses are limited to 10,000 rows and 5 MiB, with a
+10-second statement timeout.
 
 Agents can inspect applets, query them, and load small tables without writing an
 API backend:

--- a/infra/marina/README.md
+++ b/infra/marina/README.md
@@ -1,11 +1,8 @@
 # Marina
 
-One Cloud Run service that hosts Marin's small internal web apps. An app is a
-directory under `apps/` with an `app.toml` and a `web/` frontend, and optionally
-a Python package with an API. The kernel in `src/marina` discovers every app at
-startup and serves each one under `/<name>/` on a single IAP-gated origin. What
-an app would otherwise rebuild for itself lives in the kernel and the shared kit
-in `web/`: login, a database, a data bucket, deployment, a top bar, and a
+One Cloud Run service that hosts Marin's small internal web apps. Checked-in
+apps live under `apps/`; dynamic applets are uploaded with `marina publish` and
+stored in Postgres. Both use the same IAP login, database, app directory, and
 browser test harness.
 
 ## Layout
@@ -16,6 +13,7 @@ infra/marina/
   web/             the shared Vue kit apps import as @marina (tokens, Shell, Prose)
   apps/<name>/     one app: app.toml, web/, dist/ after a build, and for Python
                    apps an app.py with create_api() and migrate(), tests/, journeys/
+  examples/        applet packages that can be published to a running Marina
   .data/<app>/     the local data root (gitignored); gs://marin-marina in production
   Dockerfile       node stage builds every apps/*/web; python stage runs `marina serve`
   __main__.py      Pulumi: database, bucket, the service, and manifest-declared job runners
@@ -128,6 +126,12 @@ prefix on the canonical origin. The auth chain is IAP's signed assertion header
 when an audience is configured, then loopback; on Cloud Run a missing audience
 is a startup error rather than an open service.
 
+`MARINA_APPLET_ORIGIN` names the separate origin that serves `/a/*`. Requests
+for applet pages on Marina's main host redirect there. The applet host returns
+404 for checked-in apps and Marina control routes. `MARINA_APPLET_OPERATORS` is
+a comma-separated set of user IDs allowed to update, roll back, or archive any
+applet; otherwise only the recorded owner may do so.
+
 ## Deploying
 
 ```bash
@@ -161,6 +165,132 @@ Data under the bucket is uploaded by hand when an app's files change:
 ```bash
 gsutil -m rsync -r infra/marina/.data/tasktrove gs://marin-marina/tasktrove
 ```
+
+## Publishing an applet
+
+An applet is a small application uploaded without rebuilding Marina. Its UUID
+is stable; each publish creates a numbered revision. Every applet gets a
+Postgres schema and role named `applet_<uuid>` on its first publish. Production
+URLs use `https://applets.marina.oa.dev/a/<uuid>/` so uploaded JavaScript does
+not share an origin with checked-in apps or Marina's control API.
+
+```text
+my-applet/
+  applet.toml
+  dist/index.html
+  server/__init__.py       # optional
+  server/app.py            # optional
+```
+
+The manifest names the applet and, when present, its Python entry point:
+
+```toml
+title = "Problem sets"
+description = "Browse generated math problem sets."
+python_entrypoint = "server.app:create_api"
+```
+
+Publish a built directory:
+
+```bash
+uv run marina publish infra/marina/examples/problem-set-applet
+```
+
+The production target defaults to `https://marina.oa.dev`. The client uses the
+same cached `iris login` credentials or ambient Google service-account
+credentials as the other Marina CLIs; the caller needs IAP access to Marina.
+On the first publish the server generates the stable UUID and records the IAP
+identity's `user_id` as owner. `MARINA_APPLET_OPERATORS` is a comma-separated
+list of those exact user IDs (normally email addresses in production).
+
+The command prints the immutable revision URL under
+`https://applets.marina.oa.dev/a/<uuid>/v/<revision>/`. A successful publish
+runs the migration and then atomically changes the stable current URL,
+`https://applets.marina.oa.dev/a/<uuid>/`, to that revision. To update the same
+applet, pass both the UUID and the current revision:
+
+```bash
+uv run marina publish my-applet --update <uuid> --base-version 1
+```
+
+`--dry-run` validates and lists the package without sending it. Packages are
+limited to 25 MiB, 8 MiB per file, and 2,000 regular files. Web files and Python
+source are stored as inline blobs in Postgres and deduplicated by digest and
+media type. Marina retains the current revision plus four other recent
+revisions and removes blobs that no retained revision references.
+
+Frontend assets must use relative URLs so they work below both the stable and
+revision prefixes. From a revision page, `fetch("api/problems")` calls that
+revision's Python backend and `fetch("query", {method: "POST", ...})` runs a
+query for the applet. Marina falls back to `index.html` only for paths accepted
+as HTML; missing asset paths remain 404.
+
+Every applet has `POST /a/<uuid>/query`, which accepts one SQLAlchemy text
+statement and an optional parameter object. Statements run as the applet's
+generated Postgres role with its schema first on `search_path`. The role owns
+that schema and inherits `marina_reader`, which can select from checked-in and
+other applet schemas. It cannot write outside its own schema. Transaction and
+role-control commands are rejected. Responses are limited to 10,000 rows and
+5 MiB, with a 10-second statement timeout.
+
+Agents can inspect applets, query them, and load small tables without writing an
+API backend:
+
+```bash
+uv run marina applets list
+uv run marina applets versions <uuid>
+uv run marina applets sql <uuid> 'SELECT * FROM problems'
+uv run marina applets table load <uuid> observations rows.parquet --replace
+uv run marina applets rollback <uuid> 2
+uv run marina applets archive <uuid>
+```
+
+Table loading accepts JSON arrays, JSONL, CSV, and Parquet with scalar columns.
+The `marina.applet_catalog` view records active applets and the tables and
+columns visible in their schemas.
+
+A Python applet exports `create_api(services) -> ASGIApp` and may export
+`migrate(connection) -> None`. `services` is an `AppletServices`; its
+`engine()` method returns a SQLAlchemy `Engine` configured for the applet role
+and schema. The migration receives a SQLAlchemy `Connection` inside the publish
+transaction, so an exception leaves the old revision current and rolls back its
+database changes. Before publishing, Marina imports the module in a
+short-lived subprocess with environment credentials removed and verifies that
+the declared factory and migration are callable. The server imports the
+revision again under a unique module name, runs its migration as the applet
+database role before activation, and serves its ASGI application at the
+revision and current `/api/` paths. Applets may import only dependencies already
+installed by `infra/marina/pyproject.toml`; publishing does not install packages.
+A worker caches a failed runtime load and returns 503 for that revision. Publish
+a corrected revision or roll back to a retained revision to bypass that cache;
+retrying the same broken revision requires replacing or restarting the worker.
+
+`services.engine()` assumes the applet role and schema. Python applets still run
+inside the Marina process with its installed dependencies, service credentials,
+filesystem, and network access. They are trusted plugins. They must not require
+lifespan events, background workers, or local filesystem persistence.
+Migrations must remain compatible with retained backend revisions because every
+revision observes the same mutable schema.
+
+For local development, configure Postgres, create the registry, and run Marina
+before publishing to the loopback URL:
+
+```bash
+MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina migrate
+MARINA_DATABASE_URL=postgresql+pg8000://... uv run marina dev
+uv run marina publish infra/marina/examples/problem-set-applet \
+  --url http://127.0.0.1:8080
+```
+
+Open the printed revision URL to exercise the exact published frontend and
+backend. Run `marina applets versions <uuid> --url http://127.0.0.1:8080`
+before choosing a rollback target.
+
+On local Postgres, `marina migrate` installs the provisioning function when the
+configured database user has `CREATEROLE`. In production the Marina Pulumi
+stack runs `infra/marina/database_grants.py` as the Cloud SQL administrator,
+then starts the migration job. The service account can execute that function
+but does not need unrestricted role creation.
 
 ## Tests
 

--- a/infra/marina/__main__.py
+++ b/infra/marina/__main__.py
@@ -19,7 +19,8 @@ Vanity hosts: the apps are served from ``marina.oa.dev``. ``echo.oa.dev`` and
 ``evaldash.oa.dev`` map to the same service. Legacy API paths route to the corresponding
 app without a redirect; pages redirect to ``marina.oa.dev/echo/`` or
 ``marina.oa.dev/evaldash/`` with their path, so old links keep resolving and one origin
-holds the apps.
+holds the checked-in apps. ``applets.marina.oa.dev`` maps to the service but the kernel
+exposes only dynamic applet routes on that host.
 """
 
 from pathlib import Path
@@ -54,8 +55,10 @@ MARINMIRROR_TOKEN_SECRET = "marinmirror-token"
 CLOUD_RUN_FRONTEND = "ghs.googlehosted.com"
 HOST_APPS = {"echo.oa.dev": "echo", "evaldash.oa.dev": "evaldash"}
 MARINA_HOST = "marina.oa.dev"
+APPLET_HOST = "applets.marina.oa.dev"
 GRANTS_SCRIPT = Path(__file__).parent / "database_grants.py"
 APPS_DIR = Path(__file__).parent / "apps"
+DATABASE_SETUP_SCRIPT = Path(__file__).parent / "src" / "marina" / "database_setup.py"
 
 DATABASE_ENV = {"CLOUDSQL_CONNECTION": CONNECTION_NAME, "PGDATABASE": DATABASE, "PGUSER": DATABASE_USER}
 
@@ -116,6 +119,9 @@ def job_template(
 
 def main() -> None:
     config = pulumi.Config()
+    applet_operators = config.get_object("applet_operators") or []
+    if not isinstance(applet_operators, list) or not all(isinstance(item, str) for item in applet_operators):
+        raise ValueError("marin-marina:applet_operators must be a list of user IDs")
     gcp_provider = gcp.Provider("gcp", project=PROJECT)
     child = pulumi.ResourceOptions(provider=gcp_provider)
 
@@ -183,7 +189,7 @@ def main() -> None:
     grants = command.local.Command(
         "database-grants",
         create=f"uv run {GRANTS_SCRIPT}",
-        triggers=[GRANTS_SCRIPT.read_text()],
+        triggers=[GRANTS_SCRIPT.read_text(), DATABASE_SETUP_SCRIPT.read_text()],
         environment={"GOOGLE_CLOUD_QUOTA_PROJECT": PROJECT},
         opts=pulumi.ResourceOptions(depends_on=[database_user, loom_user, reader_group, database, codehealth_database]),
     )
@@ -247,6 +253,8 @@ def main() -> None:
                 "MARINA_DATA_ROOT": f"gs://{DATA_BUCKET}",
                 "MARINA_HOST_APPS": ",".join(f"{host}={app}" for host, app in HOST_APPS.items()),
                 "MARINA_CANONICAL_ORIGIN": f"https://{MARINA_HOST}",
+                "MARINA_APPLET_ORIGIN": f"https://{APPLET_HOST}",
+                "MARINA_APPLET_OPERATORS": ",".join(applet_operators),
                 **DATABASE_ENV,
                 **runner_env,
             },
@@ -272,7 +280,7 @@ def main() -> None:
     # server-set metadata, so those fields are ignored. Set marin-marina:dns_zone_id to enable.
     dns_zone_id = config.get("dns_zone_id")
     if dns_zone_id:
-        for host in (MARINA_HOST, *HOST_APPS):
+        for host in (MARINA_HOST, APPLET_HOST, *HOST_APPS):
             slug = host.split(".")[0]
             gcp.cloudrun.DomainMapping(
                 f"{slug}-domain",

--- a/infra/marina/apps/conftest.py
+++ b/infra/marina/apps/conftest.py
@@ -1,14 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Journeys under apps/*/journeys use the kernel and browser fixtures; unit tests under
-# apps/*/tests share the throwaway database.
-pytest_plugins = ["marina.journey_plugin"]
+# Unit tests under apps/*/tests share the throwaway database.
+from collections.abc import Iterator
 
-from collections.abc import Iterator  # noqa: E402
-
-import pytest  # noqa: E402
-from marina.testing import test_database  # noqa: E402
+import pytest
+from marina.testing import test_database
 
 
 @pytest.fixture(scope="session")

--- a/infra/marina/conftest.py
+++ b/infra/marina/conftest.py
@@ -1,0 +1,5 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Journeys under apps/*/journeys use the kernel and browser fixtures.
+pytest_plugins = ["marina.journey_plugin"]

--- a/infra/marina/database_grants.py
+++ b/infra/marina/database_grants.py
@@ -6,10 +6,10 @@
 Run by the Pulumi program after the databases and IAM users exist, as the native
 ``pulumi_db_admin`` user whose password lives in Secret Manager. A Cloud SQL IAM user can
 connect but cannot create schemas, so the Marina service account gets every privilege on
-the ``marina`` database (each app's schema is created and owned by it from there), and the
-Loom VM gets CREATE on ``context``'s public schema for the codehealth workbench tables.
-It also installs the pgvector extension Echo needs, which only the Cloud SQL superuser may
-do. Every statement is idempotent.
+the ``marina`` database. This script also installs the restricted function that creates
+one role and schema for a generated applet UUID. The Loom VM gets CREATE on ``context``'s
+public schema for the codehealth workbench tables. It also installs the pgvector extension
+Echo needs, which only the Cloud SQL superuser may do. Every statement is idempotent.
 
     uv run infra/marina/database_grants.py
 """
@@ -18,16 +18,19 @@ import subprocess
 
 import sqlalchemy
 from google.cloud.sql.connector import Connector
+from marina.database_setup import applet_provisioning_statements
 
 PROJECT = "hai-gcp-models"
 CONNECTION_NAME = f"{PROJECT}:us-central1:marin-metadata"
 ADMIN_USER = "pulumi_db_admin"
 ADMIN_PASSWORD_SECRET = "cloudsql-pulumi-admin-password"
+MARINA_SERVICE_ROLE = "marina@hai-gcp-models.iam"
 GRANTS = {
     "marina": [
-        'GRANT ALL PRIVILEGES ON DATABASE marina TO "marina@hai-gcp-models.iam"',
+        f'GRANT ALL PRIVILEGES ON DATABASE marina TO "{MARINA_SERVICE_ROLE}"',
         # Only the Cloud SQL superuser can install extensions; Echo's search needs pgvector.
         "CREATE EXTENSION IF NOT EXISTS vector",
+        *applet_provisioning_statements(MARINA_SERVICE_ROLE),
     ],
     "context": ['GRANT CREATE ON SCHEMA public TO "loom-vm@hai-gcp-models.iam"'],
 }

--- a/infra/marina/examples/problem-set-applet/applet.toml
+++ b/infra/marina/examples/problem-set-applet/applet.toml
@@ -1,0 +1,3 @@
+title = "Problem sets"
+description = "Browse a small collection of generated arithmetic problems."
+python_entrypoint = "server.app:create_api"

--- a/infra/marina/examples/problem-set-applet/dist/app.js
+++ b/infra/marina/examples/problem-set-applet/dist/app.js
@@ -1,0 +1,7 @@
+fetch('api/problems')
+  .then((response) => response.json())
+  .then((problems) => {
+    document.querySelector('#problems').innerHTML = problems
+      .map((problem) => `<li><code>${problem.prompt}</code></li>`)
+      .join('')
+  })

--- a/infra/marina/examples/problem-set-applet/dist/index.html
+++ b/infra/marina/examples/problem-set-applet/dist/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Problem sets</title>
+    <style>
+      body { font: 16px/1.5 system-ui, sans-serif; max-width: 46rem; margin: 3rem auto; padding: 0 1rem; }
+      li { margin: 0.75rem 0; }
+      code { background: #eee; padding: 0.15rem 0.35rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Problem sets</h1>
+    <p>This page and its Python API were published as one Marina applet.</p>
+    <ol id="problems"><li>Loading…</li></ol>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/infra/marina/examples/problem-set-applet/server/__init__.py
+++ b/infra/marina/examples/problem-set-applet/server/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/infra/marina/examples/problem-set-applet/server/app.py
+++ b/infra/marina/examples/problem-set-applet/server/app.py
@@ -1,0 +1,43 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small dynamic backend used by the Marina applet example."""
+
+from fastapi import FastAPI
+from marina.applets import AppletServices
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+def migrate(connection: Connection) -> None:
+    connection.execute(
+        text(
+            "CREATE TABLE IF NOT EXISTS problems ("
+            "id INTEGER PRIMARY KEY, prompt TEXT NOT NULL, answer INTEGER NOT NULL)"
+        )
+    )
+    connection.execute(
+        text(
+            "INSERT INTO problems (id, prompt, answer) VALUES "
+            "(1, '12 * 7', 84), (2, '144 ÷ 12', 12), (3, '19 + 28', 47) "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+    )
+
+
+def create_api(services: AppletServices) -> FastAPI:
+    api = FastAPI()
+    engine = services.engine()
+
+    @api.get("/problems")
+    def problems() -> list[dict[str, object]]:
+        with engine.connect() as connection:
+            return [
+                dict(row) for row in connection.execute(text("SELECT id, prompt FROM problems ORDER BY id")).mappings()
+            ]
+
+    @api.get("/revision")
+    def revision() -> dict[str, int]:
+        return {"version": services.version}
+
+    return api

--- a/infra/marina/examples/problem-set-applet/server/app.py
+++ b/infra/marina/examples/problem-set-applet/server/app.py
@@ -5,6 +5,7 @@
 
 from fastapi import FastAPI
 from marina.applets import AppletServices
+from rigging.server_auth import get_verified_identity
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
@@ -39,5 +40,10 @@ def create_api(services: AppletServices) -> FastAPI:
     @api.get("/revision")
     def revision() -> dict[str, int]:
         return {"version": services.version}
+
+    @api.get("/identity")
+    def identity() -> dict[str, str | None]:
+        caller = get_verified_identity()
+        return {"user": caller.user_id if caller is not None else None}
 
     return api

--- a/infra/marina/src/marina/applet_validator.py
+++ b/infra/marina/src/marina/applet_validator.py
@@ -1,0 +1,27 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Subprocess entry point that imports one proposed applet backend."""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: python -m marina.applet_validator MODULE_ROOT MODULE:FACTORY")
+    module_root = Path(sys.argv[1]).resolve()
+    module_path, factory_name = sys.argv[2].split(":", 1)
+    sys.path.insert(0, str(module_root.parent))
+    module = importlib.import_module(f"{module_root.name}.{module_path}")
+    factory = getattr(module, factory_name)
+    if not callable(factory):
+        raise TypeError(f"{factory_name} is not callable")
+    migration = getattr(module, "migrate", None)
+    if migration is not None and not callable(migration):
+        raise TypeError("migrate is not callable")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/marina/src/marina/applets.py
+++ b/infra/marina/src/marina/applets.py
@@ -1,0 +1,853 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamic Marina applets: packages, persistence, data, and Python backends."""
+
+import hashlib
+import importlib
+import io
+import json
+import mimetypes
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import tomllib
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+from starlette.types import ASGIApp
+
+from marina.database_setup import APPLET_READER_ROLE, PROVISION_APPLET_FUNCTION
+from marina.db import DatabaseSpec, engine_for, engine_for_role
+
+APPLET_MANIFEST = "applet.toml"
+DIST_PREFIX = "dist/"
+SERVER_PREFIX = "server/"
+INDEX_FILE = "dist/index.html"
+MAX_PACKAGE_BYTES = 25 * 1024 * 1024
+MAX_ARCHIVE_BYTES = 30 * 1024 * 1024
+MAX_FILE_BYTES = 8 * 1024 * 1024
+MAX_FILES = 2_000
+QUERY_TIMEOUT_MS = 10_000
+MAX_QUERY_ROWS = 10_000
+MAX_QUERY_RESPONSE_BYTES = 5 * 1024 * 1024
+MAX_REVISIONS = 5
+BACKEND_VALIDATION_TIMEOUT = 15
+KNOWN_MANIFEST_KEYS = frozenset({"title", "description", "connect_src", "build_command", "python_entrypoint"})
+ENTRYPOINT_PATTERN = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
+BACKEND_CACHE_ROOT = Path(tempfile.gettempdir()) / "marina-applet-backends"
+
+
+class AppletNotFound(Exception):
+    pass
+
+
+class AppletConflict(Exception):
+    pass
+
+
+class AppletForbidden(Exception):
+    pass
+
+
+class QueryLimitExceeded(Exception):
+    pass
+
+
+class InvalidQuery(Exception):
+    pass
+
+
+class AppletBackendUnavailable(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class AppletManifest:
+    title: str
+    description: str
+    connect_src: tuple[str, ...] = ()
+    build_command: str | None = None
+    python_entrypoint: str | None = None
+
+
+@dataclass(frozen=True)
+class AppletPackage:
+    manifest: AppletManifest
+    files: dict[str, bytes]
+    digest: bytes
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class AppletSummary:
+    id: uuid.UUID
+    title: str
+    description: str
+    owner: str
+    current_version: int
+
+    @property
+    def path(self) -> str:
+        return f"/a/{self.id}/"
+
+
+@dataclass(frozen=True)
+class AppletVersion:
+    applet_id: uuid.UUID
+    version: int
+    manifest: AppletManifest
+    digest: bytes
+
+
+@dataclass(frozen=True)
+class AppletVersionSummary:
+    version: int
+    published_by: str
+    published_at: datetime
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class StoredFile:
+    body: bytes
+    media_type: str
+    digest: bytes
+    content_encoding: str | None = None
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    applet_id: uuid.UUID
+    version: int
+
+    @property
+    def path(self) -> str:
+        return f"/a/{self.applet_id}/v/{self.version}/"
+
+
+def parse_applet_manifest(content: bytes) -> AppletManifest:
+    """Parse an applet manifest and reject fields the publisher would otherwise ignore."""
+    try:
+        raw = tomllib.loads(content.decode())
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"invalid {APPLET_MANIFEST}: {error}") from error
+    unknown = set(raw) - KNOWN_MANIFEST_KEYS
+    if unknown:
+        raise ValueError(f"{APPLET_MANIFEST}: unknown keys {sorted(unknown)}")
+    for field in ("title", "description"):
+        if not isinstance(raw.get(field), str) or not raw[field].strip():
+            raise ValueError(f"{APPLET_MANIFEST}: {field!r} must be a non-empty string")
+    connect_src = raw.get("connect_src", [])
+    if not isinstance(connect_src, list) or not all(isinstance(item, str) for item in connect_src):
+        raise ValueError(f"{APPLET_MANIFEST}: 'connect_src' must be a list of strings")
+    if any(not item or any(character.isspace() or character == ";" for character in item) for item in connect_src):
+        raise ValueError(f"{APPLET_MANIFEST}: connect_src entries must be single CSP source expressions")
+    for optional in ("build_command", "python_entrypoint"):
+        if optional in raw and not isinstance(raw[optional], str):
+            raise ValueError(f"{APPLET_MANIFEST}: {optional!r} must be a string")
+    entrypoint = raw.get("python_entrypoint")
+    if entrypoint is not None and not ENTRYPOINT_PATTERN.fullmatch(entrypoint):
+        raise ValueError(f"{APPLET_MANIFEST}: invalid python_entrypoint {entrypoint!r}")
+    return AppletManifest(
+        title=raw["title"].strip(),
+        description=raw["description"].strip(),
+        connect_src=tuple(connect_src),
+        build_command=raw.get("build_command"),
+        python_entrypoint=entrypoint,
+    )
+
+
+def _clean_package_path(name: str) -> str:
+    stripped = name.removeprefix("./")
+    path = PurePosixPath(stripped)
+    if not stripped or path.is_absolute() or "\\" in stripped or any(part in ("", ".", "..") for part in path.parts):
+        raise ValueError(f"unsafe package path {name!r}")
+    return path.as_posix()
+
+
+def _validate_package_files(files: dict[str, bytes]) -> AppletPackage:
+    if APPLET_MANIFEST not in files:
+        raise ValueError(f"package has no {APPLET_MANIFEST}")
+    if INDEX_FILE not in files:
+        raise ValueError(f"package has no {INDEX_FILE}")
+    manifest = parse_applet_manifest(files[APPLET_MANIFEST])
+    for path in files:
+        if path == APPLET_MANIFEST or path.startswith(DIST_PREFIX):
+            continue
+        if path.startswith(SERVER_PREFIX) and path.endswith(".py"):
+            continue
+        raise ValueError(f"package entry {path!r} is outside applet.toml, dist/, or Python files under server/")
+    if manifest.python_entrypoint is not None:
+        module, _factory = manifest.python_entrypoint.split(":", 1)
+        module_file = module.replace(".", "/") + ".py"
+        package_file = module.replace(".", "/") + "/__init__.py"
+        if module_file not in files and package_file not in files:
+            raise ValueError(f"python_entrypoint module {module!r} is absent from the package")
+        if not module.startswith("server"):
+            raise ValueError("python_entrypoint must name a module under server/")
+    digest = hashlib.sha256()
+    for path, body in sorted(files.items()):
+        digest.update(path.encode())
+        digest.update(b"\0")
+        digest.update(body)
+        digest.update(b"\0")
+    return AppletPackage(manifest=manifest, files=files, digest=digest.digest(), byte_size=sum(map(len, files.values())))
+
+
+def read_applet_package(payload: bytes) -> AppletPackage:
+    """Validate and unpack an applet tarball without writing uploaded paths to disk."""
+    files: dict[str, bytes] = {}
+    total = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:*") as archive:
+            for member in archive:
+                if member.isdir():
+                    continue
+                if not member.isreg():
+                    raise ValueError(f"package entry {member.name!r} is not a regular file")
+                if len(files) >= MAX_FILES:
+                    raise ValueError(f"package contains more than {MAX_FILES} files")
+                path = _clean_package_path(member.name)
+                if path in files:
+                    raise ValueError(f"package contains duplicate path {path!r}")
+                if member.size > MAX_FILE_BYTES:
+                    raise ValueError(f"package entry {path!r} exceeds {MAX_FILE_BYTES} bytes")
+                total += member.size
+                if total > MAX_PACKAGE_BYTES:
+                    raise ValueError(f"package exceeds {MAX_PACKAGE_BYTES} bytes")
+                extracted = archive.extractfile(member)
+                assert extracted is not None
+                body = extracted.read(MAX_FILE_BYTES + 1)
+                if len(body) != member.size:
+                    raise ValueError(f"package entry {path!r} has an invalid size")
+                files[path] = body
+    except tarfile.TarError as error:
+        raise ValueError(f"invalid applet archive: {error}") from error
+    return _validate_package_files(files)
+
+
+def package_applet(app_dir: Path) -> bytes:
+    """Build the validated tarball sent by ``marina publish``."""
+    paths = [app_dir / APPLET_MANIFEST]
+    for directory in (app_dir / "dist", app_dir / "server"):
+        if directory.exists():
+            paths.extend(path for path in sorted(directory.rglob("*")) if not path.is_dir())
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for path in paths:
+            if path.is_symlink() or not path.is_file():
+                raise ValueError(f"package entry {path} is not a regular file")
+            archive.add(path, arcname=path.relative_to(app_dir).as_posix(), recursive=False)
+    payload = buffer.getvalue()
+    read_applet_package(payload)
+    return payload
+
+
+def applet_schema(applet_id: uuid.UUID) -> str:
+    return f"applet_{applet_id.hex}"
+
+
+def applet_role(applet_id: uuid.UUID) -> str:
+    return applet_schema(applet_id)
+
+
+def _manifest_json(manifest: AppletManifest) -> str:
+    return json.dumps(
+        {
+            "title": manifest.title,
+            "description": manifest.description,
+            "connect_src": list(manifest.connect_src),
+            "build_command": manifest.build_command,
+            "python_entrypoint": manifest.python_entrypoint,
+        }
+    )
+
+
+def _manifest_from_json(value: dict[str, object]) -> AppletManifest:
+    connect_src = value.get("connect_src", [])
+    assert isinstance(connect_src, list)
+    return AppletManifest(
+        title=str(value["title"]),
+        description=str(value["description"]),
+        connect_src=tuple(str(item) for item in connect_src),
+        build_command=str(value["build_command"]) if value.get("build_command") is not None else None,
+        python_entrypoint=str(value["python_entrypoint"]) if value.get("python_entrypoint") is not None else None,
+    )
+
+
+class AppletStore:
+    """Postgres-backed registry and inline blob store for dynamic applets."""
+
+    def __init__(self, database: DatabaseSpec):
+        self.database = database
+        self.engine = engine_for(database, "marina")
+
+    def migrate(self) -> None:
+        statements = (
+            """CREATE TABLE IF NOT EXISTS applets (
+                id UUID PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                owner TEXT NOT NULL,
+                current_version INTEGER,
+                archived_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )""",
+            """CREATE TABLE IF NOT EXISTS applet_versions (
+                applet_id UUID NOT NULL REFERENCES applets(id) ON DELETE CASCADE,
+                version INTEGER NOT NULL,
+                manifest JSONB NOT NULL,
+                package_digest BYTEA NOT NULL,
+                byte_size BIGINT NOT NULL,
+                published_by TEXT NOT NULL,
+                published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (applet_id, version)
+            )""",
+            """CREATE TABLE IF NOT EXISTS blobs (
+                id UUID PRIMARY KEY,
+                digest BYTEA NOT NULL,
+                byte_size BIGINT NOT NULL,
+                media_type TEXT NOT NULL,
+                inline_bytes BYTEA NOT NULL,
+                UNIQUE (digest, media_type)
+            )""",
+            """CREATE TABLE IF NOT EXISTS applet_files (
+                applet_id UUID NOT NULL,
+                version INTEGER NOT NULL,
+                path TEXT NOT NULL,
+                blob_id UUID NOT NULL REFERENCES blobs(id),
+                PRIMARY KEY (applet_id, version, path),
+                FOREIGN KEY (applet_id, version) REFERENCES applet_versions(applet_id, version) ON DELETE CASCADE
+            )""",
+            """CREATE OR REPLACE VIEW applet_catalog AS
+                SELECT a.id AS applet_id, a.title, a.owner,
+                       'applet_' || replace(a.id::TEXT, '-', '') AS schema_name,
+                       c.table_name, c.column_name, c.data_type, c.ordinal_position
+                FROM applets a
+                LEFT JOIN information_schema.columns c
+                  ON c.table_schema = 'applet_' || replace(a.id::TEXT, '-', '')
+                WHERE a.archived_at IS NULL""",
+            f"GRANT USAGE ON SCHEMA marina TO {APPLET_READER_ROLE}",
+            f"GRANT SELECT ON applet_catalog TO {APPLET_READER_ROLE}",
+        )
+        with self.engine.begin() as connection:
+            for statement in statements:
+                connection.execute(text(statement))
+
+    def publish(
+        self,
+        package: AppletPackage,
+        owner: str,
+        applet_id: uuid.UUID | None = None,
+        base_version: int | None = None,
+        operators: frozenset[str] = frozenset(),
+    ) -> PublishResult:
+        applet_id = applet_id or uuid.uuid4()
+        with self.engine.begin() as connection:
+            connection.execute(text("SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"), {"id": str(applet_id)})
+            existing = (
+                connection.execute(
+                    text("SELECT owner, current_version FROM applets WHERE id = :id FOR UPDATE"), {"id": applet_id}
+                )
+                .mappings()
+                .first()
+            )
+            if existing is None:
+                if base_version is not None:
+                    raise AppletNotFound(str(applet_id))
+                version = 1
+                connection.execute(text(f"SELECT {PROVISION_APPLET_FUNCTION}(:id)"), {"id": applet_id})
+                connection.execute(
+                    text(
+                        "INSERT INTO applets (id, title, description, owner) "
+                        "VALUES (:id, :title, :description, :owner)"
+                    ),
+                    {
+                        "id": applet_id,
+                        "title": package.manifest.title,
+                        "description": package.manifest.description,
+                        "owner": owner,
+                    },
+                )
+            else:
+                if existing["owner"] != owner and owner not in operators:
+                    raise AppletForbidden(str(applet_id))
+                if base_version is None or existing["current_version"] != base_version:
+                    raise AppletConflict(str(applet_id))
+                version = int(
+                    connection.execute(
+                        text("SELECT COALESCE(MAX(version), 0) + 1 FROM applet_versions WHERE applet_id = :id"),
+                        {"id": applet_id},
+                    ).scalar_one()
+                )
+            connection.execute(
+                text(
+                    "INSERT INTO applet_versions "
+                    "(applet_id, version, manifest, package_digest, byte_size, published_by) "
+                    "VALUES (:id, :version, CAST(:manifest AS jsonb), :digest, :byte_size, :owner)"
+                ),
+                {
+                    "id": applet_id,
+                    "version": version,
+                    "manifest": _manifest_json(package.manifest),
+                    "digest": package.digest,
+                    "byte_size": package.byte_size,
+                    "owner": owner,
+                },
+            )
+            for path, body in package.files.items():
+                digest = hashlib.sha256(body).digest()
+                media_path = path.removesuffix(".gz")
+                media_type = mimetypes.guess_type(media_path)[0] or "application/octet-stream"
+                blob_id = connection.execute(
+                    text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
+                    {"digest": digest, "media_type": media_type},
+                ).scalar()
+                if blob_id is None:
+                    blob_id = uuid.uuid4()
+                    inserted = connection.execute(
+                        text(
+                            "INSERT INTO blobs (id, digest, byte_size, media_type, inline_bytes) "
+                            "VALUES (:id, :digest, :byte_size, :media_type, :body) "
+                            "ON CONFLICT (digest, media_type) DO NOTHING RETURNING id"
+                        ),
+                        {
+                            "id": blob_id,
+                            "digest": digest,
+                            "byte_size": len(body),
+                            "media_type": media_type,
+                            "body": body,
+                        },
+                    ).scalar()
+                    if inserted is None:
+                        blob_id = connection.execute(
+                            text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
+                            {"digest": digest, "media_type": media_type},
+                        ).scalar_one()
+                connection.execute(
+                    text(
+                        "INSERT INTO applet_files (applet_id, version, path, blob_id) "
+                        "VALUES (:id, :version, :path, :blob_id)"
+                    ),
+                    {"id": applet_id, "version": version, "path": path, "blob_id": blob_id},
+                )
+            connection.execute(text(f'SET LOCAL ROLE "{applet_role(applet_id)}"'))
+            connection.execute(text(f'SET LOCAL search_path TO "{applet_schema(applet_id)}", public'))
+            try:
+                if package.manifest.python_entrypoint is not None:
+                    module, _factory = load_package_module(applet_id, version, package)
+                    migration = getattr(module, "migrate", None)
+                    if migration is not None:
+                        migration(connection)
+            except Exception:
+                remove_package_module(applet_id, version, package.digest)
+                raise
+            connection.execute(text(f'GRANT USAGE ON SCHEMA "{applet_schema(applet_id)}" TO {APPLET_READER_ROLE}'))
+            connection.execute(
+                text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{applet_schema(applet_id)}" ' f"TO {APPLET_READER_ROLE}")
+            )
+            connection.execute(
+                text(f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA "{applet_schema(applet_id)}" ' f"TO {APPLET_READER_ROLE}")
+            )
+            connection.execute(
+                text(
+                    f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{applet_schema(applet_id)}" '
+                    f"GRANT SELECT ON TABLES TO {APPLET_READER_ROLE}"
+                )
+            )
+            connection.execute(
+                text(
+                    f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{applet_schema(applet_id)}" '
+                    f"GRANT SELECT ON SEQUENCES TO {APPLET_READER_ROLE}"
+                )
+            )
+            connection.execute(text("RESET ROLE"))
+            connection.execute(text("SET LOCAL search_path TO marina, public"))
+            connection.execute(
+                text(
+                    "UPDATE applets SET title = :title, description = :description, current_version = :version, "
+                    "updated_at = now() WHERE id = :id"
+                ),
+                {
+                    "id": applet_id,
+                    "title": package.manifest.title,
+                    "description": package.manifest.description,
+                    "version": version,
+                },
+            )
+            connection.execute(
+                text(
+                    "DELETE FROM applet_versions WHERE applet_id = :id AND version <> :current "
+                    "AND version NOT IN (SELECT version FROM applet_versions WHERE applet_id = :id "
+                    "AND version <> :current ORDER BY version DESC LIMIT :retained)"
+                ),
+                {"id": applet_id, "current": version, "retained": MAX_REVISIONS - 1},
+            )
+            self._delete_unreferenced_blobs(connection)
+        return PublishResult(applet_id=applet_id, version=version)
+
+    @staticmethod
+    def _delete_unreferenced_blobs(connection: Connection) -> None:
+        connection.execute(
+            text("DELETE FROM blobs WHERE NOT EXISTS (SELECT 1 FROM applet_files WHERE blob_id = blobs.id)")
+        )
+
+    def apps(self) -> list[AppletSummary]:
+        with self.engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT id, title, description, owner, current_version FROM applets "
+                    "WHERE archived_at IS NULL AND current_version IS NOT NULL ORDER BY title, id"
+                )
+            ).mappings()
+            return [
+                AppletSummary(
+                    id=row["id"],
+                    title=row["title"],
+                    description=row["description"],
+                    owner=row["owner"],
+                    current_version=row["current_version"],
+                )
+                for row in rows
+            ]
+
+    def current_version(self, applet_id: uuid.UUID) -> int:
+        with self.engine.connect() as connection:
+            version = connection.execute(
+                text("SELECT current_version FROM applets WHERE id = :id AND archived_at IS NULL"),
+                {"id": applet_id},
+            ).scalar()
+        if version is None:
+            raise AppletNotFound(str(applet_id))
+        return int(version)
+
+    def version(self, applet_id: uuid.UUID, version: int) -> AppletVersion:
+        with self.engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text(
+                        "SELECT v.manifest, v.package_digest FROM applet_versions v "
+                        "JOIN applets a ON a.id = v.applet_id "
+                        "WHERE v.applet_id = :id AND v.version = :version AND a.archived_at IS NULL"
+                    ),
+                    {"id": applet_id, "version": version},
+                )
+                .mappings()
+                .first()
+            )
+        if row is None:
+            raise AppletNotFound(f"{applet_id}/v/{version}")
+        return AppletVersion(
+            applet_id=applet_id,
+            version=version,
+            manifest=_manifest_from_json(row["manifest"]),
+            digest=bytes(row["package_digest"]),
+        )
+
+    def versions(self, applet_id: uuid.UUID) -> list[AppletVersionSummary]:
+        self.current_version(applet_id)
+        with self.engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT version, published_by, published_at, byte_size FROM applet_versions "
+                    "WHERE applet_id = :id ORDER BY version DESC"
+                ),
+                {"id": applet_id},
+            ).mappings()
+            return [
+                AppletVersionSummary(
+                    version=int(row["version"]),
+                    published_by=row["published_by"],
+                    published_at=row["published_at"],
+                    byte_size=int(row["byte_size"]),
+                )
+                for row in rows
+            ]
+
+    def rollback(
+        self,
+        applet_id: uuid.UUID,
+        version: int,
+        actor: str,
+        base_version: int,
+        operators: frozenset[str] = frozenset(),
+    ) -> None:
+        with self.engine.begin() as connection:
+            connection.execute(text("SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"), {"id": str(applet_id)})
+            applet = (
+                connection.execute(
+                    text("SELECT owner, current_version FROM applets WHERE id = :id AND archived_at IS NULL FOR UPDATE"),
+                    {"id": applet_id},
+                )
+                .mappings()
+                .first()
+            )
+            if applet is None:
+                raise AppletNotFound(str(applet_id))
+            if applet["owner"] != actor and actor not in operators:
+                raise AppletForbidden(str(applet_id))
+            if int(applet["current_version"]) != base_version:
+                raise AppletConflict(str(applet_id))
+            exists = connection.execute(
+                text("SELECT 1 FROM applet_versions WHERE applet_id = :id AND version = :version"),
+                {"id": applet_id, "version": version},
+            ).scalar()
+            if exists is None:
+                raise AppletNotFound(f"{applet_id}/v/{version}")
+            connection.execute(
+                text("UPDATE applets SET current_version = :version, updated_at = now() WHERE id = :id"),
+                {"id": applet_id, "version": version},
+            )
+
+    def archive(self, applet_id: uuid.UUID, actor: str, operators: frozenset[str] = frozenset()) -> None:
+        with self.engine.begin() as connection:
+            applet = (
+                connection.execute(
+                    text("SELECT owner FROM applets WHERE id = :id AND archived_at IS NULL FOR UPDATE"),
+                    {"id": applet_id},
+                )
+                .mappings()
+                .first()
+            )
+            if applet is None:
+                raise AppletNotFound(str(applet_id))
+            if applet["owner"] != actor and actor not in operators:
+                raise AppletForbidden(str(applet_id))
+            connection.execute(
+                text("UPDATE applets SET archived_at = now(), updated_at = now() WHERE id = :id"), {"id": applet_id}
+            )
+
+    def package(self, applet_id: uuid.UUID, version: int) -> AppletPackage:
+        record = self.version(applet_id, version)
+        with self.engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT f.path, b.inline_bytes FROM applet_files f "
+                    "JOIN blobs b ON b.id = f.blob_id "
+                    "WHERE f.applet_id = :id AND f.version = :version"
+                ),
+                {"id": applet_id, "version": version},
+            ).mappings()
+            files = {row["path"]: bytes(row["inline_bytes"]) for row in rows}
+        package = _validate_package_files(files)
+        if package.digest != record.digest:
+            raise RuntimeError(f"stored package digest does not match {applet_id}/v/{version}")
+        return package
+
+    def file(
+        self,
+        applet_id: uuid.UUID,
+        version: int,
+        path: str,
+        accept_gzip: bool,
+        accept_html: bool,
+    ) -> StoredFile:
+        self.version(applet_id, version)
+        requested = path.strip("/")
+        candidates = [f"{DIST_PREFIX}{requested}" if requested else INDEX_FILE]
+        if requested.endswith("/"):
+            candidates.append(f"{DIST_PREFIX}{requested}index.html")
+        elif requested and "." not in PurePosixPath(requested).name and accept_html:
+            candidates.append(INDEX_FILE)
+        for candidate in candidates:
+            variants = [(candidate + ".gz", "gzip"), (candidate, None)] if accept_gzip else [(candidate, None)]
+            for stored_path, encoding in variants:
+                found = self._stored_file(applet_id, version, stored_path, encoding)
+                if found is not None:
+                    return found
+        raise AppletNotFound(f"{applet_id}/v/{version}/{path}")
+
+    def _stored_file(
+        self, applet_id: uuid.UUID, version: int, path: str, content_encoding: str | None
+    ) -> StoredFile | None:
+        with self.engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text(
+                        "SELECT b.inline_bytes, b.media_type, b.digest FROM applet_files f "
+                        "JOIN blobs b ON b.id = f.blob_id "
+                        "WHERE f.applet_id = :id AND f.version = :version AND f.path = :path"
+                    ),
+                    {"id": applet_id, "version": version, "path": path},
+                )
+                .mappings()
+                .first()
+            )
+        if row is None:
+            return None
+        return StoredFile(
+            body=bytes(row["inline_bytes"]),
+            media_type=row["media_type"],
+            digest=bytes(row["digest"]),
+            content_encoding=content_encoding,
+        )
+
+    def query(self, applet_id: uuid.UUID, sql: str, parameters: dict[str, object]) -> dict[str, object]:
+        self.current_version(applet_id)
+        validate_query(sql)
+        engine = engine_for_role(self.database, applet_schema(applet_id), applet_role(applet_id))
+        try:
+            with engine.begin() as connection:
+                connection.execute(text(f"SET LOCAL statement_timeout = '{QUERY_TIMEOUT_MS}ms'"))
+                result = connection.execute(text(sql), parameters)
+                if not result.returns_rows:
+                    return {"columns": [], "rows": [], "row_count": result.rowcount}
+                columns = list(result.keys())
+                rows = [dict(row) for row in result.mappings().fetchmany(MAX_QUERY_ROWS + 1)]
+                if len(rows) > MAX_QUERY_ROWS:
+                    raise QueryLimitExceeded(f"query returned more than {MAX_QUERY_ROWS} rows")
+                encoded = jsonable_encoder(rows)
+                if len(json.dumps(encoded).encode()) > MAX_QUERY_RESPONSE_BYTES:
+                    raise QueryLimitExceeded(f"query response exceeds {MAX_QUERY_RESPONSE_BYTES} bytes")
+                return {"columns": columns, "rows": encoded, "row_count": len(rows)}
+        finally:
+            engine.dispose()
+
+
+@dataclass(frozen=True)
+class AppletServices:
+    """Services passed to a dynamic Python applet backend."""
+
+    applet_id: uuid.UUID
+    version: int
+    database: DatabaseSpec
+
+    def engine(self) -> Engine:
+        return engine_for_role(self.database, applet_schema(self.applet_id), applet_role(self.applet_id))
+
+
+def validate_query(sql: str) -> None:
+    """Accept one data or schema statement while blocking transaction and role control."""
+    statement = sql.strip()
+    if not statement or ";" in statement.rstrip(";"):
+        raise InvalidQuery("query must contain exactly one statement")
+    command = re.match(r"[A-Za-z]+", statement)
+    if command is None or command.group(0).upper() not in {
+        "ALTER",
+        "COMMENT",
+        "CREATE",
+        "DELETE",
+        "DROP",
+        "INSERT",
+        "SELECT",
+        "TRUNCATE",
+        "UPDATE",
+        "WITH",
+    }:
+        raise InvalidQuery("query command is not allowed")
+
+
+def _module_name(applet_id: uuid.UUID, version: int, digest: bytes) -> str:
+    return f"marina_applet_{applet_id.hex}_v{version}_{digest.hex()[:12]}"
+
+
+def _materialize_package(module_root: Path, package: AppletPackage) -> None:
+    module_root.mkdir(parents=True, exist_ok=True)
+    (module_root / "__init__.py").touch()
+    for path, body in package.files.items():
+        if not path.startswith(SERVER_PREFIX):
+            continue
+        target = module_root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(body)
+
+
+def validate_backend_import(package: AppletPackage) -> None:
+    """Import a Python backend without Marina's environment credentials before publishing it."""
+    if package.manifest.python_entrypoint is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="marina-applet-validate-") as directory:
+        module_root = Path(directory) / "candidate"
+        _materialize_package(module_root, package)
+        environment = {name: os.environ[name] for name in ("PATH", "LANG", "LC_ALL") if name in os.environ}
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-I",
+                    "-m",
+                    "marina.applet_validator",
+                    str(module_root),
+                    package.manifest.python_entrypoint,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=BACKEND_VALIDATION_TIMEOUT,
+                env=environment,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ValueError(f"Python backend validation exceeded {BACKEND_VALIDATION_TIMEOUT} seconds") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "import failed"
+        raise ValueError(f"Python backend validation failed: {detail[:500]}")
+
+
+def load_package_module(applet_id: uuid.UUID, version: int, package: AppletPackage) -> tuple[object, str]:
+    """Materialize and import one revision under a content-specific module name."""
+    assert package.manifest.python_entrypoint is not None
+    module_path, factory_name = package.manifest.python_entrypoint.split(":", 1)
+    root_name = _module_name(applet_id, version, package.digest)
+    module_root = BACKEND_CACHE_ROOT / root_name
+    _materialize_package(module_root, package)
+    cache_parent = str(BACKEND_CACHE_ROOT)
+    if cache_parent not in sys.path:
+        sys.path.insert(0, cache_parent)
+    module = importlib.import_module(f"{root_name}.{module_path}")
+    return module, factory_name
+
+
+def remove_package_module(applet_id: uuid.UUID, version: int, digest: bytes) -> None:
+    """Remove one failed backend revision from Python and the materialized-file cache."""
+    root_name = _module_name(applet_id, version, digest)
+    for name in [name for name in sys.modules if name == root_name or name.startswith(root_name + ".")]:
+        del sys.modules[name]
+    shutil.rmtree(BACKEND_CACHE_ROOT / root_name, ignore_errors=True)
+
+
+class AppletRuntime:
+    """Load and retain revision-specific ASGI applications."""
+
+    def __init__(self, store: AppletStore):
+        self.store = store
+        self._apis: dict[tuple[uuid.UUID, int], ASGIApp] = {}
+        self._failures: dict[tuple[uuid.UUID, int], str] = {}
+        self._lock = threading.Lock()
+
+    def api(self, applet_id: uuid.UUID, version: int) -> ASGIApp:
+        key = (applet_id, version)
+        with self._lock:
+            self.store.version(applet_id, version)
+            if key in self._failures:
+                raise AppletBackendUnavailable(self._failures[key])
+            if key in self._apis:
+                return self._apis[key]
+            package = self.store.package(applet_id, version)
+            if package.manifest.python_entrypoint is None:
+                raise AppletNotFound(f"{applet_id}/v/{version}/api")
+            try:
+                module, factory_name = load_package_module(applet_id, version, package)
+                factory = getattr(module, factory_name)
+                candidate = factory(AppletServices(applet_id=applet_id, version=version, database=self.store.database))
+                if not callable(candidate):
+                    raise TypeError("create_api did not return an ASGI application")
+                api = cast(ASGIApp, candidate)
+            except Exception as error:
+                remove_package_module(applet_id, version, package.digest)
+                message = f"{type(error).__name__}: {error}"
+                self._failures[key] = message
+                raise AppletBackendUnavailable(message) from error
+            self._apis[key] = api
+            return api

--- a/infra/marina/src/marina/applets.py
+++ b/infra/marina/src/marina/applets.py
@@ -27,7 +27,12 @@ from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
 from starlette.types import ASGIApp
 
-from marina.database_setup import APPLET_READER_ROLE, PROVISION_APPLET_FUNCTION
+from marina.database_setup import (
+    APPLET_READER_ROLE,
+    APPLET_ROLE_PREFIX,
+    MARINA_SCHEMA,
+    PROVISION_APPLET_FUNCTION,
+)
 from marina.db import DatabaseSpec, engine_for, engine_for_role, grant_read_on_connection
 
 APPLET_MANIFEST = "applet.toml"
@@ -256,7 +261,7 @@ def package_applet(app_dir: Path) -> bytes:
 
 
 def applet_schema(applet_id: uuid.UUID) -> str:
-    return f"applet_{applet_id.hex}"
+    return f"{APPLET_ROLE_PREFIX}{applet_id.hex}"
 
 
 def applet_role(applet_id: uuid.UUID) -> str:
@@ -292,7 +297,7 @@ class AppletStore:
 
     def __init__(self, database: DatabaseSpec):
         self.database = database
-        self.engine = engine_for(database, "marina")
+        self.engine = engine_for(database, MARINA_SCHEMA)
 
     def migrate(self) -> None:
         statements = (
@@ -332,15 +337,15 @@ class AppletStore:
                 PRIMARY KEY (applet_id, version, path),
                 FOREIGN KEY (applet_id, version) REFERENCES applet_versions(applet_id, version) ON DELETE CASCADE
             )""",
-            """CREATE OR REPLACE VIEW applet_catalog AS
+            f"""CREATE OR REPLACE VIEW applet_catalog AS
                 SELECT a.id AS applet_id, a.title, a.owner,
-                       'applet_' || replace(a.id::TEXT, '-', '') AS schema_name,
+                       '{APPLET_ROLE_PREFIX}' || replace(a.id::TEXT, '-', '') AS schema_name,
                        c.table_name, c.column_name, c.data_type, c.ordinal_position
                 FROM applets a
                 LEFT JOIN information_schema.columns c
-                  ON c.table_schema = 'applet_' || replace(a.id::TEXT, '-', '')
+                  ON c.table_schema = '{APPLET_ROLE_PREFIX}' || replace(a.id::TEXT, '-', '')
                 WHERE a.archived_at IS NULL""",
-            f"GRANT USAGE ON SCHEMA marina TO {APPLET_READER_ROLE}",
+            f"GRANT USAGE ON SCHEMA {MARINA_SCHEMA} TO {APPLET_READER_ROLE}",
             f"GRANT SELECT ON applet_catalog TO {APPLET_READER_ROLE}",
         )
         with self.engine.begin() as connection:
@@ -555,7 +560,7 @@ class AppletStore:
             text("DELETE FROM blobs WHERE NOT EXISTS (SELECT 1 FROM applet_files WHERE blob_id = blobs.id)")
         )
 
-    def apps(self) -> list[AppletSummary]:
+    def active_applets(self) -> list[AppletSummary]:
         with self.engine.connect() as connection:
             rows = connection.execute(
                 text(

--- a/infra/marina/src/marina/applets.py
+++ b/infra/marina/src/marina/applets.py
@@ -28,7 +28,7 @@ from sqlalchemy.engine import Connection, Engine
 from starlette.types import ASGIApp
 
 from marina.database_setup import APPLET_READER_ROLE, PROVISION_APPLET_FUNCTION
-from marina.db import DatabaseSpec, engine_for, engine_for_role
+from marina.db import DatabaseSpec, engine_for, engine_for_role, grant_read_on_connection
 
 APPLET_MANIFEST = "applet.toml"
 DIST_PREFIX = "dist/"
@@ -46,6 +46,7 @@ BACKEND_VALIDATION_TIMEOUT = 15
 KNOWN_MANIFEST_KEYS = frozenset({"title", "description", "connect_src", "build_command", "python_entrypoint"})
 ENTRYPOINT_PATTERN = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
 BACKEND_CACHE_ROOT = Path(tempfile.gettempdir()) / "marina-applet-backends"
+APPLET_LOCK_SQL = "SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"
 
 
 class AppletNotFound(Exception):
@@ -356,149 +357,197 @@ class AppletStore:
     ) -> PublishResult:
         applet_id = applet_id or uuid.uuid4()
         with self.engine.begin() as connection:
-            connection.execute(text("SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"), {"id": str(applet_id)})
-            existing = (
-                connection.execute(
-                    text("SELECT owner, current_version, archived_at FROM applets WHERE id = :id FOR UPDATE"),
-                    {"id": applet_id},
-                )
-                .mappings()
-                .first()
+            self._lock_applet(connection, applet_id)
+            version = self._allocate_version(
+                connection,
+                applet_id,
+                package.manifest,
+                owner,
+                base_version,
+                operators,
             )
-            if existing is None:
-                if base_version is not None:
-                    raise AppletNotFound(str(applet_id))
-                version = 1
-                connection.execute(text(f"SELECT {PROVISION_APPLET_FUNCTION}(:id)"), {"id": applet_id})
-                connection.execute(
-                    text(
-                        "INSERT INTO applets (id, title, description, owner) "
-                        "VALUES (:id, :title, :description, :owner)"
-                    ),
-                    {
-                        "id": applet_id,
-                        "title": package.manifest.title,
-                        "description": package.manifest.description,
-                        "owner": owner,
-                    },
-                )
-            else:
-                if existing["archived_at"] is not None:
-                    raise AppletNotFound(str(applet_id))
-                if existing["owner"] != owner and owner not in operators:
-                    raise AppletForbidden(str(applet_id))
-                if base_version is None or existing["current_version"] != base_version:
-                    raise AppletConflict(str(applet_id))
-                version = int(
-                    connection.execute(
-                        text("SELECT COALESCE(MAX(version), 0) + 1 FROM applet_versions WHERE applet_id = :id"),
-                        {"id": applet_id},
-                    ).scalar_one()
-                )
-            connection.execute(
-                text(
-                    "INSERT INTO applet_versions "
-                    "(applet_id, version, manifest, package_digest, byte_size, published_by) "
-                    "VALUES (:id, :version, CAST(:manifest AS jsonb), :digest, :byte_size, :owner)"
-                ),
-                {
-                    "id": applet_id,
-                    "version": version,
-                    "manifest": _manifest_json(package.manifest),
-                    "digest": package.digest,
-                    "byte_size": package.byte_size,
-                    "owner": owner,
-                },
-            )
-            for path, body in package.files.items():
-                digest = hashlib.sha256(body).digest()
-                media_path = path.removesuffix(".gz")
-                media_type = mimetypes.guess_type(media_path)[0] or "application/octet-stream"
-                blob_id = connection.execute(
-                    text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
-                    {"digest": digest, "media_type": media_type},
-                ).scalar()
-                if blob_id is None:
-                    blob_id = uuid.uuid4()
-                    inserted = connection.execute(
-                        text(
-                            "INSERT INTO blobs (id, digest, byte_size, media_type, inline_bytes) "
-                            "VALUES (:id, :digest, :byte_size, :media_type, :body) "
-                            "ON CONFLICT (digest, media_type) DO NOTHING RETURNING id"
-                        ),
-                        {
-                            "id": blob_id,
-                            "digest": digest,
-                            "byte_size": len(body),
-                            "media_type": media_type,
-                            "body": body,
-                        },
-                    ).scalar()
-                    if inserted is None:
-                        blob_id = connection.execute(
-                            text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
-                            {"digest": digest, "media_type": media_type},
-                        ).scalar_one()
-                connection.execute(
-                    text(
-                        "INSERT INTO applet_files (applet_id, version, path, blob_id) "
-                        "VALUES (:id, :version, :path, :blob_id)"
-                    ),
-                    {"id": applet_id, "version": version, "path": path, "blob_id": blob_id},
-                )
+            self._insert_version(connection, applet_id, version, package, owner)
+            self._store_files(connection, applet_id, version, package.files)
             connection.execute(text(f'SET LOCAL ROLE "{applet_role(applet_id)}"'))
             connection.execute(text(f'SET LOCAL search_path TO "{applet_schema(applet_id)}", public'))
-            if package.manifest.python_entrypoint is not None:
-                try:
-                    module, _factory = load_package_module(applet_id, version, package)
-                    migration = getattr(module, "migrate", None)
-                    if migration is not None:
-                        migration(connection)
-                finally:
-                    remove_package_module(applet_id, version, package.digest)
-            connection.execute(text(f'GRANT USAGE ON SCHEMA "{applet_schema(applet_id)}" TO {APPLET_READER_ROLE}'))
-            connection.execute(
-                text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{applet_schema(applet_id)}" ' f"TO {APPLET_READER_ROLE}")
-            )
-            connection.execute(
-                text(f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA "{applet_schema(applet_id)}" ' f"TO {APPLET_READER_ROLE}")
-            )
-            connection.execute(
-                text(
-                    f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{applet_schema(applet_id)}" '
-                    f"GRANT SELECT ON TABLES TO {APPLET_READER_ROLE}"
-                )
-            )
-            connection.execute(
-                text(
-                    f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{applet_schema(applet_id)}" '
-                    f"GRANT SELECT ON SEQUENCES TO {APPLET_READER_ROLE}"
-                )
-            )
+            self._run_migration(connection, applet_id, version, package)
+            grant_read_on_connection(connection, applet_schema(applet_id), APPLET_READER_ROLE)
             connection.execute(text("RESET ROLE"))
             connection.execute(text("SET LOCAL search_path TO marina, public"))
+            self._activate_version(connection, applet_id, version, package.manifest)
+            self._delete_unreferenced_blobs(connection)
+        return PublishResult(applet_id=applet_id, version=version)
+
+    @staticmethod
+    def _lock_applet(connection: Connection, applet_id: uuid.UUID) -> None:
+        connection.execute(text(APPLET_LOCK_SQL), {"id": str(applet_id)})
+
+    @staticmethod
+    def _allocate_version(
+        connection: Connection,
+        applet_id: uuid.UUID,
+        manifest: AppletManifest,
+        owner: str,
+        base_version: int | None,
+        operators: frozenset[str],
+    ) -> int:
+        existing = (
+            connection.execute(
+                text("SELECT owner, current_version, archived_at FROM applets WHERE id = :id FOR UPDATE"),
+                {"id": applet_id},
+            )
+            .mappings()
+            .first()
+        )
+        if existing is not None:
+            if existing["archived_at"] is not None:
+                raise AppletNotFound(str(applet_id))
+            if existing["owner"] != owner and owner not in operators:
+                raise AppletForbidden(str(applet_id))
+            if base_version is None or existing["current_version"] != base_version:
+                raise AppletConflict(str(applet_id))
+            return int(
+                connection.execute(
+                    text("SELECT COALESCE(MAX(version), 0) + 1 FROM applet_versions WHERE applet_id = :id"),
+                    {"id": applet_id},
+                ).scalar_one()
+            )
+        if base_version is not None:
+            raise AppletNotFound(str(applet_id))
+        connection.execute(text(f"SELECT {PROVISION_APPLET_FUNCTION}(:id)"), {"id": applet_id})
+        connection.execute(
+            text("INSERT INTO applets (id, title, description, owner) VALUES (:id, :title, :description, :owner)"),
+            {
+                "id": applet_id,
+                "title": manifest.title,
+                "description": manifest.description,
+                "owner": owner,
+            },
+        )
+        return 1
+
+    @staticmethod
+    def _insert_version(
+        connection: Connection,
+        applet_id: uuid.UUID,
+        version: int,
+        package: AppletPackage,
+        owner: str,
+    ) -> None:
+        connection.execute(
+            text(
+                "INSERT INTO applet_versions "
+                "(applet_id, version, manifest, package_digest, byte_size, published_by) "
+                "VALUES (:id, :version, CAST(:manifest AS jsonb), :digest, :byte_size, :owner)"
+            ),
+            {
+                "id": applet_id,
+                "version": version,
+                "manifest": _manifest_json(package.manifest),
+                "digest": package.digest,
+                "byte_size": package.byte_size,
+                "owner": owner,
+            },
+        )
+
+    @staticmethod
+    def _blob_id(connection: Connection, path: str, body: bytes) -> uuid.UUID:
+        digest = hashlib.sha256(body).digest()
+        media_type = mimetypes.guess_type(path.removesuffix(".gz"))[0] or "application/octet-stream"
+        existing = connection.execute(
+            text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
+            {"digest": digest, "media_type": media_type},
+        ).scalar()
+        if existing is not None:
+            return existing
+        blob_id = uuid.uuid4()
+        inserted = connection.execute(
+            text(
+                "INSERT INTO blobs (id, digest, byte_size, media_type, inline_bytes) "
+                "VALUES (:id, :digest, :byte_size, :media_type, :body) "
+                "ON CONFLICT (digest, media_type) DO NOTHING RETURNING id"
+            ),
+            {
+                "id": blob_id,
+                "digest": digest,
+                "byte_size": len(body),
+                "media_type": media_type,
+                "body": body,
+            },
+        ).scalar()
+        if inserted is not None:
+            return inserted
+        return connection.execute(
+            text("SELECT id FROM blobs WHERE digest = :digest AND media_type = :media_type"),
+            {"digest": digest, "media_type": media_type},
+        ).scalar_one()
+
+    @classmethod
+    def _store_files(
+        cls,
+        connection: Connection,
+        applet_id: uuid.UUID,
+        version: int,
+        files: dict[str, bytes],
+    ) -> None:
+        for path, body in files.items():
             connection.execute(
                 text(
-                    "UPDATE applets SET title = :title, description = :description, current_version = :version, "
-                    "updated_at = now() WHERE id = :id"
+                    "INSERT INTO applet_files (applet_id, version, path, blob_id) "
+                    "VALUES (:id, :version, :path, :blob_id)"
                 ),
                 {
                     "id": applet_id,
-                    "title": package.manifest.title,
-                    "description": package.manifest.description,
                     "version": version,
+                    "path": path,
+                    "blob_id": cls._blob_id(connection, path, body),
                 },
             )
-            connection.execute(
-                text(
-                    "DELETE FROM applet_versions WHERE applet_id = :id AND version <> :current "
-                    "AND version NOT IN (SELECT version FROM applet_versions WHERE applet_id = :id "
-                    "AND version <> :current ORDER BY version DESC LIMIT :retained)"
-                ),
-                {"id": applet_id, "current": version, "retained": MAX_REVISIONS - 1},
-            )
-            self._delete_unreferenced_blobs(connection)
-        return PublishResult(applet_id=applet_id, version=version)
+
+    @staticmethod
+    def _run_migration(
+        connection: Connection,
+        applet_id: uuid.UUID,
+        version: int,
+        package: AppletPackage,
+    ) -> None:
+        if package.manifest.python_entrypoint is None:
+            return
+        try:
+            module, _factory = load_backend_entrypoint(applet_id, version, package)
+            migration = getattr(module, "migrate", None)
+            if migration is not None:
+                migration(connection)
+        finally:
+            remove_backend_revision(applet_id, version, package.digest)
+
+    @staticmethod
+    def _activate_version(
+        connection: Connection,
+        applet_id: uuid.UUID,
+        version: int,
+        manifest: AppletManifest,
+    ) -> None:
+        connection.execute(
+            text(
+                "UPDATE applets SET title = :title, description = :description, current_version = :version, "
+                "updated_at = now() WHERE id = :id"
+            ),
+            {
+                "id": applet_id,
+                "title": manifest.title,
+                "description": manifest.description,
+                "version": version,
+            },
+        )
+        connection.execute(
+            text(
+                "DELETE FROM applet_versions WHERE applet_id = :id AND version <> :current "
+                "AND version NOT IN (SELECT version FROM applet_versions WHERE applet_id = :id "
+                "AND version <> :current ORDER BY version DESC LIMIT :retained)"
+            ),
+            {"id": applet_id, "current": version, "retained": MAX_REVISIONS - 1},
+        )
 
     @staticmethod
     def _delete_unreferenced_blobs(connection: Connection) -> None:
@@ -587,7 +636,7 @@ class AppletStore:
         operators: frozenset[str] = frozenset(),
     ) -> None:
         with self.engine.begin() as connection:
-            connection.execute(text("SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"), {"id": str(applet_id)})
+            self._lock_applet(connection, applet_id)
             applet = (
                 connection.execute(
                     text("SELECT owner, current_version FROM applets WHERE id = :id AND archived_at IS NULL FOR UPDATE"),
@@ -819,8 +868,8 @@ def validate_backend_import(package: AppletPackage) -> None:
         raise ValueError(f"Python backend validation failed: {detail[:500]}")
 
 
-def load_package_module(applet_id: uuid.UUID, version: int, package: AppletPackage) -> tuple[object, str]:
-    """Materialize and import one revision under a content-specific module name."""
+def load_backend_entrypoint(applet_id: uuid.UUID, version: int, package: AppletPackage) -> tuple[object, str]:
+    """Return the imported backend module and factory name for one applet revision."""
     assert package.manifest.python_entrypoint is not None
     module_path, factory_name = package.manifest.python_entrypoint.split(":", 1)
     root_name = _module_name(applet_id, version, package.digest)
@@ -833,8 +882,8 @@ def load_package_module(applet_id: uuid.UUID, version: int, package: AppletPacka
     return module, factory_name
 
 
-def remove_package_module(applet_id: uuid.UUID, version: int, digest: bytes) -> None:
-    """Remove one failed backend revision from Python and the materialized-file cache."""
+def remove_backend_revision(applet_id: uuid.UUID, version: int, digest: bytes) -> None:
+    """Remove imported modules and source files for one applet revision."""
     root_name = _module_name(applet_id, version, digest)
     for name in [name for name in sys.modules if name == root_name or name.startswith(root_name + ".")]:
         del sys.modules[name]
@@ -875,14 +924,14 @@ class AppletRuntime:
             if package.manifest.python_entrypoint is None:
                 raise AppletNotFound(f"{applet_id}/v/{version}/api")
             try:
-                module, factory_name = load_package_module(applet_id, version, package)
+                module, factory_name = load_backend_entrypoint(applet_id, version, package)
                 factory = getattr(module, factory_name)
                 candidate = factory(AppletServices(applet_id=applet_id, version=version, database=self.store.database))
                 if not callable(candidate):
                     raise TypeError("create_api did not return an ASGI application")
                 api = cast(ASGIApp, candidate)
             except Exception as error:
-                remove_package_module(applet_id, version, package.digest)
+                remove_backend_revision(applet_id, version, package.digest)
                 message = f"{type(error).__name__}: {error}"
                 with self._lock:
                     self._failures[key] = message
@@ -918,4 +967,4 @@ class AppletRuntime:
             for key in stale_initializers:
                 self._initializers.pop(key)
         for version, digest in removed:
-            remove_package_module(applet_id, version, digest)
+            remove_backend_revision(applet_id, version, digest)

--- a/infra/marina/src/marina/applets.py
+++ b/infra/marina/src/marina/applets.py
@@ -360,7 +360,8 @@ class AppletStore:
             connection.execute(text("SELECT pg_advisory_xact_lock(hashtextextended(:id, 0))"), {"id": str(applet_id)})
             existing = (
                 connection.execute(
-                    text("SELECT owner, current_version FROM applets WHERE id = :id FOR UPDATE"), {"id": applet_id}
+                    text("SELECT owner, current_version, archived_at FROM applets WHERE id = :id FOR UPDATE"),
+                    {"id": applet_id},
                 )
                 .mappings()
                 .first()
@@ -383,6 +384,8 @@ class AppletStore:
                     },
                 )
             else:
+                if existing["archived_at"] is not None:
+                    raise AppletNotFound(str(applet_id))
                 if existing["owner"] != owner and owner not in operators:
                     raise AppletForbidden(str(applet_id))
                 if base_version is None or existing["current_version"] != base_version:
@@ -446,15 +449,14 @@ class AppletStore:
                 )
             connection.execute(text(f'SET LOCAL ROLE "{applet_role(applet_id)}"'))
             connection.execute(text(f'SET LOCAL search_path TO "{applet_schema(applet_id)}", public'))
-            try:
-                if package.manifest.python_entrypoint is not None:
+            if package.manifest.python_entrypoint is not None:
+                try:
                     module, _factory = load_package_module(applet_id, version, package)
                     migration = getattr(module, "migrate", None)
                     if migration is not None:
                         migration(connection)
-            except Exception:
-                remove_package_module(applet_id, version, package.digest)
-                raise
+                finally:
+                    remove_package_module(applet_id, version, package.digest)
             connection.execute(text(f'GRANT USAGE ON SCHEMA "{applet_schema(applet_id)}" TO {APPLET_READER_ROLE}'))
             connection.execute(
                 text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{applet_schema(applet_id)}" ' f"TO {APPLET_READER_ROLE}")
@@ -824,16 +826,29 @@ class AppletRuntime:
         self.store = store
         self._apis: dict[tuple[uuid.UUID, int], ASGIApp] = {}
         self._failures: dict[tuple[uuid.UUID, int], str] = {}
+        self._digests: dict[tuple[uuid.UUID, int], bytes] = {}
+        self._initializers: dict[tuple[uuid.UUID, int], threading.Lock] = {}
         self._lock = threading.Lock()
 
     def api(self, applet_id: uuid.UUID, version: int) -> ASGIApp:
         key = (applet_id, version)
-        with self._lock:
+        try:
             self.store.version(applet_id, version)
+        except AppletNotFound:
+            self.retain_versions(applet_id, self._retained_versions(applet_id))
+            raise
+        with self._lock:
             if key in self._failures:
                 raise AppletBackendUnavailable(self._failures[key])
             if key in self._apis:
                 return self._apis[key]
+            initializer = self._initializers.setdefault(key, threading.Lock())
+        with initializer:
+            with self._lock:
+                if key in self._failures:
+                    raise AppletBackendUnavailable(self._failures[key])
+                if key in self._apis:
+                    return self._apis[key]
             package = self.store.package(applet_id, version)
             if package.manifest.python_entrypoint is None:
                 raise AppletNotFound(f"{applet_id}/v/{version}/api")
@@ -847,7 +862,38 @@ class AppletRuntime:
             except Exception as error:
                 remove_package_module(applet_id, version, package.digest)
                 message = f"{type(error).__name__}: {error}"
-                self._failures[key] = message
+                with self._lock:
+                    self._failures[key] = message
                 raise AppletBackendUnavailable(message) from error
-            self._apis[key] = api
+            with self._lock:
+                self._apis[key] = api
+                self._digests[key] = package.digest
+            try:
+                self.store.version(applet_id, version)
+            except AppletNotFound:
+                self.retain_versions(applet_id, self._retained_versions(applet_id))
+                raise
             return api
+
+    def _retained_versions(self, applet_id: uuid.UUID) -> set[int]:
+        try:
+            return {item.version for item in self.store.versions(applet_id)}
+        except AppletNotFound:
+            return set()
+
+    def retain_versions(self, applet_id: uuid.UUID, versions: set[int]) -> None:
+        """Discard cached runtime state for revisions outside the retained set."""
+        removed: list[tuple[int, bytes]] = []
+        with self._lock:
+            stale_apis = [key for key in self._apis if key[0] == applet_id and key[1] not in versions]
+            for key in stale_apis:
+                self._apis.pop(key)
+                removed.append((key[1], self._digests.pop(key)))
+            stale_failures = [key for key in self._failures if key[0] == applet_id and key[1] not in versions]
+            for key in stale_failures:
+                self._failures.pop(key)
+            stale_initializers = [key for key in self._initializers if key[0] == applet_id and key[1] not in versions]
+            for key in stale_initializers:
+                self._initializers.pop(key)
+        for version, digest in removed:
+            remove_package_module(applet_id, version, digest)

--- a/infra/marina/src/marina/applets.py
+++ b/infra/marina/src/marina/applets.py
@@ -23,7 +23,6 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import cast
 
-from fastapi.encoders import jsonable_encoder
 from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
 from starlette.types import ASGIApp
@@ -699,22 +698,39 @@ class AppletStore:
 
     def query(self, applet_id: uuid.UUID, sql: str, parameters: dict[str, object]) -> dict[str, object]:
         self.current_version(applet_id)
-        validate_query(sql)
+        command = validate_query(sql)
         engine = engine_for_role(self.database, applet_schema(applet_id), applet_role(applet_id))
         try:
             with engine.begin() as connection:
                 connection.execute(text(f"SET LOCAL statement_timeout = '{QUERY_TIMEOUT_MS}ms'"))
+                if command in {"SELECT", "WITH"}:
+                    statement = sql.strip().removesuffix(";").rstrip()
+                    bounded = text(
+                        "SELECT CASE WHEN pg_column_size(payload) <= "
+                        f"{MAX_QUERY_RESPONSE_BYTES} THEN payload END AS payload, "
+                        "row_count, pg_column_size(payload) AS byte_size FROM ("
+                        "SELECT COALESCE(json_agg(row_to_json(applet_query)), '[]'::json) AS payload, "
+                        "count(*) AS row_count FROM (SELECT * FROM ("
+                        f"{statement}"
+                        f") AS applet_result LIMIT {MAX_QUERY_ROWS + 1}) AS applet_query"
+                        ") AS applet_payload"
+                    )
+                    result = connection.execute(bounded, parameters).mappings().one()
+                    row_count = int(result["row_count"])
+                    if row_count > MAX_QUERY_ROWS:
+                        raise QueryLimitExceeded(f"query returned more than {MAX_QUERY_ROWS} rows")
+                    if int(result["byte_size"]) > MAX_QUERY_RESPONSE_BYTES:
+                        raise QueryLimitExceeded(f"query response exceeds {MAX_QUERY_RESPONSE_BYTES} bytes")
+                    rows = cast(list[dict[str, object]], result["payload"])
+                    columns = list(rows[0]) if rows else []
+                    response: dict[str, object] = {"columns": columns, "rows": rows, "row_count": row_count}
+                    if len(json.dumps(response).encode()) > MAX_QUERY_RESPONSE_BYTES:
+                        raise QueryLimitExceeded(f"query response exceeds {MAX_QUERY_RESPONSE_BYTES} bytes")
+                    return response
                 result = connection.execute(text(sql), parameters)
-                if not result.returns_rows:
-                    return {"columns": [], "rows": [], "row_count": result.rowcount}
-                columns = list(result.keys())
-                rows = [dict(row) for row in result.mappings().fetchmany(MAX_QUERY_ROWS + 1)]
-                if len(rows) > MAX_QUERY_ROWS:
-                    raise QueryLimitExceeded(f"query returned more than {MAX_QUERY_ROWS} rows")
-                encoded = jsonable_encoder(rows)
-                if len(json.dumps(encoded).encode()) > MAX_QUERY_RESPONSE_BYTES:
-                    raise QueryLimitExceeded(f"query response exceeds {MAX_QUERY_RESPONSE_BYTES} bytes")
-                return {"columns": columns, "rows": encoded, "row_count": len(rows)}
+                if result.returns_rows:
+                    raise InvalidQuery(f"{command} statements may not return rows")
+                return {"columns": [], "rows": [], "row_count": result.rowcount}
         finally:
             engine.dispose()
 
@@ -731,7 +747,7 @@ class AppletServices:
         return engine_for_role(self.database, applet_schema(self.applet_id), applet_role(self.applet_id))
 
 
-def validate_query(sql: str) -> None:
+def validate_query(sql: str) -> str:
     """Accept one data or schema statement while blocking transaction and role control."""
     statement = sql.strip()
     if not statement or ";" in statement.rstrip(";"):
@@ -750,6 +766,12 @@ def validate_query(sql: str) -> None:
         "WITH",
     }:
         raise InvalidQuery("query command is not allowed")
+    normalized = command.group(0).upper()
+    if normalized == "WITH" and re.search(r"\b(INSERT|UPDATE|DELETE)\b", statement, re.IGNORECASE):
+        raise InvalidQuery("data-modifying WITH statements are not allowed")
+    if normalized not in {"SELECT", "WITH"} and re.search(r"\bRETURNING\b", statement, re.IGNORECASE):
+        raise InvalidQuery(f"{normalized} statements may not return rows")
+    return normalized
 
 
 def _module_name(applet_id: uuid.UUID, version: int, digest: bytes) -> str:

--- a/infra/marina/src/marina/cli.py
+++ b/infra/marina/src/marina/cli.py
@@ -3,15 +3,20 @@
 
 """The ``marina`` command: check manifests, build frontends, run the kernel."""
 
+import json
 import os
 import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 import click
 import pytest
 import uvicorn
 
+from marina.applets import APPLET_MANIFEST, AppletStore, package_applet, parse_applet_manifest, read_applet_package
 from marina.apps import is_python_app, migration, services_for
+from marina.client import DEFAULT_MARINA_URL, marina_request, publish_applet
+from marina.database_setup import APPLET_READER_ROLE, ensure_applet_provisioning
 from marina.db import (
     DatabaseSpec,
     database_from_env,
@@ -24,6 +29,7 @@ from marina.db import (
 from marina.journey_plugin import DEFAULT_SHOTS_DIR, JOURNEYS_DIR
 from marina.manifest import AppManifest, JobRunner, discover_apps, job_runners
 from marina.server import APPS_DIR_ENV, MarinaConfig, create_app
+from marina.table_load import read_table, table_statements
 
 # The environment wins so the deployed image (MARINA_APPS_DIR=/app/apps) runs `marina migrate` unchanged.
 DEFAULT_APPS_DIR = Path(os.environ.get(APPS_DIR_ENV) or Path(__file__).resolve().parents[2] / "apps")
@@ -74,6 +80,12 @@ def migrate(apps_dir: Path, only: tuple[str, ...], reader: str | None) -> None:
 
 def _migrate_apps(apps: list[AppManifest], database: DatabaseSpec, only: tuple[str, ...], reader: str | None) -> None:
     with migration_lock(database):
+        applet_store = AppletStore(database)
+        try:
+            ensure_applet_provisioning(applet_store.engine)
+            applet_store.migrate()
+        finally:
+            applet_store.engine.dispose()
         for app in apps:
             if only and app.name not in only:
                 continue
@@ -86,6 +98,7 @@ def _migrate_apps(apps: list[AppManifest], database: DatabaseSpec, only: tuple[s
             engine = services_for(app, "", database).engine()
             try:
                 run(engine)
+                grant_read(engine, schema_name(app.name), APPLET_READER_ROLE)
                 if reader:
                     grant_read(engine, schema_name(app.name), reader)
             finally:
@@ -144,6 +157,216 @@ def run_jobs(runner_name: str, apps_dir: Path, reader: str | None, migrate_only:
                 failures.append(bound.qualified_name)
         if failures:
             raise click.ClickException(f"job failures: {', '.join(failures)}")
+
+
+@cli.command()
+@click.argument("app_dir", type=click.Path(path_type=Path, file_okay=False, exists=True))
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+@click.option("--update", "applet_id", default=None, help="Applet UUID to update.")
+@click.option("--base-version", type=int, default=None, help="Current version required by an update.")
+@click.option("--build/--no-build", default=True, help="Run build_command when dist/index.html is absent.")
+@click.option("--dry-run", is_flag=True, help="Validate and print package contents without publishing.")
+@click.option("--json", "json_output", is_flag=True, help="Print the publish result as JSON.")
+def publish(
+    app_dir: Path,
+    service_url: str,
+    applet_id: str | None,
+    base_version: int | None,
+    build: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Publish a built applet directory and print its URL."""
+    manifest_path = app_dir / APPLET_MANIFEST
+    if not manifest_path.is_file():
+        raise click.UsageError(f"{app_dir} has no {APPLET_MANIFEST}")
+    manifest = parse_applet_manifest(manifest_path.read_bytes())
+    if not (app_dir / "dist" / "index.html").is_file() and build:
+        if manifest.build_command is None:
+            raise click.UsageError("dist/index.html is absent and applet.toml has no build_command")
+        subprocess.run(manifest.build_command, shell=True, cwd=app_dir, check=True)
+    try:
+        payload = package_applet(app_dir)
+    except ValueError as error:
+        raise click.UsageError(str(error)) from error
+    package = read_applet_package(payload)
+    if dry_run:
+        files = sorted(package.files)
+        report = {
+            "files": files,
+            "file_count": len(files),
+            "byte_size": package.byte_size,
+            "digest": package.digest.hex(),
+        }
+        if json_output:
+            click.echo(json.dumps(report, sort_keys=True))
+        else:
+            click.echo(f"{report['file_count']} files, {report['byte_size']} bytes, sha256 {report['digest']}")
+            for path in files:
+                click.echo(path)
+        return
+    if (applet_id is None) != (base_version is None):
+        raise click.UsageError("--update and --base-version must be supplied together")
+    try:
+        result = publish_applet(service_url, payload, applet_id=applet_id, base_version=base_version)
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    if not isinstance(result.get("url"), str) or not urlparse(str(result["url"])).netloc:
+        result["url"] = service_url.rstrip("/") + str(result["path"])
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+    else:
+        click.echo(result["url"])
+
+
+@cli.group()
+def applets() -> None:
+    """Inspect and manage published applets."""
+
+
+def _applet_origin(service_url: str, applet_id: str) -> str:
+    details = marina_request(service_url, "GET", f"/api/marina/applets/{applet_id}")
+    if not isinstance(details, dict) or not isinstance(details.get("url"), str):
+        raise RuntimeError("Marina returned invalid applet details")
+    parsed = urlparse(details["url"])
+    return f"{parsed.scheme}://{parsed.netloc}" if parsed.netloc else service_url.rstrip("/")
+
+
+@applets.command("list")
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+@click.option("--json", "json_output", is_flag=True)
+def list_applets(service_url: str, json_output: bool) -> None:
+    """List active applets."""
+    try:
+        result = marina_request(service_url, "GET", "/api/marina/applets")
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    if not isinstance(result, dict) or not isinstance(result.get("applets"), list):
+        raise click.ClickException("Marina returned an invalid applet list")
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+    for applet in result["applets"]:
+        click.echo(f"{applet['name']}  v{applet['version']}  {applet['title']}  {applet['path']}")
+
+
+@applets.command("versions")
+@click.argument("applet_id")
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+@click.option("--json", "json_output", is_flag=True)
+def list_applet_versions(applet_id: str, service_url: str, json_output: bool) -> None:
+    """List the retained revisions of one applet."""
+    try:
+        result = marina_request(service_url, "GET", f"/api/marina/applets/{applet_id}")
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    if (
+        not isinstance(result, dict)
+        or not isinstance(result.get("current_version"), int)
+        or not isinstance(result.get("versions"), list)
+    ):
+        raise click.ClickException("Marina returned invalid applet details")
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+    for revision in result["versions"]:
+        current = " current" if revision["version"] == result["current_version"] else ""
+        click.echo(
+            f"v{revision['version']}{current}  {revision['published_at']}  "
+            f"{revision['published_by']}  {revision['byte_size']} bytes"
+        )
+
+
+@applets.command("rollback")
+@click.argument("applet_id")
+@click.argument("version", type=int)
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+def rollback_applet(applet_id: str, version: int, service_url: str) -> None:
+    """Move an applet's current URL to a retained revision."""
+    try:
+        details = marina_request(service_url, "GET", f"/api/marina/applets/{applet_id}")
+        if not isinstance(details, dict) or not isinstance(details.get("current_version"), int):
+            raise RuntimeError("Marina returned invalid applet details")
+        marina_request(
+            service_url,
+            "PUT",
+            f"/api/marina/applets/{applet_id}/current",
+            json_body={"version": version, "base_version": details["current_version"]},
+        )
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"{applet_id} now points to revision {version}")
+
+
+@applets.command("archive")
+@click.argument("applet_id")
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+def archive_applet(applet_id: str, service_url: str) -> None:
+    """Hide an applet while preserving its schema and retained revisions."""
+    try:
+        marina_request(service_url, "DELETE", f"/api/marina/applets/{applet_id}")
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"archived {applet_id}")
+
+
+@applets.command("sql")
+@click.argument("applet_id")
+@click.argument("sql")
+@click.option("--parameters", default="{}", help="JSON object bound to SQL parameters.")
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+def applet_sql(applet_id: str, sql: str, parameters: str, service_url: str) -> None:
+    """Execute one parameterized statement as an applet's database role."""
+    try:
+        values = json.loads(parameters)
+        if not isinstance(values, dict):
+            raise ValueError("--parameters must be a JSON object")
+        origin = _applet_origin(service_url, applet_id)
+        result = marina_request(
+            origin,
+            "POST",
+            f"/a/{applet_id}/query",
+            json_body={"sql": sql, "parameters": values},
+        )
+    except (RuntimeError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(result, indent=2, sort_keys=True))
+
+
+@applets.group("table")
+def applet_tables() -> None:
+    """Load local tabular files into an applet schema."""
+
+
+@applet_tables.command("load")
+@click.argument("applet_id")
+@click.argument("table_name")
+@click.argument("source", type=click.Path(path_type=Path, dir_okay=False, exists=True))
+@click.option("--replace", is_flag=True, help="Drop and recreate the table before loading.")
+@click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
+def load_applet_table(applet_id: str, table_name: str, source: Path, replace: bool, service_url: str) -> None:
+    """Load JSON, JSONL, CSV, or Parquet rows into an applet table."""
+    try:
+        table = read_table(source)
+        schema_sql, inserts = table_statements(table_name, table, replace)
+        origin = _applet_origin(service_url, applet_id)
+        for statement in schema_sql:
+            marina_request(
+                origin,
+                "POST",
+                f"/a/{applet_id}/query",
+                json_body={"sql": statement, "parameters": {}},
+            )
+        for statement, parameters in inserts:
+            marina_request(
+                origin,
+                "POST",
+                f"/a/{applet_id}/query",
+                json_body={"sql": statement, "parameters": parameters},
+            )
+    except (RuntimeError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"loaded {table.num_rows} rows into {table_name}")
 
 
 @cli.command()

--- a/infra/marina/src/marina/cli.py
+++ b/infra/marina/src/marina/cli.py
@@ -6,6 +6,8 @@
 import json
 import os
 import subprocess
+import tempfile
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -26,6 +28,7 @@ from marina.client import DEFAULT_MARINA_URL, marina_request, publish_applet
 from marina.database_setup import APPLET_READER_ROLE, ensure_applet_provisioning
 from marina.db import (
     DatabaseSpec,
+    UrlDatabase,
     database_from_env,
     deployment_runner_lock,
     grant_read,
@@ -34,6 +37,8 @@ from marina.db import (
     schema_name,
 )
 from marina.journey_plugin import DEFAULT_SHOTS_DIR, JOURNEYS_DIR
+from marina.journeys import running_kernel
+from marina.local_postgres import docker_database
 from marina.manifest import AppManifest, JobRunner, discover_apps, job_runners
 from marina.server import APPS_DIR_ENV, MarinaConfig, create_app
 from marina.table_load import read_table, table_statements
@@ -207,12 +212,45 @@ def _print_publish_result(result: dict[str, object], service_url: str, *, json_o
     click.echo(result["url"])
 
 
+def _serve_local_applet(payload: bytes, *, json_output: bool) -> None:
+    try:
+        with docker_database() as database_url:
+            database = UrlDatabase(database_url)
+            _migrate_apps([], database, (), None)
+            with tempfile.TemporaryDirectory(prefix="marina-local-applet-") as directory:
+                root = Path(directory)
+                apps_dir = root / "apps"
+                data_root = root / "data"
+                apps_dir.mkdir()
+                data_root.mkdir()
+                config = MarinaConfig(
+                    apps_dir=apps_dir,
+                    data_root=str(data_root),
+                    iap_audience=None,
+                    database=database,
+                )
+                with running_kernel(config) as kernel:
+                    result = publish_applet(kernel.origin, payload)
+                    _print_publish_result(result, kernel.origin, json_output=json_output)
+                    click.echo("Serving until Ctrl-C; Postgres and Marina will be removed on exit.", err=True)
+                    try:
+                        threading.Event().wait()
+                    except KeyboardInterrupt:
+                        return
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode(errors="replace").strip() if isinstance(error.stderr, bytes) else error.stderr
+        raise click.ClickException(detail or str(error)) from error
+    except (OSError, RuntimeError) as error:
+        raise click.ClickException(str(error)) from error
+
+
 @cli.command()
 @click.argument("app_dir", type=click.Path(path_type=Path, file_okay=False, exists=True))
 @click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
 @click.option("--update", "applet_id", default=None, help="Applet UUID to update.")
 @click.option("--base-version", type=int, default=None, help="Current version required by an update.")
 @click.option("--build/--no-build", default=True, help="Run build_command when dist/index.html is absent.")
+@click.option("--local", is_flag=True, help="Run this applet against disposable Postgres and Marina.")
 @click.option("--dry-run", is_flag=True, help="Validate and print package contents without publishing.")
 @click.option("--json", "json_output", is_flag=True, help="Print the publish result as JSON.")
 def publish(
@@ -221,11 +259,20 @@ def publish(
     applet_id: str | None,
     base_version: int | None,
     build: bool,
+    local: bool,
     dry_run: bool,
     json_output: bool,
 ) -> None:
     """Publish a built applet directory and print its URL."""
+    if local:
+        if dry_run:
+            raise click.UsageError("--local cannot be combined with --dry-run")
+        if applet_id is not None or base_version is not None:
+            raise click.UsageError("--local cannot be combined with --update or --base-version")
     payload, package = _publish_package(app_dir, build=build)
+    if local:
+        _serve_local_applet(payload, json_output=json_output)
+        return
     if dry_run:
         _print_dry_run(package, json_output=json_output)
         return

--- a/infra/marina/src/marina/cli.py
+++ b/infra/marina/src/marina/cli.py
@@ -13,7 +13,14 @@ import click
 import pytest
 import uvicorn
 
-from marina.applets import APPLET_MANIFEST, AppletStore, package_applet, parse_applet_manifest, read_applet_package
+from marina.applets import (
+    APPLET_MANIFEST,
+    AppletPackage,
+    AppletStore,
+    package_applet,
+    parse_applet_manifest,
+    read_applet_package,
+)
 from marina.apps import is_python_app, migration, services_for
 from marina.client import DEFAULT_MARINA_URL, marina_request, publish_applet
 from marina.database_setup import APPLET_READER_ROLE, ensure_applet_provisioning
@@ -159,6 +166,47 @@ def run_jobs(runner_name: str, apps_dir: Path, reader: str | None, migrate_only:
             raise click.ClickException(f"job failures: {', '.join(failures)}")
 
 
+def _publish_package(app_dir: Path, *, build: bool) -> tuple[bytes, AppletPackage]:
+    manifest_path = app_dir / APPLET_MANIFEST
+    if not manifest_path.is_file():
+        raise click.UsageError(f"{app_dir} has no {APPLET_MANIFEST}")
+    manifest = parse_applet_manifest(manifest_path.read_bytes())
+    if not (app_dir / "dist" / "index.html").is_file() and build:
+        if manifest.build_command is None:
+            raise click.UsageError("dist/index.html is absent and applet.toml has no build_command")
+        subprocess.run(manifest.build_command, shell=True, cwd=app_dir, check=True)
+    try:
+        payload = package_applet(app_dir)
+    except ValueError as error:
+        raise click.UsageError(str(error)) from error
+    return payload, read_applet_package(payload)
+
+
+def _print_dry_run(package: AppletPackage, *, json_output: bool) -> None:
+    files = sorted(package.files)
+    report = {
+        "files": files,
+        "file_count": len(files),
+        "byte_size": package.byte_size,
+        "digest": package.digest.hex(),
+    }
+    if json_output:
+        click.echo(json.dumps(report, sort_keys=True))
+        return
+    click.echo(f"{report['file_count']} files, {report['byte_size']} bytes, sha256 {report['digest']}")
+    for path in files:
+        click.echo(path)
+
+
+def _print_publish_result(result: dict[str, object], service_url: str, *, json_output: bool) -> None:
+    if not isinstance(result.get("url"), str) or not urlparse(str(result["url"])).netloc:
+        result["url"] = service_url.rstrip("/") + str(result["path"])
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+    click.echo(result["url"])
+
+
 @cli.command()
 @click.argument("app_dir", type=click.Path(path_type=Path, file_okay=False, exists=True))
 @click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
@@ -177,33 +225,9 @@ def publish(
     json_output: bool,
 ) -> None:
     """Publish a built applet directory and print its URL."""
-    manifest_path = app_dir / APPLET_MANIFEST
-    if not manifest_path.is_file():
-        raise click.UsageError(f"{app_dir} has no {APPLET_MANIFEST}")
-    manifest = parse_applet_manifest(manifest_path.read_bytes())
-    if not (app_dir / "dist" / "index.html").is_file() and build:
-        if manifest.build_command is None:
-            raise click.UsageError("dist/index.html is absent and applet.toml has no build_command")
-        subprocess.run(manifest.build_command, shell=True, cwd=app_dir, check=True)
-    try:
-        payload = package_applet(app_dir)
-    except ValueError as error:
-        raise click.UsageError(str(error)) from error
-    package = read_applet_package(payload)
+    payload, package = _publish_package(app_dir, build=build)
     if dry_run:
-        files = sorted(package.files)
-        report = {
-            "files": files,
-            "file_count": len(files),
-            "byte_size": package.byte_size,
-            "digest": package.digest.hex(),
-        }
-        if json_output:
-            click.echo(json.dumps(report, sort_keys=True))
-        else:
-            click.echo(f"{report['file_count']} files, {report['byte_size']} bytes, sha256 {report['digest']}")
-            for path in files:
-                click.echo(path)
+        _print_dry_run(package, json_output=json_output)
         return
     if (applet_id is None) != (base_version is None):
         raise click.UsageError("--update and --base-version must be supplied together")
@@ -211,12 +235,7 @@ def publish(
         result = publish_applet(service_url, payload, applet_id=applet_id, base_version=base_version)
     except RuntimeError as error:
         raise click.ClickException(str(error)) from error
-    if not isinstance(result.get("url"), str) or not urlparse(str(result["url"])).netloc:
-        result["url"] = service_url.rstrip("/") + str(result["path"])
-    if json_output:
-        click.echo(json.dumps(result, sort_keys=True))
-    else:
-        click.echo(result["url"])
+    _print_publish_result(result, service_url, json_output=json_output)
 
 
 @cli.group()
@@ -348,7 +367,7 @@ def load_applet_table(applet_id: str, table_name: str, source: Path, replace: bo
     """Load JSON, JSONL, CSV, or Parquet rows into an applet table."""
     try:
         table = read_table(source)
-        schema_sql, inserts = table_statements(table_name, table, replace)
+        schema_sql, inserts = table_statements(table_name, table, replace=replace)
         origin = _applet_origin(service_url, applet_id)
         for statement in schema_sql:
             marina_request(

--- a/infra/marina/src/marina/client.py
+++ b/infra/marina/src/marina/client.py
@@ -1,0 +1,101 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated HTTP client helpers for Marina's command line."""
+
+from urllib.parse import urlparse
+
+import requests
+from rigging.auth import (
+    MARIN_DESKTOP_OAUTH_CLIENT,
+    IapCredentialsUnavailable,
+    IapLoginRequired,
+    IapServiceAccountTokenProvider,
+    TokenProvider,
+)
+from rigging.credential_store import credentials_dir
+from rigging.credentials import iap_edge_provider
+
+DEFAULT_MARINA_URL = "https://marina.oa.dev"
+DEFAULT_TIMEOUT = 60
+
+
+def _cached_login_provider() -> TokenProvider | None:
+    provider = iap_edge_provider("marin")
+    if provider is not None:
+        return provider
+    for path in sorted(credentials_dir().glob("*.json")):
+        candidate = iap_edge_provider(path.stem)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def bearer_token() -> str:
+    """Return an IAP token from a cached Marin login or ambient service account."""
+    provider = _cached_login_provider() or IapServiceAccountTokenProvider(MARIN_DESKTOP_OAUTH_CLIENT.client_id)
+    try:
+        token = provider.get_token()
+    except (IapCredentialsUnavailable, IapLoginRequired) as error:
+        raise RuntimeError(f"{error}; human callers should run `iris login`") from error
+    if not token:
+        raise RuntimeError("could not obtain an IAP token for Marina")
+    return token
+
+
+def marina_request(
+    service_url: str,
+    method: str,
+    path: str,
+    *,
+    json_body: object | None = None,
+    payload: bytes | None = None,
+    params: dict[str, object] | None = None,
+) -> object | None:
+    """Call one Marina endpoint with the shared CLI authentication behavior."""
+    service_url = service_url.rstrip("/")
+    headers: dict[str, str] = {}
+    if payload is not None:
+        headers["Content-Type"] = "application/gzip"
+    host = urlparse(service_url).hostname
+    if host not in {"127.0.0.1", "localhost"}:
+        headers["Authorization"] = f"Bearer {bearer_token()}"
+    response = requests.request(
+        method,
+        service_url + path,
+        params=params,
+        json=json_body,
+        data=payload,
+        headers=headers,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    if response.status_code >= 400:
+        detail = (
+            response.json().get("detail", response.text)
+            if "json" in response.headers.get("content-type", "")
+            else response.text
+        )
+        raise RuntimeError(f"Marina request failed ({response.status_code}): {detail}")
+    if response.status_code == 204:
+        return None
+    return response.json()
+
+
+def publish_applet(
+    service_url: str,
+    payload: bytes,
+    applet_id: str | None = None,
+    base_version: int | None = None,
+) -> dict[str, object]:
+    """Publish an applet archive and return Marina's structured response."""
+    path = "/api/marina/applets" + (f"/{applet_id}" if applet_id is not None else "")
+    value = marina_request(
+        service_url,
+        "POST",
+        path,
+        params={"base_version": base_version} if base_version is not None else None,
+        payload=payload,
+    )
+    if not isinstance(value, dict):
+        raise RuntimeError("Marina returned a non-object publish response")
+    return value

--- a/infra/marina/src/marina/database_setup.py
+++ b/infra/marina/src/marina/database_setup.py
@@ -9,7 +9,9 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 APPLET_READER_ROLE = "marina_reader"
-PROVISION_APPLET_FUNCTION = "marina.provision_applet"
+APPLET_ROLE_PREFIX = "applet_"
+MARINA_SCHEMA = "marina"
+PROVISION_APPLET_FUNCTION = f"{MARINA_SCHEMA}.provision_applet"
 POSTGRES_ROLE_PATTERN = re.compile(r"^[A-Za-z0-9_@.\-]+$")
 
 
@@ -23,8 +25,8 @@ def applet_provisioning_statements(service_role: str) -> tuple[str, ...]:
     """SQL an administrator runs once to let Marina provision constrained applet roles."""
     service = _quoted_role(service_role)
     return (
-        f"CREATE SCHEMA IF NOT EXISTS marina AUTHORIZATION {service}",
-        f"GRANT ALL ON SCHEMA marina TO {service}",
+        f"CREATE SCHEMA IF NOT EXISTS {MARINA_SCHEMA} AUTHORIZATION {service}",
+        f"GRANT ALL ON SCHEMA {MARINA_SCHEMA} TO {service}",
         f"""DO $$
         BEGIN
             CREATE ROLE {APPLET_READER_ROLE} NOLOGIN;
@@ -41,7 +43,7 @@ def applet_provisioning_statements(service_role: str) -> tuple[str, ...]:
         SET search_path = pg_catalog
         AS $$
         DECLARE
-            applet_role TEXT := 'applet_' || replace(applet_id::TEXT, '-', '');
+            applet_role TEXT := '{APPLET_ROLE_PREFIX}' || replace(applet_id::TEXT, '-', '');
         BEGIN
             IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = applet_role) THEN
                 EXECUTE format('CREATE ROLE %I NOLOGIN', applet_role);
@@ -66,7 +68,7 @@ def ensure_applet_provisioning(engine: Engine) -> None:
             text("SELECT current_user, rolcreaterole OR rolsuper FROM pg_roles " "WHERE rolname = current_user")
         ).one()
         installed = connection.execute(
-            text("SELECT to_regprocedure('marina.provision_applet(uuid)') IS NOT NULL")
+            text(f"SELECT to_regprocedure('{PROVISION_APPLET_FUNCTION}(uuid)') IS NOT NULL")
         ).scalar_one()
         if installed:
             return

--- a/infra/marina/src/marina/database_setup.py
+++ b/infra/marina/src/marina/database_setup.py
@@ -1,0 +1,76 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Privileged Postgres setup for Marina's dynamic applets."""
+
+import re
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+APPLET_READER_ROLE = "marina_reader"
+PROVISION_APPLET_FUNCTION = "marina.provision_applet"
+POSTGRES_ROLE_PATTERN = re.compile(r"^[A-Za-z0-9_@.\-]+$")
+
+
+def _quoted_role(role: str) -> str:
+    if not POSTGRES_ROLE_PATTERN.fullmatch(role):
+        raise ValueError(f"invalid Postgres role {role!r}")
+    return '"' + role.replace('"', '""') + '"'
+
+
+def applet_provisioning_statements(service_role: str) -> tuple[str, ...]:
+    """SQL an administrator runs once to let Marina provision constrained applet roles."""
+    service = _quoted_role(service_role)
+    return (
+        f"CREATE SCHEMA IF NOT EXISTS marina AUTHORIZATION {service}",
+        f"GRANT ALL ON SCHEMA marina TO {service}",
+        f"""DO $$
+        BEGIN
+            CREATE ROLE {APPLET_READER_ROLE} NOLOGIN;
+        EXCEPTION WHEN duplicate_object THEN
+            ALTER ROLE {APPLET_READER_ROLE} NOLOGIN;
+        END
+        $$""",
+        "REVOKE CREATE ON SCHEMA public FROM PUBLIC",
+        f"GRANT USAGE ON SCHEMA public TO {APPLET_READER_ROLE}",
+        f"""CREATE OR REPLACE FUNCTION {PROVISION_APPLET_FUNCTION}(applet_id UUID)
+        RETURNS TEXT
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = pg_catalog
+        AS $$
+        DECLARE
+            applet_role TEXT := 'applet_' || replace(applet_id::TEXT, '-', '');
+        BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = applet_role) THEN
+                EXECUTE format('CREATE ROLE %I NOLOGIN', applet_role);
+            END IF;
+            EXECUTE format('GRANT {APPLET_READER_ROLE} TO %I', applet_role);
+            EXECUTE format('GRANT %I TO %I', applet_role, {service_role!r});
+            EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I AUTHORIZATION %I', applet_role, applet_role);
+            EXECUTE format('ALTER SCHEMA %I OWNER TO %I', applet_role, applet_role);
+            EXECUTE format('GRANT USAGE ON SCHEMA %I TO {APPLET_READER_ROLE}', applet_role);
+            RETURN applet_role;
+        END
+        $$""",
+        f"REVOKE ALL ON FUNCTION {PROVISION_APPLET_FUNCTION}(UUID) FROM PUBLIC",
+        f"GRANT EXECUTE ON FUNCTION {PROVISION_APPLET_FUNCTION}(UUID) TO {service}",
+    )
+
+
+def ensure_applet_provisioning(engine: Engine) -> None:
+    """Install provisioning as a local admin, or verify an operator already installed it."""
+    with engine.begin() as connection:
+        service_role, can_create_role = connection.execute(
+            text("SELECT current_user, rolcreaterole OR rolsuper FROM pg_roles " "WHERE rolname = current_user")
+        ).one()
+        installed = connection.execute(
+            text("SELECT to_regprocedure('marina.provision_applet(uuid)') IS NOT NULL")
+        ).scalar_one()
+        if installed:
+            return
+        if not can_create_role:
+            raise RuntimeError("an administrator must install marina.provision_applet before marina migrate")
+        for statement in applet_provisioning_statements(service_role):
+            connection.execute(text(statement))

--- a/infra/marina/src/marina/db.py
+++ b/infra/marina/src/marina/db.py
@@ -20,7 +20,7 @@ from enum import StrEnum
 import sqlalchemy
 from google.cloud.sql.connector import Connector
 from sqlalchemy import event, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
 
 logger = logging.getLogger(__name__)
 
@@ -109,12 +109,17 @@ def grant_read(engine: Engine, schema: str, role: str) -> None:
     write and hold every reader behind it, so the grant gives up rather than wait.
     """
     with engine.begin() as conn:
-        conn.execute(text(f"SET LOCAL lock_timeout = '{GRANT_LOCK_TIMEOUT}'"))
-        conn.execute(text(f'GRANT USAGE ON SCHEMA "{schema}" TO "{role}"'))
-        conn.execute(text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{schema}" TO "{role}"'))
-        conn.execute(text(f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role}"'))
-        conn.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON TABLES TO "{role}"'))
-        conn.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON SEQUENCES TO "{role}"'))
+        grant_read_on_connection(conn, schema, role)
+
+
+def grant_read_on_connection(connection: Connection, schema: str, role: str) -> None:
+    """Let ``role`` read existing and future relations in ``schema`` within a caller transaction."""
+    connection.execute(text(f"SET LOCAL lock_timeout = '{GRANT_LOCK_TIMEOUT}'"))
+    connection.execute(text(f'GRANT USAGE ON SCHEMA "{schema}" TO "{role}"'))
+    connection.execute(text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{schema}" TO "{role}"'))
+    connection.execute(text(f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role}"'))
+    connection.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON TABLES TO "{role}"'))
+    connection.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON SEQUENCES TO "{role}"'))
 
 
 def engine_for(spec: DatabaseSpec, app: str) -> Engine:

--- a/infra/marina/src/marina/db.py
+++ b/infra/marina/src/marina/db.py
@@ -112,7 +112,9 @@ def grant_read(engine: Engine, schema: str, role: str) -> None:
         conn.execute(text(f"SET LOCAL lock_timeout = '{GRANT_LOCK_TIMEOUT}'"))
         conn.execute(text(f'GRANT USAGE ON SCHEMA "{schema}" TO "{role}"'))
         conn.execute(text(f'GRANT SELECT ON ALL TABLES IN SCHEMA "{schema}" TO "{role}"'))
+        conn.execute(text(f'GRANT SELECT ON ALL SEQUENCES IN SCHEMA "{schema}" TO "{role}"'))
         conn.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON TABLES TO "{role}"'))
+        conn.execute(text(f'ALTER DEFAULT PRIVILEGES IN SCHEMA "{schema}" GRANT SELECT ON SEQUENCES TO "{role}"'))
 
 
 def engine_for(spec: DatabaseSpec, app: str) -> Engine:
@@ -135,6 +137,21 @@ def engine_for(spec: DatabaseSpec, app: str) -> Engine:
 
     with engine.begin() as conn:
         conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+    return engine
+
+
+def engine_for_role(spec: DatabaseSpec, schema: str, role: str) -> Engine:
+    """An engine whose connections assume a pre-provisioned role and schema."""
+    engine = _bare_engine(spec)
+
+    @event.listens_for(engine, "connect")
+    def _set_role_and_search_path(dbapi_connection, _record) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute(f'SET ROLE "{role}"')
+        cursor.execute(f'SET search_path TO "{schema}", public')
+        cursor.close()
+        dbapi_connection.commit()
+
     return engine
 
 

--- a/infra/marina/src/marina/local_postgres.py
+++ b/infra/marina/src/marina/local_postgres.py
@@ -1,0 +1,70 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Disposable Postgres for local Marina processes."""
+
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import sqlalchemy
+
+from marina.journeys import free_port
+
+POSTGRES_IMAGE = "pgvector/pgvector:0.8.5-pg16-bookworm"
+POSTGRES_PASSWORD = "marina"
+START_TIMEOUT = 60.0
+
+
+def _wait_ready(url: str) -> None:
+    deadline = time.monotonic() + START_TIMEOUT
+    engine = sqlalchemy.create_engine(url)
+    refused: Exception | None = None
+    try:
+        while time.monotonic() < deadline:
+            try:
+                with engine.connect() as conn:
+                    conn.execute(sqlalchemy.text("SELECT 1"))
+                return
+            except (sqlalchemy.exc.SQLAlchemyError, OSError) as error:
+                # A container that is still starting may refuse the connection or
+                # reset it mid-handshake. Preserve the last error for a useful timeout.
+                refused = error
+                time.sleep(0.3)
+        raise RuntimeError(f"postgres at {url} did not become ready within {START_TIMEOUT}s") from refused
+    finally:
+        engine.dispose()
+
+
+@contextmanager
+def docker_database() -> Iterator[str]:
+    """Run disposable Postgres in Docker and yield its SQLAlchemy URL."""
+    port = free_port()
+    name = f"marina-postgres-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--name",
+            name,
+            "-e",
+            f"POSTGRES_PASSWORD={POSTGRES_PASSWORD}",
+            "-e",
+            "POSTGRES_DB=marina",
+            "-p",
+            f"127.0.0.1:{port}:5432",
+            POSTGRES_IMAGE,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    url = f"postgresql+pg8000://postgres:{POSTGRES_PASSWORD}@127.0.0.1:{port}/marina"
+    try:
+        _wait_ready(url)
+        yield url
+    finally:
+        subprocess.run(["docker", "rm", "--force", name], check=False, capture_output=True)

--- a/infra/marina/src/marina/server.py
+++ b/infra/marina/src/marina/server.py
@@ -194,7 +194,7 @@ def applet_directory(store: AppletStore | None, applet_origin: str | None) -> li
             "published_by": applet.owner,
             "version": applet.current_version,
         }
-        for applet in store.apps()
+        for applet in store.active_applets()
     ]
 
 

--- a/infra/marina/src/marina/server.py
+++ b/infra/marina/src/marina/server.py
@@ -632,7 +632,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         try:
             version = await run_in_threadpool(applet_store.current_version, applet_id)
             applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
-            return await call_applet_api(applet_api, request, path)
+            with identity_scope(identity_for(request, policy)):
+                return await call_applet_api(applet_api, request, path)
         except AppletNotFound as error:
             raise HTTPException(status_code=404, detail="applet API not found") from error
         except AppletBackendUnavailable as error:
@@ -649,7 +650,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
             raise HTTPException(status_code=404, detail="applet API not found")
         try:
             applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
-            return await call_applet_api(applet_api, request, path)
+            with identity_scope(identity_for(request, policy)):
+                return await call_applet_api(applet_api, request, path)
         except AppletNotFound as error:
             raise HTTPException(status_code=404, detail="applet API not found") from error
         except AppletBackendUnavailable as error:

--- a/infra/marina/src/marina/server.py
+++ b/infra/marina/src/marina/server.py
@@ -423,8 +423,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         if len(payload) > MAX_ARCHIVE_BYTES:
             raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
         try:
-            package = read_applet_package(payload)
-            validate_backend_import(package)
+            package = await run_in_threadpool(read_applet_package, payload)
+            await run_in_threadpool(validate_backend_import, package)
             owner = identity_for(request, policy).user_id
             published = await run_in_threadpool(applet_store.publish, package, owner)
         except ValueError as error:
@@ -448,8 +448,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         if len(payload) > MAX_ARCHIVE_BYTES:
             raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
         try:
-            package = read_applet_package(payload)
-            validate_backend_import(package)
+            package = await run_in_threadpool(read_applet_package, payload)
+            await run_in_threadpool(validate_backend_import, package)
             owner = identity_for(request, policy).user_id
             published = await run_in_threadpool(
                 applet_store.publish,
@@ -458,6 +458,13 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
                 applet_id,
                 base_version,
                 config.applet_operators,
+            )
+            retained = await run_in_threadpool(applet_store.versions, applet_id)
+            assert applet_runtime is not None
+            await run_in_threadpool(
+                applet_runtime.retain_versions,
+                applet_id,
+                {item.version for item in retained},
             )
         except ValueError as error:
             raise HTTPException(status_code=400, detail=str(error)) from error
@@ -544,6 +551,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         actor = identity_for(request, policy).user_id
         try:
             await run_in_threadpool(applet_store.archive, applet_id, actor, config.applet_operators)
+            assert applet_runtime is not None
+            await run_in_threadpool(applet_runtime.retain_versions, applet_id, set())
         except AppletNotFound as error:
             raise HTTPException(status_code=404, detail="applet not found") from error
         except AppletForbidden as error:

--- a/infra/marina/src/marina/server.py
+++ b/infra/marina/src/marina/server.py
@@ -19,10 +19,14 @@ import html
 import mimetypes
 import os
 import posixpath
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 
-from fastapi import FastAPI, Request
+import httpx
+import sqlalchemy
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import prefix_join
@@ -39,6 +43,19 @@ from rigging.server_auth import (
 from starlette.concurrency import run_in_threadpool
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from marina.applets import (
+    MAX_ARCHIVE_BYTES,
+    AppletBackendUnavailable,
+    AppletConflict,
+    AppletForbidden,
+    AppletNotFound,
+    AppletRuntime,
+    AppletStore,
+    InvalidQuery,
+    QueryLimitExceeded,
+    read_applet_package,
+    validate_backend_import,
+)
 from marina.apps import create_api, data_url_for, is_python_app, services_for
 from marina.auth import build_policy, identity_for
 from marina.db import DatabaseSpec, database_from_env
@@ -59,12 +76,14 @@ HOST_APPS_ENV = "MARINA_HOST_APPS"
 # The origin the apps are served from. Aliased hosts send every request here, so one URL
 # space holds the apps and a link from one app to another resolves against this origin.
 CANONICAL_ORIGIN_ENV = "MARINA_CANONICAL_ORIGIN"
+APPLET_ORIGIN_ENV = "MARINA_APPLET_ORIGIN"
+APPLET_OPERATORS_ENV = "MARINA_APPLET_OPERATORS"
 DATA_PREFIX = "data/"
 API_PREFIX = "/api"
 # The first path segment the kernel answers itself. An app named for one of these would
 # register the same route and lose it: FastAPI keeps the first match, and the kernel's
 # routes are installed before any app's.
-KERNEL_PREFIXES = frozenset({"api", "healthz"})
+KERNEL_PREFIXES = frozenset({"a", "api", "healthz"})
 DATA_CACHE_CONTROL = "private, max-age=300"
 
 
@@ -81,6 +100,9 @@ class MarinaConfig:
     host_apps: dict[str, str] = field(default_factory=dict)
     # Scheme and host the aliased hosts redirect to, e.g. https://marina.oa.dev.
     canonical_origin: str | None = None
+    # A separate IAP-gated origin that exposes only /a/* applet routes.
+    applet_origin: str | None = None
+    applet_operators: frozenset[str] = frozenset()
 
     @classmethod
     def from_env(cls, default_apps_dir: Path) -> "MarinaConfig":
@@ -99,6 +121,10 @@ class MarinaConfig:
             database=database_from_env(os.environ),
             host_apps=parse_host_apps(os.environ.get(HOST_APPS_ENV, "")),
             canonical_origin=(os.environ.get(CANONICAL_ORIGIN_ENV) or "").rstrip("/") or None,
+            applet_origin=(os.environ.get(APPLET_ORIGIN_ENV) or "").rstrip("/") or None,
+            applet_operators=frozenset(
+                item.strip() for item in os.environ.get(APPLET_OPERATORS_ENV, "").split(",") if item.strip()
+            ),
         )
 
 
@@ -153,10 +179,76 @@ def app_directory(apps: list[AppManifest]) -> list[dict[str, str]]:
     return [{"name": app.name, "title": app.title, "description": app.description, "path": app.path} for app in apps]
 
 
-def landing_page(apps: list[AppManifest]) -> str:
+def applet_directory(store: AppletStore | None, applet_origin: str | None) -> list[dict[str, object]]:
+    if store is None:
+        return []
+    return [
+        {
+            "name": str(applet.id),
+            "title": applet.title,
+            "description": applet.description,
+            "path": (applet_origin or "") + applet.path,
+            "kind": "applet",
+            "published_by": applet.owner,
+            "version": applet.current_version,
+        }
+        for applet in store.apps()
+    ]
+
+
+def applet_content_security_policy(connect_src: tuple[str, ...]) -> str:
+    connect = " ".join(("'self'", *connect_src))
+    return (
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+        f"img-src 'self' data:; font-src 'self' data:; connect-src {connect}; frame-ancestors 'none'"
+    )
+
+
+def accepts_encoding(header: str, encoding: str) -> bool:
+    """Whether an HTTP Accept-Encoding value permits one named encoding."""
+    qualities: dict[str, float] = {}
+    for item in header.split(","):
+        name, *parameters = item.split(";")
+        name = name.strip().lower()
+        if name not in {encoding.lower(), "*"}:
+            continue
+        quality = next((value for value in parameters if value.strip().lower().startswith("q=")), "q=1")
+        try:
+            qualities[name] = float(quality.split("=", 1)[1])
+        except ValueError:
+            qualities[name] = 0
+    return qualities.get(encoding.lower(), qualities.get("*", 0)) > 0
+
+
+def accepts_html(header: str) -> bool:
+    accepted = {item.split(";", 1)[0].strip().lower() for item in header.split(",")}
+    return not accepted or "text/html" in accepted or "*/*" in accepted
+
+
+def sqlstate(error: sqlalchemy.exc.SQLAlchemyError) -> str | None:
+    original = getattr(error, "orig", None)
+    if original is None or not original.args or not isinstance(original.args[0], dict):
+        return None
+    value = original.args[0].get("C")
+    return str(value) if value is not None else None
+
+
+async def request_json(request: Request) -> object:
+    try:
+        return await request.json()
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail="request body is not valid JSON") from error
+
+
+def landing_page(apps: list[AppManifest], applets: list[dict[str, object]] | None = None) -> str:
+    entries = [
+        *({"title": app.title, "description": app.description, "path": app.path} for app in apps),
+        *(applets or []),
+    ]
     rows = "".join(
-        f'<li><a href="{app.path}">{html.escape(app.title)}</a>' f"<span>{html.escape(app.description)}</span></li>"
-        for app in apps
+        f'<li><a href="{html.escape(str(app["path"]))}">{html.escape(str(app["title"]))}</a>'
+        f'<span>{html.escape(str(app["description"]))}</span></li>'
+        for app in entries
     )
     return (
         "<!doctype html><meta charset=utf-8><meta name=viewport content='width=device-width,initial-scale=1'>"
@@ -263,6 +355,29 @@ def install_app_routes(api: FastAPI, app: AppManifest, data_root: str) -> None:
         return serve_app_file(app, path)
 
 
+async def call_applet_api(app: ASGIApp, request: Request, path: str) -> Response:
+    """Forward one request to a revision-specific in-process ASGI app."""
+    headers = {
+        name: value
+        for name, value in request.headers.items()
+        if name.lower() not in {"content-length", "host", "transfer-encoding"}
+    }
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://applet") as client:
+        response = await client.request(
+            request.method,
+            f"/{path}",
+            params=request.query_params,
+            headers=headers,
+            content=await request.body(),
+        )
+    forwarded = {
+        name: value
+        for name, value in response.headers.items()
+        if name.lower() not in {"content-length", "content-encoding", "transfer-encoding", "connection"}
+    }
+    return Response(response.content, status_code=response.status_code, headers=forwarded)
+
+
 def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     apps = discover_apps(config.apps_dir)
     shadowed = sorted(app.name for app in apps if app.name in KERNEL_PREFIXES)
@@ -270,6 +385,8 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         raise ValueError(f"app {shadowed[0]!r} is named for a kernel route; rename it")
     policy = build_policy(config.iap_audience)
     api = FastAPI(title="Marina", docs_url=None, redoc_url=None)
+    applet_store = AppletStore(config.database) if config.database is not None else None
+    applet_runtime = AppletRuntime(applet_store) if applet_store is not None else None
 
     @api.get("/healthz", include_in_schema=False)
     @public
@@ -279,7 +396,12 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     @api.get("/api/marina/apps")
     @requires_auth
     def list_apps() -> JSONResponse:
-        return JSONResponse({"apps": app_directory(apps)})
+        return JSONResponse({"apps": [*app_directory(apps), *applet_directory(applet_store, config.applet_origin)]})
+
+    @api.get("/api/marina/applets")
+    @requires_auth
+    def list_applets() -> JSONResponse:
+        return JSONResponse({"applets": applet_directory(applet_store, config.applet_origin)})
 
     @api.get("/api/marina/me")
     @requires_auth
@@ -290,7 +412,314 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     @api.get("/", include_in_schema=False)
     @requires_auth
     def landing() -> HTMLResponse:
-        return HTMLResponse(landing_page(apps))
+        return HTMLResponse(landing_page(apps, applet_directory(applet_store, config.applet_origin)))
+
+    @api.post("/api/marina/applets")
+    @requires_auth
+    async def publish_applet(request: Request) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=503, detail="Marina has no database configured")
+        payload = await request.body()
+        if len(payload) > MAX_ARCHIVE_BYTES:
+            raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+        try:
+            package = read_applet_package(payload)
+            validate_backend_import(package)
+            owner = identity_for(request, policy).user_id
+            published = await run_in_threadpool(applet_store.publish, package, owner)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+        return JSONResponse(
+            {
+                "id": str(published.applet_id),
+                "version": published.version,
+                "path": published.path,
+                "url": (config.applet_origin or "") + published.path,
+            },
+            status_code=201,
+        )
+
+    @api.post("/api/marina/applets/{applet_id}")
+    @requires_auth
+    async def update_applet(applet_id: uuid.UUID, base_version: int, request: Request) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=503, detail="Marina has no database configured")
+        payload = await request.body()
+        if len(payload) > MAX_ARCHIVE_BYTES:
+            raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+        try:
+            package = read_applet_package(payload)
+            validate_backend_import(package)
+            owner = identity_for(request, policy).user_id
+            published = await run_in_threadpool(
+                applet_store.publish,
+                package,
+                owner,
+                applet_id,
+                base_version,
+                config.applet_operators,
+            )
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet not found") from error
+        except AppletForbidden as error:
+            raise HTTPException(status_code=403, detail="only the publisher may update this applet") from error
+        except AppletConflict as error:
+            raise HTTPException(status_code=409, detail="applet has a newer current version") from error
+        return JSONResponse(
+            {
+                "id": str(published.applet_id),
+                "version": published.version,
+                "path": published.path,
+                "url": (config.applet_origin or "") + published.path,
+            },
+            status_code=201,
+        )
+
+    @api.get("/api/marina/applets/{applet_id}")
+    @requires_auth
+    async def applet_details(applet_id: uuid.UUID) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        try:
+            current = await run_in_threadpool(applet_store.current_version, applet_id)
+            versions = await run_in_threadpool(applet_store.versions, applet_id)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet not found") from error
+        return JSONResponse(
+            {
+                "id": str(applet_id),
+                "current_version": current,
+                "url": f"{config.applet_origin or ''}/a/{applet_id}/",
+                "versions": [
+                    {
+                        "version": item.version,
+                        "published_by": item.published_by,
+                        "published_at": item.published_at.isoformat(),
+                        "byte_size": item.byte_size,
+                    }
+                    for item in versions
+                ],
+            }
+        )
+
+    @api.put("/api/marina/applets/{applet_id}/current")
+    @requires_auth
+    async def rollback_applet(applet_id: uuid.UUID, request: Request) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        body = await request_json(request)
+        if (
+            not isinstance(body, dict)
+            or not isinstance(body.get("version"), int)
+            or not isinstance(body.get("base_version"), int)
+        ):
+            raise HTTPException(status_code=400, detail="body must contain integer version and base_version")
+        actor = identity_for(request, policy).user_id
+        try:
+            await run_in_threadpool(
+                applet_store.rollback,
+                applet_id,
+                body["version"],
+                actor,
+                body["base_version"],
+                config.applet_operators,
+            )
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet or revision not found") from error
+        except AppletForbidden as error:
+            raise HTTPException(
+                status_code=403, detail="only the publisher or an operator may roll back this applet"
+            ) from error
+        except AppletConflict as error:
+            raise HTTPException(status_code=409, detail="applet has a newer current version") from error
+        return JSONResponse({"id": str(applet_id), "version": body["version"]})
+
+    @api.delete("/api/marina/applets/{applet_id}", status_code=204)
+    @requires_auth
+    async def archive_applet(applet_id: uuid.UUID, request: Request) -> Response:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        actor = identity_for(request, policy).user_id
+        try:
+            await run_in_threadpool(applet_store.archive, applet_id, actor, config.applet_operators)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet not found") from error
+        except AppletForbidden as error:
+            raise HTTPException(
+                status_code=403, detail="only the publisher or an operator may archive this applet"
+            ) from error
+        return Response(status_code=204)
+
+    @api.get("/a/{applet_id}", include_in_schema=False)
+    @requires_auth
+    def applet_without_slash(applet_id: uuid.UUID) -> RedirectResponse:
+        return RedirectResponse(f"/a/{applet_id}/")
+
+    @api.get("/a/{applet_id}/", include_in_schema=False)
+    @requires_auth
+    def current_applet(applet_id: uuid.UUID) -> RedirectResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        try:
+            version = applet_store.current_version(applet_id)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet not found") from error
+        return RedirectResponse(
+            f"/a/{applet_id}/v/{version}/",
+            status_code=307,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    async def execute_applet_query(applet_id: uuid.UUID, request: Request) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        body = await request_json(request)
+        if not isinstance(body, dict) or not isinstance(body.get("sql"), str):
+            raise HTTPException(status_code=400, detail="body must contain a SQL string")
+        parameters = body.get("parameters", {})
+        if not isinstance(parameters, dict):
+            raise HTTPException(status_code=400, detail="parameters must be an object")
+        try:
+            result = await run_in_threadpool(applet_store.query, applet_id, body["sql"], parameters)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet not found") from error
+        except QueryLimitExceeded as error:
+            raise HTTPException(status_code=413, detail=str(error)) from error
+        except InvalidQuery as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+        except sqlalchemy.exc.SQLAlchemyError as error:
+            if sqlstate(error) == "57014":
+                raise HTTPException(status_code=504, detail="query exceeded its statement timeout") from error
+            raise HTTPException(status_code=422, detail=str(error)) from error
+        return JSONResponse(result)
+
+    @api.post("/a/{applet_id}/query")
+    @requires_auth
+    async def query_applet(applet_id: uuid.UUID, request: Request) -> JSONResponse:
+        return await execute_applet_query(applet_id, request)
+
+    @api.post("/a/{applet_id}/v/{version}/query")
+    @requires_auth
+    async def versioned_applet_query(applet_id: uuid.UUID, version: int, request: Request) -> JSONResponse:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        try:
+            await run_in_threadpool(applet_store.version, applet_id, version)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet or revision not found") from error
+        return await execute_applet_query(applet_id, request)
+
+    @api.api_route(
+        "/a/{applet_id}/api/{path:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+        include_in_schema=False,
+    )
+    @requires_auth
+    async def current_applet_api(applet_id: uuid.UUID, path: str, request: Request) -> Response:
+        if applet_store is None or applet_runtime is None:
+            raise HTTPException(status_code=404, detail="applet API not found")
+        try:
+            version = await run_in_threadpool(applet_store.current_version, applet_id)
+            applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
+            return await call_applet_api(applet_api, request, path)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet API not found") from error
+        except AppletBackendUnavailable as error:
+            raise HTTPException(status_code=503, detail=str(error)) from error
+
+    @api.api_route(
+        "/a/{applet_id}/v/{version}/api/{path:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+        include_in_schema=False,
+    )
+    @requires_auth
+    async def versioned_applet_api(applet_id: uuid.UUID, version: int, path: str, request: Request) -> Response:
+        if applet_runtime is None:
+            raise HTTPException(status_code=404, detail="applet API not found")
+        try:
+            applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
+            return await call_applet_api(applet_api, request, path)
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet API not found") from error
+        except AppletBackendUnavailable as error:
+            raise HTTPException(status_code=503, detail=str(error)) from error
+
+    def applet_file_response(applet_id: uuid.UUID, version: int, path: str, request: Request) -> Response:
+        if applet_store is None:
+            raise HTTPException(status_code=404, detail="applet not found")
+        try:
+            record = applet_store.version(applet_id, version)
+            stored = applet_store.file(
+                applet_id,
+                version,
+                path,
+                accept_gzip=accepts_encoding(request.headers.get("accept-encoding", ""), "gzip"),
+                accept_html=accepts_html(request.headers.get("accept", "")),
+            )
+        except AppletNotFound as error:
+            raise HTTPException(status_code=404, detail="applet file not found") from error
+        etag = f'"{stored.digest.hex()}"'
+        headers = {
+            "Cache-Control": "private, max-age=31536000, immutable",
+            "Content-Security-Policy": applet_content_security_policy(record.manifest.connect_src),
+            "ETag": etag,
+            "Vary": "Accept-Encoding",
+        }
+        if stored.content_encoding is not None:
+            headers["Content-Encoding"] = stored.content_encoding
+        if etag in {item.strip() for item in request.headers.get("if-none-match", "").split(",")}:
+            return Response(status_code=304, headers=headers)
+        return Response(stored.body, media_type=stored.media_type, headers=headers)
+
+    @api.api_route(
+        "/a/{applet_id}/v/{version}/",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    @requires_auth
+    def applet_root(applet_id: uuid.UUID, version: int, request: Request) -> Response:
+        return applet_file_response(applet_id, version, "", request)
+
+    @api.api_route(
+        "/a/{applet_id}/v/{version}/{path:path}",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    @requires_auth
+    def applet_file(applet_id: uuid.UUID, version: int, path: str, request: Request) -> Response:
+        return applet_file_response(applet_id, version, path, request)
+
+    if config.applet_origin is not None:
+        parsed_applet_origin = urlparse(config.applet_origin)
+        applet_host = parsed_applet_origin.hostname
+        if (
+            applet_host is None
+            or parsed_applet_origin.scheme not in {"http", "https"}
+            or parsed_applet_origin.path not in {"", "/"}
+        ):
+            raise ValueError(f"{APPLET_ORIGIN_ENV} must be an absolute URL")
+
+        @api.middleware("http")
+        async def isolate_applet_host(request: Request, call_next):
+            host = request.headers.get("host", "").split(":", 1)[0].lower()
+            path = request.url.path
+            is_applet_path = path == "/a" or path.startswith("/a/")
+            if host == applet_host:
+                if not is_applet_path:
+                    return JSONResponse({"error": "not found"}, status_code=404)
+                return await call_next(request)
+            if is_applet_path and request.method in {"GET", "HEAD"}:
+                query = f"?{request.url.query}" if request.url.query else ""
+                return RedirectResponse(
+                    config.applet_origin + path + query,
+                    status_code=307,
+                    headers={"Cache-Control": "no-store"},
+                )
+            if is_applet_path:
+                return JSONResponse({"error": "not found"}, status_code=404)
+            return await call_next(request)
 
     if config.host_apps:
         origin = config.canonical_origin

--- a/infra/marina/src/marina/server.py
+++ b/infra/marina/src/marina/server.py
@@ -49,9 +49,11 @@ from marina.applets import (
     AppletConflict,
     AppletForbidden,
     AppletNotFound,
+    AppletPackage,
     AppletRuntime,
     AppletStore,
     InvalidQuery,
+    PublishResult,
     QueryLimitExceeded,
     read_applet_package,
     validate_backend_import,
@@ -167,8 +169,8 @@ def legacy_api_app(host: str, path: str, host_apps: dict[str, str]) -> str | Non
     return app
 
 
-def content_security_policy(app: AppManifest) -> str:
-    connect = " ".join(("'self'", *app.connect_src))
+def content_security_policy(connect_src: tuple[str, ...]) -> str:
+    connect = " ".join(("'self'", *connect_src))
     return (
         "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
         f"img-src 'self' data:; font-src 'self' data:; connect-src {connect}; frame-ancestors 'none'"
@@ -194,14 +196,6 @@ def applet_directory(store: AppletStore | None, applet_origin: str | None) -> li
         }
         for applet in store.apps()
     ]
-
-
-def applet_content_security_policy(connect_src: tuple[str, ...]) -> str:
-    connect = " ".join(("'self'", *connect_src))
-    return (
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
-        f"img-src 'self' data:; font-src 'self' data:; connect-src {connect}; frame-ancestors 'none'"
-    )
 
 
 def accepts_encoding(header: str, encoding: str) -> bool:
@@ -270,7 +264,7 @@ def serve_app_file(app: AppManifest, path: str) -> Response:
             f"<h1>{html.escape(app.title)}</h1><p>Frontend not built. Run <code>marina build</code>.</p>",
             status_code=503,
         )
-    headers = {"Content-Security-Policy": content_security_policy(app)}
+    headers = {"Content-Security-Policy": content_security_policy(app.connect_src)}
     candidate = (dist / path).resolve() if path else dist / INDEX_FILE
     inside = candidate == dist or dist in candidate.parents
     if not inside:
@@ -299,7 +293,7 @@ async def serve_data_file(app: AppManifest, data_root: str, path: str) -> Respon
         return JSONResponse({"error": "not found"}, status_code=404)
     fs, root = url_to_fs(data_url_for(data_root, app.name))
     target = prefix_join(root, relative)
-    headers = {"Content-Security-Policy": content_security_policy(app), "Cache-Control": DATA_CACHE_CONTROL}
+    headers = {"Content-Security-Policy": content_security_policy(app.connect_src), "Cache-Control": DATA_CACHE_CONTROL}
     media_type = mimetypes.guess_type(relative)[0] or "application/octet-stream"
     if await run_in_threadpool(fs.isfile, target):
         body = await run_in_threadpool(fs.cat_file, target)
@@ -378,6 +372,54 @@ async def call_applet_api(app: ASGIApp, request: Request, path: str) -> Response
     return Response(response.content, status_code=response.status_code, headers=forwarded)
 
 
+async def uploaded_applet_package(request: Request) -> AppletPackage:
+    payload = await request.body()
+    if len(payload) > MAX_ARCHIVE_BYTES:
+        raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+    try:
+        package = await run_in_threadpool(read_applet_package, payload)
+        await run_in_threadpool(validate_backend_import, package)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return package
+
+
+def publish_result_response(published: PublishResult, applet_origin: str | None) -> JSONResponse:
+    return JSONResponse(
+        {
+            "id": str(published.applet_id),
+            "version": published.version,
+            "path": published.path,
+            "url": (applet_origin or "") + published.path,
+        },
+        status_code=201,
+    )
+
+
+async def dispatch_applet_api(
+    store: AppletStore | None,
+    runtime: AppletRuntime | None,
+    policy: RequestAuthPolicy,
+    applet_id: uuid.UUID,
+    version: int | None,
+    path: str,
+    request: Request,
+) -> Response:
+    if store is None or runtime is None:
+        raise HTTPException(status_code=404, detail="applet API not found")
+    try:
+        selected_version = version
+        if selected_version is None:
+            selected_version = await run_in_threadpool(store.current_version, applet_id)
+        applet_api = await run_in_threadpool(runtime.api, applet_id, selected_version)
+        with identity_scope(identity_for(request, policy)):
+            return await call_applet_api(applet_api, request, path)
+    except AppletNotFound as error:
+        raise HTTPException(status_code=404, detail="applet API not found") from error
+    except AppletBackendUnavailable as error:
+        raise HTTPException(status_code=503, detail=str(error)) from error
+
+
 def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     apps = discover_apps(config.apps_dir)
     shadowed = sorted(app.name for app in apps if app.name in KERNEL_PREFIXES)
@@ -419,37 +461,21 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     async def publish_applet(request: Request) -> JSONResponse:
         if applet_store is None:
             raise HTTPException(status_code=503, detail="Marina has no database configured")
-        payload = await request.body()
-        if len(payload) > MAX_ARCHIVE_BYTES:
-            raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+        package = await uploaded_applet_package(request)
         try:
-            package = await run_in_threadpool(read_applet_package, payload)
-            await run_in_threadpool(validate_backend_import, package)
             owner = identity_for(request, policy).user_id
             published = await run_in_threadpool(applet_store.publish, package, owner)
         except ValueError as error:
             raise HTTPException(status_code=400, detail=str(error)) from error
-        return JSONResponse(
-            {
-                "id": str(published.applet_id),
-                "version": published.version,
-                "path": published.path,
-                "url": (config.applet_origin or "") + published.path,
-            },
-            status_code=201,
-        )
+        return publish_result_response(published, config.applet_origin)
 
     @api.post("/api/marina/applets/{applet_id}")
     @requires_auth
     async def update_applet(applet_id: uuid.UUID, base_version: int, request: Request) -> JSONResponse:
         if applet_store is None:
             raise HTTPException(status_code=503, detail="Marina has no database configured")
-        payload = await request.body()
-        if len(payload) > MAX_ARCHIVE_BYTES:
-            raise HTTPException(status_code=400, detail=f"archive exceeds {MAX_ARCHIVE_BYTES} bytes")
+        package = await uploaded_applet_package(request)
         try:
-            package = await run_in_threadpool(read_applet_package, payload)
-            await run_in_threadpool(validate_backend_import, package)
             owner = identity_for(request, policy).user_id
             published = await run_in_threadpool(
                 applet_store.publish,
@@ -474,15 +500,7 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
             raise HTTPException(status_code=403, detail="only the publisher may update this applet") from error
         except AppletConflict as error:
             raise HTTPException(status_code=409, detail="applet has a newer current version") from error
-        return JSONResponse(
-            {
-                "id": str(published.applet_id),
-                "version": published.version,
-                "path": published.path,
-                "url": (config.applet_origin or "") + published.path,
-            },
-            status_code=201,
-        )
+        return publish_result_response(published, config.applet_origin)
 
     @api.get("/api/marina/applets/{applet_id}")
     @requires_auth
@@ -627,17 +645,7 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     )
     @requires_auth
     async def current_applet_api(applet_id: uuid.UUID, path: str, request: Request) -> Response:
-        if applet_store is None or applet_runtime is None:
-            raise HTTPException(status_code=404, detail="applet API not found")
-        try:
-            version = await run_in_threadpool(applet_store.current_version, applet_id)
-            applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
-            with identity_scope(identity_for(request, policy)):
-                return await call_applet_api(applet_api, request, path)
-        except AppletNotFound as error:
-            raise HTTPException(status_code=404, detail="applet API not found") from error
-        except AppletBackendUnavailable as error:
-            raise HTTPException(status_code=503, detail=str(error)) from error
+        return await dispatch_applet_api(applet_store, applet_runtime, policy, applet_id, None, path, request)
 
     @api.api_route(
         "/a/{applet_id}/v/{version}/api/{path:path}",
@@ -646,16 +654,7 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
     )
     @requires_auth
     async def versioned_applet_api(applet_id: uuid.UUID, version: int, path: str, request: Request) -> Response:
-        if applet_runtime is None:
-            raise HTTPException(status_code=404, detail="applet API not found")
-        try:
-            applet_api = await run_in_threadpool(applet_runtime.api, applet_id, version)
-            with identity_scope(identity_for(request, policy)):
-                return await call_applet_api(applet_api, request, path)
-        except AppletNotFound as error:
-            raise HTTPException(status_code=404, detail="applet API not found") from error
-        except AppletBackendUnavailable as error:
-            raise HTTPException(status_code=503, detail=str(error)) from error
+        return await dispatch_applet_api(applet_store, applet_runtime, policy, applet_id, version, path, request)
 
     def applet_file_response(applet_id: uuid.UUID, version: int, path: str, request: Request) -> Response:
         if applet_store is None:
@@ -674,7 +673,7 @@ def create_app(config: MarinaConfig) -> RouteAuthMiddleware:
         etag = f'"{stored.digest.hex()}"'
         headers = {
             "Cache-Control": "private, max-age=31536000, immutable",
-            "Content-Security-Policy": applet_content_security_policy(record.manifest.connect_src),
+            "Content-Security-Policy": content_security_policy(record.manifest.connect_src),
             "ETag": etag,
             "Vary": "Accept-Encoding",
         }

--- a/infra/marina/src/marina/table_load.py
+++ b/infra/marina/src/marina/table_load.py
@@ -1,0 +1,88 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load small local data files into an applet through its SQL endpoint."""
+
+import json
+import re
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.csv as pa_csv
+import pyarrow.json as pa_json
+import pyarrow.parquet as pa_parquet
+from fastapi.encoders import jsonable_encoder
+
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+INSERT_BATCH_ROWS = 250
+
+
+def read_table(path: Path) -> pa.Table:
+    """Read one supported local table format into Arrow."""
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pa_csv.read_csv(path)
+    if suffix in {".jsonl", ".ndjson"}:
+        return pa_json.read_json(path)
+    if suffix == ".json":
+        value = json.loads(path.read_text())
+        if not isinstance(value, list) or not all(isinstance(row, dict) for row in value):
+            raise ValueError("JSON table input must be an array of objects")
+        return pa.Table.from_pylist(value)
+    if suffix in {".parquet", ".pq"}:
+        return pa_parquet.read_table(path)
+    raise ValueError(f"unsupported table format {suffix!r}; use JSON, JSONL, CSV, or Parquet")
+
+
+def checked_identifier(value: str) -> str:
+    if not IDENTIFIER_PATTERN.fullmatch(value):
+        raise ValueError(f"invalid SQL identifier {value!r}")
+    return f'"{value}"'
+
+
+def postgres_type(data_type: pa.DataType) -> str:
+    """Map the scalar Arrow types accepted by applet table loading to Postgres."""
+    if pa.types.is_boolean(data_type):
+        return "BOOLEAN"
+    if pa.types.is_integer(data_type):
+        return "BIGINT"
+    if pa.types.is_floating(data_type) or pa.types.is_decimal(data_type):
+        return "DOUBLE PRECISION"
+    if pa.types.is_date(data_type):
+        return "DATE"
+    if pa.types.is_timestamp(data_type):
+        return "TIMESTAMPTZ" if data_type.tz is not None else "TIMESTAMP"
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return "TEXT"
+    raise ValueError(f"unsupported Arrow column type {data_type}")
+
+
+def table_statements(
+    table_name: str, table: pa.Table, replace: bool
+) -> tuple[list[str], list[tuple[str, dict[str, object]]]]:
+    """Return schema and parameterized inserts for one Arrow table."""
+    target = checked_identifier(table_name)
+    columns = [checked_identifier(field.name) for field in table.schema]
+    if not columns:
+        raise ValueError("table input has no columns")
+    definitions = ", ".join(
+        f"{column} {postgres_type(field.type)}" for column, field in zip(columns, table.schema, strict=True)
+    )
+    schema_sql = ([f"DROP TABLE IF EXISTS {target}"] if replace else []) + [
+        f"CREATE TABLE IF NOT EXISTS {target} ({definitions})"
+    ]
+    rows = jsonable_encoder(table.to_pylist())
+    inserts: list[tuple[str, dict[str, object]]] = []
+    for batch_start in range(0, len(rows), INSERT_BATCH_ROWS):
+        batch = rows[batch_start : batch_start + INSERT_BATCH_ROWS]
+        parameters: dict[str, object] = {}
+        values: list[str] = []
+        for row_index, row in enumerate(batch):
+            placeholders: list[str] = []
+            for column_index, field in enumerate(table.schema):
+                parameter = f"r{row_index}_c{column_index}"
+                placeholders.append(f":{parameter}")
+                parameters[parameter] = row[field.name]
+            values.append("(" + ", ".join(placeholders) + ")")
+        inserts.append((f"INSERT INTO {target} ({', '.join(columns)}) VALUES {', '.join(values)}", parameters))
+    return schema_sql, inserts

--- a/infra/marina/src/marina/table_load.py
+++ b/infra/marina/src/marina/table_load.py
@@ -58,7 +58,7 @@ def postgres_type(data_type: pa.DataType) -> str:
 
 
 def table_statements(
-    table_name: str, table: pa.Table, replace: bool
+    table_name: str, table: pa.Table, *, replace: bool
 ) -> tuple[list[str], list[tuple[str, dict[str, object]]]]:
     """Return schema and parameterized inserts for one Arrow table."""
     target = checked_identifier(table_name)

--- a/infra/marina/src/marina/testing.py
+++ b/infra/marina/src/marina/testing.py
@@ -9,42 +9,15 @@ coexist and nothing is left behind.
 """
 
 import os
-import subprocess
-import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 
 import sqlalchemy
 
-from marina.journeys import free_port
+from marina.local_postgres import docker_database
 
 TEST_DATABASE_URL_ENV = "MARINA_TEST_DATABASE_URL"
-POSTGRES_IMAGE = "pgvector/pgvector:0.8.5-pg16-bookworm"
-POSTGRES_PASSWORD = "marina"
-START_TIMEOUT = 60.0
-
-
-def _wait_ready(url: str) -> None:
-    deadline = time.monotonic() + START_TIMEOUT
-    engine = sqlalchemy.create_engine(url)
-    refused: Exception | None = None
-    try:
-        while time.monotonic() < deadline:
-            try:
-                with engine.connect() as conn:
-                    conn.execute(sqlalchemy.text("SELECT 1"))
-                return
-            except (sqlalchemy.exc.SQLAlchemyError, OSError) as error:
-                # A container that is still starting refuses the connection, or resets it
-                # mid-handshake, which reaches here as a bare OSError from the driver. A bad
-                # credential or URL refuses it just as often, so keep the last one to report
-                # instead of a bare timeout.
-                refused = error
-                time.sleep(0.3)
-        raise RuntimeError(f"postgres at {url} did not become ready within {START_TIMEOUT}s") from refused
-    finally:
-        engine.dispose()
 
 
 @contextmanager
@@ -75,30 +48,5 @@ def test_database() -> Iterator[str]:
         with _fresh_database(given) as url:
             yield url
         return
-    port = free_port()
-    name = f"marina-test-{uuid.uuid4().hex[:8]}"
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--detach",
-            "--rm",
-            "--name",
-            name,
-            "-e",
-            f"POSTGRES_PASSWORD={POSTGRES_PASSWORD}",
-            "-e",
-            "POSTGRES_DB=marina",
-            "-p",
-            f"127.0.0.1:{port}:5432",
-            POSTGRES_IMAGE,
-        ],
-        check=True,
-        capture_output=True,
-    )
-    url = f"postgresql+pg8000://postgres:{POSTGRES_PASSWORD}@127.0.0.1:{port}/marina"
-    try:
-        _wait_ready(url)
+    with docker_database() as url:
         yield url
-    finally:
-        subprocess.run(["docker", "rm", "--force", name], check=False, capture_output=True)

--- a/infra/marina/tests/test_applets.py
+++ b/infra/marina/tests/test_applets.py
@@ -22,7 +22,7 @@ from starlette.testclient import TestClient
 DEMO_APPLET = Path(__file__).parents[1] / "examples" / "problem-set-applet"
 
 
-def applet_client(tmp_path: Path, database_url: str) -> tuple[TestClient, AppletStore]:
+def applet_client_and_store(tmp_path: Path, database_url: str) -> tuple[TestClient, AppletStore]:
     apps_dir = tmp_path / "apps"
     apps_dir.mkdir()
     database = UrlDatabase(database_url)
@@ -34,7 +34,7 @@ def applet_client(tmp_path: Path, database_url: str) -> tuple[TestClient, Applet
 
 
 def test_publish_demo_serves_files_schema_query_and_python_api(tmp_path: Path, database_url: str) -> None:
-    client, store = applet_client(tmp_path, database_url)
+    client, store = applet_client_and_store(tmp_path, database_url)
     response = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET))
     assert response.status_code == 201
     published = response.json()
@@ -58,7 +58,6 @@ def test_publish_demo_serves_files_schema_query_and_python_api(tmp_path: Path, d
 
     page = client.get(published["path"])
     assert page.status_code == 200
-    assert "Problem sets" in page.text
     assert page.headers["cache-control"] == "private, max-age=31536000, immutable"
     assert client.get(f"/a/{applet_id}/v/1/missing.js").status_code == 404
     assert client.get(f"/a/{applet_id}/v/1/problem/17").status_code == 200
@@ -165,7 +164,7 @@ def test_publish_demo_serves_files_schema_query_and_python_api(tmp_path: Path, d
 
 
 def test_update_keeps_old_files_and_routes_each_python_revision(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     first = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
     applet_id = first["id"]
     changed = tmp_path / "changed"
@@ -217,7 +216,7 @@ def test_update_keeps_old_files_and_routes_each_python_revision(tmp_path: Path, 
 
 
 def test_applet_host_exposes_only_applet_routes(tmp_path: Path, database_url: str) -> None:
-    _client, store = applet_client(tmp_path, database_url)
+    _client, store = applet_client_and_store(tmp_path, database_url)
     config = MarinaConfig(
         apps_dir=tmp_path / "apps",
         data_root=str(tmp_path / "data"),
@@ -253,21 +252,31 @@ def test_applet_host_exposes_only_applet_routes(tmp_path: Path, database_url: st
 
 
 def test_store_rejects_non_owner_and_allows_operator(tmp_path: Path, database_url: str) -> None:
-    _client, store = applet_client(tmp_path, database_url)
-    published = store.publish(package=read_applet_package(package_applet(DEMO_APPLET)), owner="owner@example")
+    _client, store = applet_client_and_store(tmp_path, database_url)
+    package = read_applet_package(package_applet(DEMO_APPLET))
+    published = store.publish(package=package, owner="owner@example")
+    updated = store.publish(
+        package=package,
+        owner="owner@example",
+        applet_id=published.applet_id,
+        base_version=1,
+    )
+    assert updated.version == 2
     with pytest.raises(AppletForbidden):
-        store.rollback(published.applet_id, 1, "other@example", 1)
+        store.rollback(published.applet_id, 1, "other@example", 2)
+    assert store.current_version(published.applet_id) == 2
     store.rollback(
         published.applet_id,
         1,
         "operator@example",
-        1,
+        2,
         frozenset({"operator@example"}),
     )
+    assert store.current_version(published.applet_id) == 1
 
 
 def test_publish_rejects_archive_escape(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
         entry = tarfile.TarInfo("../outside")
@@ -278,19 +287,18 @@ def test_publish_rejects_archive_escape(tmp_path: Path, database_url: str) -> No
 
 
 def test_publish_rejects_backend_that_cannot_import(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     broken = tmp_path / "broken-import"
     shutil.copytree(DEMO_APPLET, broken)
     (broken / "server" / "app.py").write_text('raise RuntimeError("broken import")\n')
     before = client.get("/api/marina/applets").json()
     response = client.post("/api/marina/applets", content=package_applet(broken))
     assert response.status_code == 400
-    assert "Python backend validation failed" in response.json()["detail"]
     assert client.get("/api/marina/applets").json() == before
 
 
 def test_backend_factory_failure_returns_503(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     broken = tmp_path / "broken-factory"
     shutil.copytree(DEMO_APPLET, broken)
     (broken / "server" / "app.py").write_text(
@@ -306,7 +314,7 @@ def test_backend_factory_failure_returns_503(tmp_path: Path, database_url: str) 
 
 
 def test_static_cache_encoding_and_html_fallback(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     packaged = tmp_path / "static"
     shutil.copytree(DEMO_APPLET, packaged)
     (packaged / "dist" / "sample.txt").write_bytes(b"plain")
@@ -328,7 +336,7 @@ def test_static_cache_encoding_and_html_fallback(tmp_path: Path, database_url: s
 
 
 def test_publish_prunes_old_revisions_and_allocates_after_rollback(tmp_path: Path, database_url: str) -> None:
-    _client, store = applet_client(tmp_path, database_url)
+    _client, store = applet_client_and_store(tmp_path, database_url)
     package_dir = tmp_path / "revisions"
     shutil.copytree(DEMO_APPLET, package_dir)
     package = read_applet_package(package_applet(package_dir))
@@ -349,7 +357,7 @@ def test_publish_prunes_old_revisions_and_allocates_after_rollback(tmp_path: Pat
 
 
 def test_table_load_statements_populate_applet_schema(tmp_path: Path, database_url: str) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     published = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
     source = tmp_path / "observations.csv"
     source.write_text("problem_id,note\n1,checked\n3,tricky\n")
@@ -371,7 +379,7 @@ def test_table_load_statements_populate_applet_schema(tmp_path: Path, database_u
 
 
 def test_query_limits_roll_back_and_timeout(tmp_path: Path, database_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    client, _store = applet_client(tmp_path, database_url)
+    client, _store = applet_client_and_store(tmp_path, database_url)
     published = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
     endpoint = f"/a/{published['id']}/query"
     assert client.post(endpoint, content=b"{").status_code == 400
@@ -404,7 +412,7 @@ def test_query_limits_roll_back_and_timeout(tmp_path: Path, database_url: str, m
 
 
 def test_failed_migration_leaves_no_applet_or_schema(tmp_path: Path, database_url: str) -> None:
-    client, store = applet_client(tmp_path, database_url)
+    client, store = applet_client_and_store(tmp_path, database_url)
     applets_before = client.get("/api/marina/apps").json()["apps"]
     with store.engine.connect() as connection:
         schemas_before = set(

--- a/infra/marina/tests/test_applets.py
+++ b/infra/marina/tests/test_applets.py
@@ -1,0 +1,437 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from marina.applets import AppletForbidden, AppletStore, package_applet, read_applet_package
+from marina.cli import cli
+from marina.database_setup import APPLET_READER_ROLE, ensure_applet_provisioning
+from marina.db import UrlDatabase, grant_read
+from marina.server import MarinaConfig, create_app
+from marina.table_load import read_table, table_statements
+from sqlalchemy import text
+from starlette.testclient import TestClient
+
+DEMO_APPLET = Path(__file__).parents[1] / "examples" / "problem-set-applet"
+
+
+def applet_client(tmp_path: Path, database_url: str) -> tuple[TestClient, AppletStore]:
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
+    database = UrlDatabase(database_url)
+    store = AppletStore(database)
+    ensure_applet_provisioning(store.engine)
+    store.migrate()
+    config = MarinaConfig(apps_dir=apps_dir, data_root=str(tmp_path / "data"), iap_audience=None, database=database)
+    return TestClient(create_app(config), client=("127.0.0.1", 40000)), store
+
+
+def test_publish_demo_serves_files_schema_query_and_python_api(tmp_path: Path, database_url: str) -> None:
+    client, store = applet_client(tmp_path, database_url)
+    response = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET))
+    assert response.status_code == 201
+    published = response.json()
+    applet_id = published["id"]
+
+    listed = client.get("/api/marina/apps").json()["apps"]
+    assert listed == [
+        {
+            "name": applet_id,
+            "title": "Problem sets",
+            "description": "Browse a small collection of generated arithmetic problems.",
+            "path": f"/a/{applet_id}/",
+            "kind": "applet",
+            "published_by": "anonymous",
+            "version": 1,
+        }
+    ]
+    current = client.get(f"/a/{applet_id}/", follow_redirects=False)
+    assert current.status_code == 307
+    assert current.headers["location"] == f"/a/{applet_id}/v/1/"
+
+    page = client.get(published["path"])
+    assert page.status_code == 200
+    assert "Problem sets" in page.text
+    assert page.headers["cache-control"] == "private, max-age=31536000, immutable"
+    assert client.get(f"/a/{applet_id}/v/1/missing.js").status_code == 404
+    assert client.get(f"/a/{applet_id}/v/1/problem/17").status_code == 200
+
+    problems = client.get(f"/a/{applet_id}/v/1/api/problems")
+    assert problems.status_code == 200
+    assert problems.json() == [
+        {"id": 1, "prompt": "12 * 7"},
+        {"id": 2, "prompt": "144 ÷ 12"},
+        {"id": 3, "prompt": "19 + 28"},
+    ]
+    assert client.get(f"/a/{applet_id}/api/revision").json() == {"version": 1}
+
+    created = client.post(
+        f"/a/{applet_id}/query",
+        json={"sql": "CREATE TABLE observations (problem_id INTEGER, note TEXT)", "parameters": {}},
+    )
+    assert created.status_code == 200
+    inserted = client.post(
+        f"/a/{applet_id}/query",
+        json={
+            "sql": "INSERT INTO observations (problem_id, note) VALUES (:id, :note)",
+            "parameters": {"id": 1, "note": "checked"},
+        },
+    )
+    assert inserted.status_code == 200
+    rows = client.post(
+        f"/a/{applet_id}/v/1/query",
+        json={"sql": "SELECT problem_id, note FROM observations", "parameters": {}},
+    )
+    assert rows.json() == {
+        "columns": ["problem_id", "note"],
+        "rows": [{"problem_id": 1, "note": "checked"}],
+        "row_count": 1,
+    }
+
+    with store.engine.connect() as connection:
+        schemas = connection.execute(
+            text("SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'applet_%'")
+        ).scalars()
+        assert list(schemas) == [f"applet_{applet_id.replace('-', '')}"]
+        owner = connection.execute(
+            text("SELECT tableowner FROM pg_tables WHERE schemaname = :schema AND tablename = 'problems'"),
+            {"schema": f"applet_{applet_id.replace('-', '')}"},
+        ).scalar_one()
+        assert owner == f"applet_{applet_id.replace('-', '')}"
+    identity = client.post(f"/a/{applet_id}/query", json={"sql": "SELECT current_user AS role", "parameters": {}}).json()
+    assert identity["rows"] == [{"role": f"applet_{applet_id.replace('-', '')}"}]
+    with store.engine.begin() as connection:
+        connection.execute(text("CREATE SCHEMA shared_read"))
+        connection.execute(text("CREATE TABLE shared_read.values (value INTEGER)"))
+        connection.execute(text("INSERT INTO shared_read.values VALUES (17)"))
+    grant_read(store.engine, "shared_read", APPLET_READER_ROLE)
+    shared = client.post(
+        f"/a/{applet_id}/query",
+        json={"sql": "SELECT value FROM shared_read.values", "parameters": {}},
+    )
+    assert shared.json()["rows"] == [{"value": 17}]
+    catalog = client.post(
+        f"/a/{applet_id}/query",
+        json={
+            "sql": (
+                "SELECT table_name, column_name FROM marina.applet_catalog "
+                "WHERE applet_id = :id AND table_name = 'problems' ORDER BY ordinal_position"
+            ),
+            "parameters": {"id": applet_id},
+        },
+    )
+    assert catalog.json()["rows"] == [
+        {"table_name": "problems", "column_name": "id"},
+        {"table_name": "problems", "column_name": "prompt"},
+        {"table_name": "problems", "column_name": "answer"},
+    ]
+    assert (
+        client.post(
+            f"/a/{applet_id}/query",
+            json={"sql": "INSERT INTO shared_read.values VALUES (18)", "parameters": {}},
+        ).status_code
+        == 422
+    )
+    assert (
+        client.post(
+            f"/a/{applet_id}/query",
+            json={"sql": "RESET ROLE", "parameters": {}},
+        ).status_code
+        == 400
+    )
+    second = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
+    cross_schema = f"applet_{applet_id.replace('-', '')}"
+    cross_read = client.post(
+        f"/a/{second['id']}/query",
+        json={"sql": f"SELECT note FROM {cross_schema}.observations", "parameters": {}},
+    )
+    assert cross_read.json()["rows"] == [{"note": "checked"}]
+    assert (
+        client.post(
+            f"/a/{second['id']}/query",
+            json={"sql": f"DELETE FROM {cross_schema}.observations", "parameters": {}},
+        ).status_code
+        == 422
+    )
+
+
+def test_update_keeps_old_files_and_routes_each_python_revision(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    first = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
+    applet_id = first["id"]
+    changed = tmp_path / "changed"
+    shutil.copytree(DEMO_APPLET, changed)
+    old_page = (changed / "dist" / "index.html").read_text()
+    (changed / "dist" / "index.html").write_text(old_page.replace("Problem sets", "Revised problems"))
+
+    second = client.post(
+        f"/api/marina/applets/{applet_id}",
+        params={"base_version": 1},
+        content=package_applet(changed),
+    )
+    assert second.status_code == 201
+    assert second.json()["version"] == 2
+    assert "Problem sets" in client.get(f"/a/{applet_id}/v/1/").text
+    assert "Revised problems" in client.get(f"/a/{applet_id}/v/2/").text
+    assert client.get(f"/a/{applet_id}/v/1/api/revision").json() == {"version": 1}
+    assert client.get(f"/a/{applet_id}/v/2/api/revision").json() == {"version": 2}
+    assert (
+        client.post(
+            f"/api/marina/applets/{applet_id}",
+            params={"base_version": 1},
+            content=package_applet(changed),
+        ).status_code
+        == 409
+    )
+
+    details = client.get(f"/api/marina/applets/{applet_id}").json()
+    assert details["current_version"] == 2
+    assert [revision["version"] for revision in details["versions"]] == [2, 1]
+    rolled_back = client.put(
+        f"/api/marina/applets/{applet_id}/current",
+        json={"version": 1, "base_version": 2},
+    )
+    assert rolled_back.status_code == 200
+    assert client.get(f"/a/{applet_id}/api/revision").json() == {"version": 1}
+    assert client.delete(f"/api/marina/applets/{applet_id}").status_code == 204
+    assert client.get(f"/a/{applet_id}/v/1/").status_code == 404
+    listed_ids = {applet["name"] for applet in client.get("/api/marina/applets").json()["applets"]}
+    assert applet_id not in listed_ids
+
+
+def test_applet_host_exposes_only_applet_routes(tmp_path: Path, database_url: str) -> None:
+    _client, store = applet_client(tmp_path, database_url)
+    config = MarinaConfig(
+        apps_dir=tmp_path / "apps",
+        data_root=str(tmp_path / "data"),
+        iap_audience=None,
+        database=store.database,
+        applet_origin="https://applets.example",
+    )
+    client = TestClient(create_app(config), client=("127.0.0.1", 40000))
+    published = client.post(
+        "/api/marina/applets",
+        headers={"host": "marina.example"},
+        content=package_applet(DEMO_APPLET),
+    ).json()
+    applet_id = published["id"]
+    assert published["url"] == f"https://applets.example/a/{applet_id}/v/1/"
+    listed = client.get("/api/marina/applets", headers={"host": "marina.example"}).json()["applets"]
+    published_entry = next(applet for applet in listed if applet["name"] == applet_id)
+    assert published_entry["path"] == f"https://applets.example/a/{applet_id}/"
+
+    redirected = client.get(f"/a/{applet_id}/v/1/", headers={"host": "marina.example"}, follow_redirects=False)
+    assert redirected.status_code == 307
+    assert redirected.headers["location"] == f"https://applets.example/a/{applet_id}/v/1/"
+    assert client.get(f"/a/{applet_id}/v/1/", headers={"host": "applets.example"}).status_code == 200
+    assert client.get("/api/marina/apps", headers={"host": "applets.example"}).status_code == 404
+    assert (
+        client.post(
+            f"/a/{applet_id}/query",
+            headers={"host": "marina.example"},
+            json={"sql": "SELECT 1", "parameters": {}},
+        ).status_code
+        == 404
+    )
+
+
+def test_store_rejects_non_owner_and_allows_operator(tmp_path: Path, database_url: str) -> None:
+    _client, store = applet_client(tmp_path, database_url)
+    published = store.publish(package=read_applet_package(package_applet(DEMO_APPLET)), owner="owner@example")
+    with pytest.raises(AppletForbidden):
+        store.rollback(published.applet_id, 1, "other@example", 1)
+    store.rollback(
+        published.applet_id,
+        1,
+        "operator@example",
+        1,
+        frozenset({"operator@example"}),
+    )
+
+
+def test_publish_rejects_archive_escape(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        entry = tarfile.TarInfo("../outside")
+        entry.size = 1
+        archive.addfile(entry, io.BytesIO(b"x"))
+    response = client.post("/api/marina/applets", content=buffer.getvalue())
+    assert response.status_code == 400
+
+
+def test_publish_rejects_backend_that_cannot_import(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    broken = tmp_path / "broken-import"
+    shutil.copytree(DEMO_APPLET, broken)
+    (broken / "server" / "app.py").write_text('raise RuntimeError("broken import")\n')
+    before = client.get("/api/marina/applets").json()
+    response = client.post("/api/marina/applets", content=package_applet(broken))
+    assert response.status_code == 400
+    assert "Python backend validation failed" in response.json()["detail"]
+    assert client.get("/api/marina/applets").json() == before
+
+
+def test_backend_factory_failure_returns_503(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    broken = tmp_path / "broken-factory"
+    shutil.copytree(DEMO_APPLET, broken)
+    (broken / "server" / "app.py").write_text(
+        """def create_api(_services):
+    raise RuntimeError("factory failed")
+"""
+    )
+    published = client.post("/api/marina/applets", content=package_applet(broken)).json()
+    first = client.get(f"/a/{published['id']}/v/1/api/test")
+    second = client.get(f"/a/{published['id']}/v/1/api/test")
+    assert first.status_code == 503
+    assert second.status_code == 503
+
+
+def test_static_cache_encoding_and_html_fallback(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    packaged = tmp_path / "static"
+    shutil.copytree(DEMO_APPLET, packaged)
+    (packaged / "dist" / "sample.txt").write_bytes(b"plain")
+    (packaged / "dist" / "sample.txt.gz").write_bytes(gzip.compress(b"compressed"))
+    published = client.post("/api/marina/applets", content=package_applet(packaged)).json()
+    prefix = f"/a/{published['id']}/v/1"
+
+    plain = client.get(f"{prefix}/sample.txt", headers={"accept-encoding": "gzip;q=0"})
+    assert plain.headers.get("content-encoding") is None
+    compressed = client.get(f"{prefix}/sample.txt", headers={"accept-encoding": "gzip"})
+    assert compressed.headers["content-encoding"] == "gzip"
+    unchanged = client.get(
+        f"{prefix}/sample.txt",
+        headers={"if-none-match": plain.headers["etag"], "accept-encoding": "gzip;q=0"},
+    )
+    assert unchanged.status_code == 304
+    assert client.get(f"{prefix}/client-route", headers={"accept": "application/json"}).status_code == 404
+    assert client.get(f"{prefix}/client-route", headers={"accept": "text/html"}).status_code == 200
+
+
+def test_publish_prunes_old_revisions_and_allocates_after_rollback(tmp_path: Path, database_url: str) -> None:
+    _client, store = applet_client(tmp_path, database_url)
+    package_dir = tmp_path / "revisions"
+    shutil.copytree(DEMO_APPLET, package_dir)
+    package = read_applet_package(package_applet(package_dir))
+    published = store.publish(package, "owner@example")
+    current = 1
+    for revision in range(2, 7):
+        page = (package_dir / "dist" / "index.html").read_text()
+        (package_dir / "dist" / "index.html").write_text(page + f"<!-- revision {revision} -->")
+        package = read_applet_package(package_applet(package_dir))
+        store.publish(package, "owner@example", published.applet_id, current)
+        current = revision
+    assert [item.version for item in store.versions(published.applet_id)] == [6, 5, 4, 3, 2]
+
+    store.rollback(published.applet_id, 2, "owner@example", 6)
+    next_revision = store.publish(package, "owner@example", published.applet_id, 2)
+    assert next_revision.version == 7
+    assert [item.version for item in store.versions(published.applet_id)] == [7, 6, 5, 4, 3]
+
+
+def test_table_load_statements_populate_applet_schema(tmp_path: Path, database_url: str) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    published = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
+    source = tmp_path / "observations.csv"
+    source.write_text("problem_id,note\n1,checked\n3,tricky\n")
+    table = read_table(source)
+    schema_sql, inserts = table_statements("observations", table, replace=True)
+    endpoint = f"/a/{published['id']}/query"
+    for statement in schema_sql:
+        assert client.post(endpoint, json={"sql": statement, "parameters": {}}).status_code == 200
+    for statement, parameters in inserts:
+        assert client.post(endpoint, json={"sql": statement, "parameters": parameters}).status_code == 200
+    rows = client.post(
+        endpoint,
+        json={"sql": "SELECT problem_id, note FROM observations ORDER BY problem_id", "parameters": {}},
+    )
+    assert rows.json()["rows"] == [
+        {"problem_id": 1, "note": "checked"},
+        {"problem_id": 3, "note": "tricky"},
+    ]
+
+
+def test_query_limits_roll_back_and_timeout(tmp_path: Path, database_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _store = applet_client(tmp_path, database_url)
+    published = client.post("/api/marina/applets", content=package_applet(DEMO_APPLET)).json()
+    endpoint = f"/a/{published['id']}/query"
+    assert client.post(endpoint, content=b"{").status_code == 400
+    too_many = client.post(
+        endpoint,
+        json={
+            "sql": (
+                "WITH inserted AS ("
+                "INSERT INTO problems (id, prompt, answer) "
+                "SELECT value + 100, 'bulk', value FROM generate_series(1, 10001) AS value RETURNING id"
+                ") SELECT id FROM inserted"
+            ),
+            "parameters": {},
+        },
+    )
+    assert too_many.status_code == 413
+    count = client.post(endpoint, json={"sql": "SELECT count(*) AS count FROM problems", "parameters": {}})
+    assert count.json()["rows"] == [{"count": 3}]
+
+    monkeypatch.setattr("marina.applets.QUERY_TIMEOUT_MS", 20)
+    timed_out = client.post(endpoint, json={"sql": "SELECT pg_sleep(0.2)", "parameters": {}})
+    assert timed_out.status_code == 504
+
+
+def test_failed_migration_leaves_no_applet_or_schema(tmp_path: Path, database_url: str) -> None:
+    client, store = applet_client(tmp_path, database_url)
+    applets_before = client.get("/api/marina/apps").json()["apps"]
+    with store.engine.connect() as connection:
+        schemas_before = set(
+            connection.execute(
+                text("SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'applet_%'")
+            ).scalars()
+        )
+    broken = tmp_path / "broken"
+    shutil.copytree(DEMO_APPLET, broken)
+    (broken / "server" / "app.py").write_text(
+        """from sqlalchemy import text
+
+
+def migrate(connection):
+    connection.execute(text("CREATE TABLE partial (id INTEGER)"))
+    raise RuntimeError("migration failed")
+
+
+def create_api(_services):
+    raise RuntimeError("unreachable")
+"""
+    )
+    failing = TestClient(client.app, client=("127.0.0.1", 40000), raise_server_exceptions=False)
+    response = failing.post("/api/marina/applets", content=package_applet(broken))
+    assert response.status_code == 500
+    assert client.get("/api/marina/apps").json()["apps"] == applets_before
+    with store.engine.connect() as connection:
+        schemas_after = set(
+            connection.execute(
+                text("SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'applet_%'")
+            ).scalars()
+        )
+        assert schemas_after == schemas_before
+
+
+def test_publish_dry_run_reports_validated_package() -> None:
+    result = CliRunner().invoke(cli, ["publish", str(DEMO_APPLET), "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["file_count"] == 5
+    assert report["files"] == [
+        "applet.toml",
+        "dist/app.js",
+        "dist/index.html",
+        "server/__init__.py",
+        "server/app.py",
+    ]

--- a/infra/marina/tests/test_applets.py
+++ b/infra/marina/tests/test_applets.py
@@ -71,6 +71,8 @@ def test_publish_demo_serves_files_schema_query_and_python_api(tmp_path: Path, d
         {"id": 3, "prompt": "19 + 28"},
     ]
     assert client.get(f"/a/{applet_id}/api/revision").json() == {"version": 1}
+    assert client.get(f"/a/{applet_id}/api/identity").json() == {"user": "anonymous"}
+    assert client.get(f"/a/{applet_id}/v/1/api/identity").json() == {"user": "anonymous"}
 
     created = client.post(
         f"/a/{applet_id}/query",
@@ -376,18 +378,25 @@ def test_query_limits_roll_back_and_timeout(tmp_path: Path, database_url: str, m
     too_many = client.post(
         endpoint,
         json={
-            "sql": (
-                "WITH inserted AS ("
-                "INSERT INTO problems (id, prompt, answer) "
-                "SELECT value + 100, 'bulk', value FROM generate_series(1, 10001) AS value RETURNING id"
-                ") SELECT id FROM inserted"
-            ),
+            "sql": "SELECT value FROM generate_series(1, 10001) AS value",
             "parameters": {},
         },
     )
     assert too_many.status_code == 413
+    returning = client.post(
+        endpoint,
+        json={
+            "sql": "INSERT INTO problems (id, prompt, answer) VALUES (100, 'new', 1) RETURNING id",
+            "parameters": {},
+        },
+    )
+    assert returning.status_code == 400
     count = client.post(endpoint, json={"sql": "SELECT count(*) AS count FROM problems", "parameters": {}})
     assert count.json()["rows"] == [{"count": 3}]
+
+    monkeypatch.setattr("marina.applets.MAX_QUERY_RESPONSE_BYTES", 200)
+    oversized = client.post(endpoint, json={"sql": "SELECT repeat('x', 10000) AS value", "parameters": {}})
+    assert oversized.status_code == 413
 
     monkeypatch.setattr("marina.applets.QUERY_TIMEOUT_MS", 20)
     timed_out = client.post(endpoint, json={"sql": "SELECT pg_sleep(0.2)", "parameters": {}})

--- a/infra/marina/tests/test_applets.py
+++ b/infra/marina/tests/test_applets.py
@@ -202,6 +202,14 @@ def test_update_keeps_old_files_and_routes_each_python_revision(tmp_path: Path, 
     assert client.get(f"/a/{applet_id}/api/revision").json() == {"version": 1}
     assert client.delete(f"/api/marina/applets/{applet_id}").status_code == 204
     assert client.get(f"/a/{applet_id}/v/1/").status_code == 404
+    assert (
+        client.post(
+            f"/api/marina/applets/{applet_id}",
+            params={"base_version": 1},
+            content=package_applet(changed),
+        ).status_code
+        == 404
+    )
     listed_ids = {applet["name"] for applet in client.get("/api/marina/applets").json()["applets"]}
     assert applet_id not in listed_ids
 


### PR DESCRIPTION
Add `marina publish` and lifecycle commands for applets stored in Postgres.
Marina's existing IAP policy gates both the publishing API and applet requests.
Each applet receives a stable UUID. Each successful publish allocates its next
revision and atomically selects it as current. Automatic retention keeps the
current revision and the four highest-numbered alternatives. Files are
deduplicated across applets by digest and media type. Only the recorded owner
or a user ID in `MARINA_APPLET_OPERATORS` can update, roll back, or archive an
applet. Archive removes its routes and entry from Marina's app list but
preserves its schema and retained revisions; v1 has no restore operation.

Give each applet a Postgres role that can write its own schema and select from
schemas owned by checked-in and dynamic Marina apps. Browser-submitted SQL
permits one statement with a 10-second timeout. Postgres bounds `SELECT` and
read-only `WITH` results to 10,000 rows and a 5 MiB serialized JSON payload
before transferring them; data-modifying `WITH` and mutation `RETURNING`
statements are rejected. The CLI also loads JSON, JSONL, CSV, and Parquet tables
as DDL and DML through the same query endpoint.

An applet may ship a Python ASGI backend and a migration that runs in the
publish transaction before activation. Any IAP-authorized caller can create a
Python applet; only its owner or an operator can upload later revisions.
The `AppletServices` object passed to the backend supplies an engine configured
for the applet's restricted database role. Uploaded Python remains trusted: it
can create other clients from Marina's process environment and access Cloud Run
filesystem, network, and service credentials. The separate
applets.marina.oa.dev origin exposes only `/a/*` routes and keeps uploaded
JavaScript off Marina's main origin; it is not a process sandbox.

`marina publish DIR --local` starts disposable pgvector Postgres, installs
`marina.provision_applet(uuid)` and the `marina.applets` registry tables,
publishes through a loopback Marina process, and serves the immutable revision
until Ctrl-C. The `marina-applet` repository skill uses this command as its
default validation path. Local mode does not enable IAP and removes its
database container on exit.