### PR TITLE
[finelog] Fail closed on object-storage errors

### DIFF
--- a/infra/pulumi/src/iac/kubernetes/finelog.py
+++ b/infra/pulumi/src/iac/kubernetes/finelog.py
@@ -94,6 +94,13 @@ def _container_env(config: FinelogConfig) -> list[k8s.core.v1.EnvVarArgs]:
                 value=str(config.query_index_cache_mb),
             )
         )
+    if config.object_cache_gb is not None:
+        env.append(
+            k8s.core.v1.EnvVarArgs(
+                name="FINELOG_OBJECT_CACHE_GB",
+                value=str(config.object_cache_gb),
+            )
+        )
     if config.auth:
         env.append(k8s.core.v1.EnvVarArgs(name="FINELOG_AUTH_POLICY", value=auth_policy_json(config.auth)))
     if config.forwarding:

--- a/infra/pulumi/tests/test_finelog.py
+++ b/infra/pulumi/tests/test_finelog.py
@@ -35,6 +35,7 @@ def _args(cache_storage: K8sCacheStorage = K8sCacheStorage.PERSISTENT_VOLUME) ->
             signing_key=("gcp-secret://projects/1/secrets/finelog-cw-signing-key/versions/1",),
         ),
         query_index_cache_mb=512,
+        object_cache_gb=200,
     )
     return FinelogServerArgs(
         config=config,
@@ -68,9 +69,11 @@ def test_finelog_resource_args_reference_secret_without_secret_values() -> None:
         "FINELOG_AUTH_POLICY",
         "FINELOG_FORWARDING",
         "FINELOG_INDEX_CACHE_MB",
+        "FINELOG_OBJECT_CACHE_GB",
         "FINELOG_PORT",
         "FINELOG_REMOTE_DIR",
     }
+    assert next(entry.value for entry in container.env if entry.name == "FINELOG_OBJECT_CACHE_GB") == "200"
     assert "gcp-secret://" not in str(resources.deployment)
 
 

--- a/infra/pulumi/tests/test_finelog.py
+++ b/infra/pulumi/tests/test_finelog.py
@@ -73,7 +73,6 @@ def test_finelog_resource_args_reference_secret_without_secret_values() -> None:
         "FINELOG_PORT",
         "FINELOG_REMOTE_DIR",
     }
-    assert next(entry.value for entry in container.env if entry.name == "FINELOG_OBJECT_CACHE_GB") == "200"
     assert "gcp-secret://" not in str(resources.deployment)
 
 

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -18,7 +18,7 @@ use finelog::server::diagnostics::spawn_pool_diagnostics;
 use finelog::server::{
     build_app_with_config, spawn_forwarder, AuthPolicy, Forwarder, ForwardingConfig, ServerConfig,
 };
-use finelog::store::object_store::is_object_store;
+use finelog::store::object_store::is_remote_object_store;
 use finelog::store::{ServeMode, Store, TelemetryRootWriteMode};
 use tokio::sync::Notify;
 
@@ -295,7 +295,7 @@ fn resolve_serve_mode(args: &Args) -> Result<ServeMode, String> {
             "shadow mode needs --log-dir: an in-memory store has no boot to rehearse".into(),
         );
     }
-    if is_object_store(&args.remote_log_dir) {
+    if is_remote_object_store(&args.remote_log_dir) {
         return Err(format!(
             "shadow mode refuses the archive {:?}: point --remote-log-dir at a local directory, \
              or leave it empty",

--- a/lib/finelog/rust/src/maintenance/mod.rs
+++ b/lib/finelog/rust/src/maintenance/mod.rs
@@ -71,6 +71,9 @@ pub struct MaintenanceLimits {
     index_backfill: tokio::sync::Mutex<()>,
     /// At most one two-worker physical-layout migration wave runs at a time.
     layout_migration: Mutex<()>,
+    /// At most one legacy encoding rewrite runs at a time. A table skips this
+    /// opportunistic work when the permit is busy instead of queueing.
+    encoding_rewrite: Mutex<()>,
     /// How many tables may run a maintenance cycle concurrently.
     maintenance_cycles: tokio::sync::Semaphore,
     /// A table whose spec migration is mid-flight cycles in this dedicated
@@ -95,6 +98,7 @@ impl MaintenanceLimits {
         Arc::new(Self {
             index_backfill: tokio::sync::Mutex::new(()),
             layout_migration: Mutex::new(()),
+            encoding_rewrite: Mutex::new(()),
             maintenance_cycles: tokio::sync::Semaphore::new(MAX_CONCURRENT_MAINTENANCE_CYCLES),
             spec_migration: tokio::sync::Mutex::new(()),
             flushes: tokio::sync::Semaphore::new(MAX_CONCURRENT_FLUSHES),
@@ -107,6 +111,10 @@ impl MaintenanceLimits {
 
     pub fn layout_migration(&self) -> &Mutex<()> {
         &self.layout_migration
+    }
+
+    pub fn encoding_rewrite(&self) -> &Mutex<()> {
+        &self.encoding_rewrite
     }
 
     pub fn maintenance_cycles(&self) -> &tokio::sync::Semaphore {

--- a/lib/finelog/rust/src/maintenance/scheduler.rs
+++ b/lib/finelog/rust/src/maintenance/scheduler.rs
@@ -25,7 +25,7 @@ use crate::maintenance::{
     MIN_POLL_INTERVAL,
 };
 use crate::store::store::ServeMode;
-use crate::store::table::{TableManager, TableRuntime, TableWork};
+use crate::store::table::{TableManager, TableRuntime, TableWork, WorkOutcome};
 
 /// Report a maintenance cycle that sat in the slot queue at least this long.
 const SLOW_CYCLE_WAIT: Duration = Duration::from_secs(5);
@@ -64,16 +64,22 @@ impl TableCadence {
 #[derive(Clone, Copy)]
 enum ScheduledWork {
     Flush,
-    Maintenance { prompt: bool },
+    Maintenance(MaintenanceQueue),
+}
+
+#[derive(Clone, Copy)]
+enum MaintenanceQueue {
+    Shared,
+    Migration,
 }
 
 impl ScheduledWork {
-    fn clear_running(self, entry: &mut TableCadence, prompt: bool) {
+    fn clear_running(self, entry: &mut TableCadence, outcome: WorkOutcome) {
         match self {
             Self::Flush => entry.flush_running = false,
-            Self::Maintenance { .. } => {
+            Self::Maintenance(_) => {
                 entry.maintenance_running = false;
-                entry.prompt_maintenance = prompt;
+                entry.prompt_maintenance = outcome.has_more_work();
             }
         }
     }
@@ -212,7 +218,7 @@ impl MaintenanceScheduler {
         // the demand rather than being swallowed by this cycle.
         runtime.clear_flush_demand();
         if !self.dispatch(runtime, ScheduledWork::Flush) {
-            ScheduledWork::Flush.clear_running(entry, false);
+            ScheduledWork::Flush.clear_running(entry, WorkOutcome::Complete);
         }
         MIN_FLUSH_INTERVAL
     }
@@ -240,11 +246,14 @@ impl MaintenanceScheduler {
         }
         entry.last_maintenance = now;
         entry.maintenance_running = true;
-        let work = ScheduledWork::Maintenance {
-            prompt: entry.prompt_maintenance,
+        let queue = if entry.prompt_maintenance {
+            MaintenanceQueue::Migration
+        } else {
+            MaintenanceQueue::Shared
         };
+        let work = ScheduledWork::Maintenance(queue);
         if !self.dispatch(runtime, work) {
-            work.clear_running(entry, false);
+            work.clear_running(entry, WorkOutcome::Complete);
         }
         interval
     }
@@ -259,20 +268,20 @@ impl MaintenanceScheduler {
         runtime.clone().spawn_tracked({
             let runtime = Arc::clone(runtime);
             async move {
-                let prompt = match work {
+                let outcome = match work {
                     ScheduledWork::Flush => {
                         let _permit = limits.flushes().acquire().await;
                         if let Err(error) = tables.run_work(&runtime, TableWork::Flush).await {
                             tracing::warn!(namespace = %runtime.name(), %error, "scheduled flush failed");
                         }
-                        false
+                        WorkOutcome::Complete
                     }
-                    ScheduledWork::Maintenance { prompt } => {
-                        run_maintenance_cycle(&tables, &limits, &runtime, prompt).await
+                    ScheduledWork::Maintenance(queue) => {
+                        run_maintenance_cycle(&tables, &limits, &runtime, queue).await
                     }
                 };
                 if let Some(entry) = cadence.lock().unwrap().get_mut(&table) {
-                    work.clear_running(entry, prompt);
+                    work.clear_running(entry, outcome);
                 }
                 wake.notify_one();
             }
@@ -284,15 +293,18 @@ async fn run_maintenance_cycle(
     tables: &TableManager,
     limits: &MaintenanceLimits,
     runtime: &Arc<TableRuntime>,
-    prompt: bool,
-) -> bool {
+    queue: MaintenanceQueue,
+) -> WorkOutcome {
     let queued = Instant::now();
     let mut _migration_slot = None;
     let mut _cycle_slot = None;
-    if prompt {
-        _migration_slot = Some(limits.spec_migration().lock().await);
-    } else {
-        _cycle_slot = Some(limits.maintenance_cycles().acquire().await);
+    match queue {
+        MaintenanceQueue::Migration => {
+            _migration_slot = Some(limits.spec_migration().lock().await);
+        }
+        MaintenanceQueue::Shared => {
+            _cycle_slot = Some(limits.maintenance_cycles().acquire().await);
+        }
     }
     let waited = queued.elapsed();
     if waited >= SLOW_CYCLE_WAIT {
@@ -306,11 +318,11 @@ async fn run_maintenance_cycle(
         force_compact_l0: false,
     };
     match tables.run_work(runtime, cycle).await {
-        Ok(outcome) => outcome.has_more_work(),
+        Ok(outcome) => outcome,
         Err(error) => {
             // A bad input must not turn this into a hot loop.
             tracing::warn!(namespace = %runtime.name(), %error, "scheduled maintenance failed");
-            false
+            WorkOutcome::Complete
         }
     }
 }

--- a/lib/finelog/rust/src/maintenance/scheduler.rs
+++ b/lib/finelog/rust/src/maintenance/scheduler.rs
@@ -39,7 +39,7 @@ struct TableCadence {
     /// Set from the previous cycle's outcome. A table rebuilding its physical
     /// layout is polled at [`LAYOUT_MIGRATION_RETRY_INTERVAL`] instead of its
     /// ordinary compaction check interval.
-    migration_pending: bool,
+    prompt_maintenance: bool,
     /// Cleared at the end of each round; an entry that stays false belongs to a
     /// table that has left the registry.
     live: bool,
@@ -55,8 +55,26 @@ impl TableCadence {
             last_maintenance: now,
             flush_running: false,
             maintenance_running: false,
-            migration_pending: false,
+            prompt_maintenance: false,
             live: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ScheduledWork {
+    Flush,
+    Maintenance { prompt: bool },
+}
+
+impl ScheduledWork {
+    fn clear_running(self, entry: &mut TableCadence, prompt: bool) {
+        match self {
+            Self::Flush => entry.flush_running = false,
+            Self::Maintenance { .. } => {
+                entry.maintenance_running = false;
+                entry.prompt_maintenance = prompt;
+            }
         }
     }
 }
@@ -109,7 +127,13 @@ impl MaintenanceScheduler {
         self.stop.notify_waiters();
         let handle = self.task.lock().unwrap().take();
         if let Some(handle) = handle {
-            let _ = handle.await;
+            if let Err(error) = handle.await {
+                if error.is_cancelled() {
+                    tracing::debug!(%error, "maintenance scheduler task was cancelled");
+                } else {
+                    tracing::error!(%error, "maintenance scheduler task failed");
+                }
+            }
         }
     }
 
@@ -187,26 +211,8 @@ impl MaintenanceScheduler {
         // Clear before the flush runs so an append that lands during it re-arms
         // the demand rather than being swallowed by this cycle.
         runtime.clear_flush_demand();
-        let table = runtime.name().to_string();
-        let limits = Arc::clone(&self.limits);
-        let wake = Arc::clone(&self.wake);
-        let cadence = Arc::clone(&self.cadence);
-        let tables = Arc::clone(&self.tables);
-        let dispatched = runtime.clone().spawn_tracked({
-            let runtime = Arc::clone(runtime);
-            async move {
-                let _permit = limits.flushes().acquire().await;
-                if let Err(error) = tables.run_work(&runtime, TableWork::Flush).await {
-                    tracing::warn!(namespace = %runtime.name(), %error, "scheduled flush failed");
-                }
-                if let Some(entry) = cadence.lock().unwrap().get_mut(&table) {
-                    entry.flush_running = false;
-                }
-                wake.notify_one();
-            }
-        });
-        if !dispatched {
-            entry.flush_running = false;
+        if !self.dispatch(runtime, ScheduledWork::Flush) {
+            ScheduledWork::Flush.clear_running(entry, false);
         }
         MIN_FLUSH_INTERVAL
     }
@@ -222,7 +228,7 @@ impl MaintenanceScheduler {
         if self.mode == ServeMode::Shadow || entry.maintenance_running {
             return MAX_POLL_INTERVAL;
         }
-        let interval = if entry.migration_pending {
+        let interval = if entry.prompt_maintenance {
             LAYOUT_MIGRATION_RETRY_INTERVAL
         } else {
             runtime.maintenance_interval()
@@ -234,60 +240,78 @@ impl MaintenanceScheduler {
         }
         entry.last_maintenance = now;
         entry.maintenance_running = true;
+        let work = ScheduledWork::Maintenance {
+            prompt: entry.prompt_maintenance,
+        };
+        if !self.dispatch(runtime, work) {
+            work.clear_running(entry, false);
+        }
+        interval
+    }
+
+    /// Spawn one tracked unit and settle its cadence state on every outcome.
+    fn dispatch(&self, runtime: &Arc<TableRuntime>, work: ScheduledWork) -> bool {
         let table = runtime.name().to_string();
-        let migration_owned = entry.migration_pending;
         let limits = Arc::clone(&self.limits);
         let wake = Arc::clone(&self.wake);
         let cadence = Arc::clone(&self.cadence);
         let tables = Arc::clone(&self.tables);
-        let dispatched = runtime.clone().spawn_tracked({
+        runtime.clone().spawn_tracked({
             let runtime = Arc::clone(runtime);
             async move {
-                let queued = Instant::now();
-                // A migrating table cycles in its own slot (see
-                // `MaintenanceLimits::spec_migration`); everything else shares
-                // the maintenance slots.
-                let mut _migration_slot = None;
-                let mut _cycle_slot = None;
-                if migration_owned {
-                    _migration_slot = Some(limits.spec_migration().lock().await);
-                } else {
-                    _cycle_slot = Some(limits.maintenance_cycles().acquire().await);
-                }
-                let waited = queued.elapsed();
-                if waited >= SLOW_CYCLE_WAIT {
-                    // A long wait means another table's cycle is hogging the
-                    // process's few maintenance slots (e.g. a legacy backlog
-                    // drain); it shows up here rather than as a mystery stall.
-                    tracing::info!(
-                        namespace = %runtime.name(),
-                        waited_ms = waited.as_millis() as u64,
-                        "maintenance cycle waited for a slot"
-                    );
-                }
-                let cycle = TableWork::Cycle {
-                    force_compact_l0: false,
-                };
-                let migration_pending = match tables.run_work(&runtime, cycle).await {
-                    Ok(outcome) => outcome.pending,
-                    Err(error) => {
-                        // Fall back to the ordinary interval after an error. A
-                        // bad input must not turn this into a hot loop.
-                        tracing::warn!(namespace = %runtime.name(), %error, "scheduled maintenance failed");
+                let prompt = match work {
+                    ScheduledWork::Flush => {
+                        let _permit = limits.flushes().acquire().await;
+                        if let Err(error) = tables.run_work(&runtime, TableWork::Flush).await {
+                            tracing::warn!(namespace = %runtime.name(), %error, "scheduled flush failed");
+                        }
                         false
+                    }
+                    ScheduledWork::Maintenance { prompt } => {
+                        run_maintenance_cycle(&tables, &limits, &runtime, prompt).await
                     }
                 };
                 if let Some(entry) = cadence.lock().unwrap().get_mut(&table) {
-                    entry.maintenance_running = false;
-                    entry.migration_pending = migration_pending;
+                    work.clear_running(entry, prompt);
                 }
                 wake.notify_one();
             }
-        });
-        if !dispatched {
-            entry.maintenance_running = false;
+        })
+    }
+}
+
+async fn run_maintenance_cycle(
+    tables: &TableManager,
+    limits: &MaintenanceLimits,
+    runtime: &Arc<TableRuntime>,
+    prompt: bool,
+) -> bool {
+    let queued = Instant::now();
+    let mut _migration_slot = None;
+    let mut _cycle_slot = None;
+    if prompt {
+        _migration_slot = Some(limits.spec_migration().lock().await);
+    } else {
+        _cycle_slot = Some(limits.maintenance_cycles().acquire().await);
+    }
+    let waited = queued.elapsed();
+    if waited >= SLOW_CYCLE_WAIT {
+        tracing::info!(
+            namespace = %runtime.name(),
+            waited_ms = waited.as_millis() as u64,
+            "maintenance cycle waited for a slot"
+        );
+    }
+    let cycle = TableWork::Cycle {
+        force_compact_l0: false,
+    };
+    match tables.run_work(runtime, cycle).await {
+        Ok(outcome) => outcome.has_more_work(),
+        Err(error) => {
+            // A bad input must not turn this into a hot loop.
+            tracing::warn!(namespace = %runtime.name(), %error, "scheduled maintenance failed");
+            false
         }
-        interval
     }
 }
 
@@ -370,29 +394,34 @@ mod tests {
         let manager = manager_with_one_table(dir.clone(), ServeMode::Live);
         let scheduler = MaintenanceScheduler::new(Arc::clone(&manager));
         let table = manager.require(TABLE).unwrap();
+        let now = Instant::now();
+        let mut cadence = TableCadence::new(now);
 
         table.request_flush(false);
-        scheduler.poll_round();
+        scheduler.schedule_flush(&table, &mut cadence, now);
         assert!(
             !table.flush_demand().requested,
             "a table's first nudge flushes without waiting"
         );
-        // Let the dispatched flush finish, still well inside the window.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Model the dispatch completion. This unit test covers the cadence
+        // decision; task completion is exercised by the scheduler shutdown
+        // tests.
+        cadence.flush_running = false;
 
         table.request_flush(false);
-        scheduler.poll_round();
+        scheduler.schedule_flush(&table, &mut cadence, now);
         assert!(
             table.flush_demand().requested,
             "a nudge inside the coalescing window is deferred, not dropped"
         );
 
         table.request_flush(true);
-        scheduler.poll_round();
+        scheduler.schedule_flush(&table, &mut cadence, now);
         assert!(
             !table.flush_demand().requested,
             "a full buffer flushes without waiting out the window"
         );
+        table.stop_and_join(Duration::from_secs(1)).await;
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -341,9 +341,13 @@ async fn read_all(client: &LogServiceClient<TestTransport>) -> Vec<(String, Stri
 
 /// Poll `condition` until it holds, or fail after five seconds with `describe()`, so a
 /// wedged forwarder fails the test rather than hanging it.
-async fn poll_until(mut condition: impl FnMut() -> bool, describe: impl Fn() -> String) {
+async fn poll_until<F, Fut>(mut condition: F, describe: impl Fn() -> String)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
     for _ in 0..200 {
-        if condition() {
+        if condition().await {
             return;
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
@@ -352,17 +356,11 @@ async fn poll_until(mut condition: impl FnMut() -> bool, describe: impl Fn() -> 
 }
 
 async fn wait_for_scalar(store: &Store, sql: &str, expected: i64) {
-    for _ in 0..200 {
-        let actual = scalar_i64(store, sql).await;
-        if actual == expected {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    panic!(
-        "query {sql:?} never returned {expected} (last saw {})",
-        scalar_i64(store, sql).await
-    );
+    poll_until(
+        || async { scalar_i64(store, sql).await == expected },
+        || format!("query {sql:?} never returned {expected}"),
+    )
+    .await;
 }
 
 /// Wait for `store`'s watermark for `(target, namespace)` to reach `expected`. Reads
@@ -370,7 +368,7 @@ async fn wait_for_scalar(store: &Store, sql: &str, expected: i64) {
 /// would perturb the target's request count.
 async fn wait_for_cursor(store: &Store, target: &str, namespace: &str, expected: i64) {
     poll_until(
-        || store.forward_cursor(target, namespace).unwrap() == Some(expected),
+        || std::future::ready(store.forward_cursor(target, namespace).unwrap() == Some(expected)),
         || {
             format!(
                 "watermark for {namespace:?} never reached {expected} (stuck at {:?})",
@@ -386,7 +384,7 @@ async fn wait_for_cursor(store: &Store, target: &str, namespace: &str, expected:
 /// produced it.
 async fn wait_for_requests(counter: &RequestStats, expected: usize) {
     poll_until(
-        || counter.total() >= expected,
+        || std::future::ready(counter.total() >= expected),
         || {
             format!(
                 "hub never served {expected} requests (saw {})",
@@ -406,16 +404,14 @@ async fn wait_for_hub_log_rows(fx: &Fixture, expected: &[(&str, &str)]) {
         .iter()
         .map(|(key, data)| (key.to_string(), data.to_string()))
         .collect();
-    for _ in 0..200 {
-        if fx.hub_log_rows().await == want {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    panic!(
-        "hub never held {want:?} (last saw {:?})",
-        fx.hub_log_rows().await
-    );
+    poll_until(
+        || {
+            let want = &want;
+            async move { fx.hub_log_rows().await == *want }
+        },
+        || format!("hub never held {want:?}"),
+    )
+    .await;
 }
 
 /// A forwarder running on its own task, stopped and joined by [`Self::finish`].
@@ -490,7 +486,7 @@ async fn fresh_remote_store_forwarder_registers_progress_without_panicking() {
 
     let running = RunningForwarder::start(forwarder);
     poll_until(
-        || source.get_table_schema(FINELOG_NAMESPACE).is_ok(),
+        || std::future::ready(source.get_table_schema(FINELOG_NAMESPACE).is_ok()),
         || "forwarder did not register its progress namespace".to_string(),
     )
     .await;

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -351,6 +351,20 @@ async fn poll_until(mut condition: impl FnMut() -> bool, describe: impl Fn() -> 
     panic!("{}", describe());
 }
 
+async fn wait_for_scalar(store: &Store, sql: &str, expected: i64) {
+    for _ in 0..200 {
+        let actual = scalar_i64(store, sql).await;
+        if actual == expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!(
+        "query {sql:?} never returned {expected} (last saw {})",
+        scalar_i64(store, sql).await
+    );
+}
+
 /// Wait for `store`'s watermark for `(target, namespace)` to reach `expected`. Reads
 /// local state only, so a test can tell "the forwarder is done" without an RPC that
 /// would perturb the target's request count.
@@ -1475,13 +1489,7 @@ async fn a_restart_mid_migration_resumes_forwarding_from_the_durable_cursor() {
 
     // The hub ACKs before its async flush seals the rows, so poll the count.
     let count_sql = format!("SELECT count(*) FROM \"{EVENTS}\"");
-    for _ in 0..200 {
-        if scalar_i64(&target, &count_sql).await == 60 {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    assert_eq!(scalar_i64(&target, &count_sql).await, 60);
+    wait_for_scalar(&target, &count_sql, 60).await;
     assert_eq!(
         scalar_i64(
             &target,
@@ -1547,7 +1555,6 @@ async fn a_hub_migration_under_live_forwarding_loses_nothing() {
             break;
         }
         hub.maintain_namespace(EVENTS, false).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(25)).await;
     }
     assert_eq!(
         hub.spec_lifecycle(EVENTS).unwrap().active_version(),
@@ -1563,13 +1570,7 @@ async fn a_hub_migration_under_live_forwarding_loses_nothing() {
     // Exactly once, before and after the flip. The hub ACKs before its async
     // flush seals rows for queries, so poll the count.
     let count_sql = format!("SELECT count(*) FROM \"{EVENTS}\"");
-    for _ in 0..200 {
-        if scalar_i64(&hub, &count_sql).await == 250 {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    assert_eq!(scalar_i64(&hub, &count_sql).await, 250);
+    wait_for_scalar(&hub, &count_sql, 250).await;
     assert_eq!(
         scalar_i64(
             &hub,

--- a/lib/finelog/rust/src/store/adopt.rs
+++ b/lib/finelog/rust/src/store/adopt.rs
@@ -516,7 +516,7 @@ fn discard_staging_files(dir: &Path, namespace: &str) {
 ///   compaction input the catalog has already superseded — its row replaced by
 ///   the merge output — but whose unlink has not yet run. Adopting the latter
 ///   resurrects a phantom segment whose file is about to vanish: a dangling
-///   reference that wedges compaction (#7361). Monotonic seq allocation
+///   reference that wedges compaction. Monotonic seq allocation
 ///   separates the two — a genuine flush orphan always sits strictly ABOVE the
 ///   cataloged high-water seq, a superseded input at or below it — so pass 2
 ///   skips any file whose `min_seq` is not past every catalog row's `max_seq`.
@@ -640,7 +640,7 @@ pub fn adopt_local_segments(
         // is a compaction input whose row the merge output replaced but whose
         // unlink has not yet run (a concurrent adopt caught the post-splice /
         // pre-unlink window). Adopting it would resurrect a phantom segment whose
-        // file is about to vanish, wedging compaction (#7361). A genuine
+        // file is about to vanish, wedging compaction. A genuine
         // uncataloged flush always sits strictly above the cataloged high-water
         // seq, so this only skips the superseded case.
         if let Some(max_seq) = max_catalog_seq {
@@ -1126,7 +1126,7 @@ mod tests {
 
     #[test]
     fn adopt_skips_superseded_compaction_input_still_on_disk() {
-        // Regression for #7361. A compaction had committed its catalog splice —
+        // A compaction had committed its catalog splice —
         // `replace_segments` swapped the L0 input rows for the merged L1 output —
         // but had not yet unlinked the input files when adoption ran (a
         // re-register replacing the engine, or a crash, caught the post-splice /

--- a/lib/finelog/rust/src/store/catalog/namespaces.rs
+++ b/lib/finelog/rust/src/store/catalog/namespaces.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::errors::StatsError;
 use crate::store::policy::StoragePolicy;
 use crate::store::schema::{schema_from_json, schema_to_json, Schema};
+use rusqlite::OptionalExtension;
 
 /// A live namespace value.
 #[derive(Debug, Clone)]
@@ -194,7 +195,8 @@ impl CatalogInner {
                 [name],
                 |row| row.get(0),
             )
-            .ok();
+            .optional()
+            .map_err(sqlite_err)?;
         let registered_at = existing.unwrap_or(now);
         self.conn
             .execute(

--- a/lib/finelog/rust/src/store/catalog/tests.rs
+++ b/lib/finelog/rust/src/store/catalog/tests.rs
@@ -162,7 +162,7 @@ fn upsert_schema_round_trips_through_json() {
 }
 
 #[test]
-fn upsert_preserves_registered_at_and_bumps_last_modified() {
+fn upsert_preserves_registered_at_and_does_not_regress_last_modified() {
     let cat = Catalog::open(None).unwrap();
     cat.upsert("a", &worker_stored()).unwrap();
     let inner = cat.inner.lock().unwrap();
@@ -175,7 +175,6 @@ fn upsert_preserves_registered_at_and_bumps_last_modified() {
         )
         .unwrap();
     drop(inner);
-    std::thread::sleep(std::time::Duration::from_millis(2));
     cat.upsert("a", &worker_stored()).unwrap();
     let inner = cat.inner.lock().unwrap();
     let (reg2, mod2): (i64, i64) = inner
@@ -187,7 +186,27 @@ fn upsert_preserves_registered_at_and_bumps_last_modified() {
         )
         .unwrap();
     assert_eq!(reg1, reg2, "registered_at preserved");
-    assert!(mod2 >= mod1, "last_modified bumped");
+    assert!(mod2 >= mod1, "last_modified did not regress");
+}
+
+#[test]
+fn upsert_reports_invalid_persisted_registration_timestamp() {
+    let cat = Catalog::open(None).unwrap();
+    cat.upsert("a", &worker_stored()).unwrap();
+    cat.inner
+        .lock()
+        .unwrap()
+        .conn
+        .execute(
+            "UPDATE namespaces SET registered_at_ms = 'invalid' WHERE namespace = 'a'",
+            [],
+        )
+        .unwrap();
+
+    assert!(matches!(
+        cat.upsert("a", &worker_stored()),
+        Err(StatsError::Internal(_))
+    ));
 }
 
 #[test]

--- a/lib/finelog/rust/src/store/compaction/local_driver.rs
+++ b/lib/finelog/rust/src/store/compaction/local_driver.rs
@@ -137,7 +137,7 @@ pub fn run_job(compaction: &LocalCompaction<'_>, job: &CompactionJob) -> Result<
                 compaction.segments,
                 compaction.query_visibility,
                 path,
-            );
+            )?;
         }
         tracing::warn!(
             namespace = %compaction.table,

--- a/lib/finelog/rust/src/store/compaction/object_driver.rs
+++ b/lib/finelog/rust/src/store/compaction/object_driver.rs
@@ -53,6 +53,14 @@ pub struct ObjectCompaction<'a> {
     pub target_object_bytes: i64,
 }
 
+/// One planned compaction with the lifecycle state its commit is fenced to.
+struct LeasedCompaction<'context, 'resources> {
+    resources: &'context ObjectCompaction<'resources>,
+    lease: MaintenanceLease,
+    table_spec_version: u64,
+    migration_backfill: bool,
+}
+
 /// Result of one object-compaction attempt.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompactionOutcome {
@@ -164,28 +172,24 @@ pub async fn compact_once(
     }
 
     let staging = StagingDir::create(compaction.table_dir)?;
-    let outcome = run(
-        &compaction,
-        &staging,
-        &job,
-        &lease,
+    let leased = LeasedCompaction {
+        resources: &compaction,
+        lease,
         table_spec_version,
         migration_backfill,
-    )
-    .await;
+    };
+    let outcome = run(&leased, &staging, &job).await;
     drop(staging);
     outcome
 }
 
 /// Execute one object compaction inside `staging` and commit its result.
 async fn run(
-    compaction: &ObjectCompaction<'_>,
+    leased: &LeasedCompaction<'_, '_>,
     staging: &StagingDir,
     job: &CompactionJob,
-    lease: &MaintenanceLease,
-    table_spec_version: u64,
-    migration_backfill: bool,
 ) -> Result<CompactionOutcome, StatsError> {
+    let compaction = leased.resources;
     let index_config = compaction.index_config.clone();
     let arrow_schema = Arc::clone(compaction.format.arrow_schema());
     let sort_columns = compaction.format.sort_columns().to_vec();
@@ -231,15 +235,7 @@ async fn run(
     // renamed, so the promotion re-advertises the same source and artifacts at
     // the higher level instead of rewriting anything.
     if swap.bump_rename.is_some() {
-        return commit_level_bump(
-            compaction,
-            &swap.removed,
-            swap.added,
-            lease,
-            table_spec_version,
-            migration_backfill,
-        )
-        .await;
+        return commit_level_bump(leased, &swap.removed, swap.added).await;
     }
     if swap.added.is_empty() {
         tracing::warn!(
@@ -287,27 +283,16 @@ async fn run(
         upload_ms = upload_started.elapsed().as_millis() as u64,
         "object compaction rewrite finished"
     );
-    commit_replacement(
-        compaction,
-        &swap.removed,
-        outputs,
-        published,
-        lease,
-        table_spec_version,
-        migration_backfill,
-    )
-    .await
+    commit_replacement(leased, &swap.removed, outputs, published).await
 }
 
 /// Promote a single input to the next level without rewriting its object.
 async fn commit_level_bump(
-    compaction: &ObjectCompaction<'_>,
+    leased: &LeasedCompaction<'_, '_>,
     removed: &[String],
     added: Vec<LocalSegment>,
-    lease: &MaintenanceLease,
-    table_spec_version: u64,
-    migration_backfill: bool,
 ) -> Result<CompactionOutcome, StatsError> {
+    let compaction = leased.resources;
     let records: HashMap<_, _> = compaction
         .catalog
         .object_segments(compaction.table)?
@@ -332,32 +317,21 @@ async fn commit_level_bump(
         });
         published.push(segment);
     }
-    commit_replacement(
-        compaction,
-        removed,
-        outputs,
-        published,
-        lease,
-        table_spec_version,
-        migration_backfill,
-    )
-    .await
+    commit_replacement(leased, removed, outputs, published).await
 }
 
 /// Commit one leased replacement and swap the local query view.
 async fn commit_replacement(
-    compaction: &ObjectCompaction<'_>,
+    leased: &LeasedCompaction<'_, '_>,
     removed: &[String],
     outputs: Vec<SegmentDescriptor>,
     published: Vec<LocalSegment>,
-    lease: &MaintenanceLease,
-    table_spec_version: u64,
-    migration_backfill: bool,
 ) -> Result<CompactionOutcome, StatsError> {
+    let compaction = leased.resources;
     let removed_paths = removed.to_vec();
     let committed = match compaction
         .controller
-        .commit_maintenance(lease, || {
+        .commit_maintenance(&leased.lease, || {
             let live: HashSet<String> = compaction
                 .catalog
                 .object_segments(compaction.table)?
@@ -373,8 +347,8 @@ async fn commit_replacement(
                 compaction.table,
                 &removed_paths,
                 &outputs,
-                table_spec_version,
-                migration_backfill,
+                leased.table_spec_version,
+                leased.migration_backfill,
             )?;
             Ok((revision, ()))
         })

--- a/lib/finelog/rust/src/store/legacy/archive.rs
+++ b/lib/finelog/rust/src/store/legacy/archive.rs
@@ -181,7 +181,7 @@ pub fn evict_to_policy(
             // Over cap but nothing eligible (still L0, or not yet uploaded).
             break;
         };
-        evict_segment(table, catalog, segments, query_visibility, &row.path);
+        evict_segment(table, catalog, segments, query_visibility, &row.path)?;
     }
 
     // Age trim: independent of size; ordered by created_at_ms.
@@ -190,7 +190,7 @@ pub fn evict_to_policy(
     };
     let cutoff_ms = crate::store::table::now_ms() - max_age_ms;
     while let Some(row) = catalog.select_aged_eviction_candidate(table, cutoff_ms)? {
-        evict_segment(table, catalog, segments, query_visibility, &row.path);
+        evict_segment(table, catalog, segments, query_visibility, &row.path)?;
     }
     Ok(())
 }
@@ -214,14 +214,17 @@ pub fn evict_segment(
     segments: &SegmentView,
     query_visibility: &Arc<RwLock<()>>,
     path: &str,
-) -> i64 {
+) -> Result<i64, StatsError> {
     let _write_guard = query_visibility.blocking_write();
-    let removed = segments.remove(path);
-    if removed.as_ref().map(|segment| segment.location) == Some(SegmentLocation::Both) {
-        let _ = catalog.set_location(table, path, SegmentLocation::Remote);
+    let Some(candidate) = segments.find(|segment| segment.path == path) else {
+        return Ok(0);
+    };
+    if candidate.location == SegmentLocation::Both {
+        catalog.set_location(table, path, SegmentLocation::Remote)?;
     } else {
-        let _ = catalog.remove_segment(table, path);
+        catalog.remove_segment(table, path)?;
     }
+    let removed = segments.remove(path);
     if let Err(error) = std::fs::remove_file(path) {
         if error.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(namespace = %table, path = %path, %error, "failed to delete evicted segment");
@@ -230,7 +233,7 @@ pub fn evict_segment(
     // Derived indexes are local-only, so they are unlinked with the local
     // Parquet on eviction.
     remove_index_artifacts(path);
-    removed.map(|segment| segment.size_bytes).unwrap_or(0)
+    Ok(removed.map(|segment| segment.size_bytes).unwrap_or(0))
 }
 
 #[cfg(test)]

--- a/lib/finelog/rust/src/store/legacy/layout.rs
+++ b/lib/finelog/rust/src/store/legacy/layout.rs
@@ -43,20 +43,6 @@ const PARTITIONING_BUDGET: Duration = Duration::from_secs(3);
 const PARTITIONING_CONCURRENCY: usize = 2;
 const PARTITIONING_WORKER_COMPRESSED_BYTES: i64 = 32 * 1024 * 1024;
 
-/// Process-wide permit for the encoding rewrite, so only one table re-encodes at
-/// a time.
-///
-/// A per-table budget alone let a store with dozens of tables spend dozens of
-/// budgets at once. On the marin hub that saturated the box: a 10 min telemetry
-/// query that normally answers in 0.18 s took 15 s, and `count(*)` went from
-/// 0.3 s to 17 s, because re-encoding pushes tens of GiB through the page cache
-/// the queries are served from and invalidates the parquet metadata cache entry
-/// for every segment it touches.
-///
-/// A table that cannot take the permit skips the step for this tick rather than
-/// queueing behind it, which would stall the rest of its maintenance.
-static REWRITE_SLOT: Mutex<()> = Mutex::new(());
-
 /// Everything the layout work reads and commits through.
 pub struct LocalLayout<'a> {
     pub compaction: LocalCompaction<'a>,
@@ -496,7 +482,7 @@ fn archive_placement_candidates(
 /// replaces its local generation identity with a UUID, so its bundle safely falls
 /// back until the next index-backfill pass rebuilds it.
 pub fn rewrite_stale_encodings(layout: &LocalLayout<'_>, budget: Duration) -> usize {
-    let Ok(_permit) = REWRITE_SLOT.try_lock() else {
+    let Ok(_permit) = layout.limits.encoding_rewrite().try_lock() else {
         return 0;
     };
     let deadline = Instant::now() + budget;
@@ -846,6 +832,7 @@ mod tests {
             )
         })
         .await
+        .unwrap()
         .unwrap();
         let mut legacy = catalog.list_segments("levanter.metrics").unwrap().remove(0);
         assert_eq!(legacy.location, SegmentLocation::Remote);

--- a/lib/finelog/rust/src/store/object_store.rs
+++ b/lib/finelog/rust/src/store/object_store.rs
@@ -12,7 +12,7 @@ mod remote;
 
 pub use cached::CachedObjectStore;
 pub use legacy::LegacyObjectStore;
-pub use provider::is_object_store;
+pub use provider::is_remote_object_store;
 pub use remote::{build_remote_object_store, RemoteObjectStore};
 
 use std::path::PathBuf;

--- a/lib/finelog/rust/src/store/object_store/local_file.rs
+++ b/lib/finelog/rust/src/store/object_store/local_file.rs
@@ -59,8 +59,14 @@ pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), StatsError> 
     if let Err(error) = published {
         // A failed write (e.g. a full disk) must not leave the staging file
         // behind: staging files are exempt from cache eviction.
-        let _ = std::fs::remove_file(&staging);
-        return Err(error);
+        return match std::fs::remove_file(&staging) {
+            Ok(()) => Err(error),
+            Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => Err(error),
+            Err(cleanup) => Err(StatsError::Internal(format!(
+                "{error}; failed to remove local object staging {}: {cleanup}",
+                staging.display()
+            ))),
+        };
     }
     std::fs::File::open(parent)
         .and_then(|directory| directory.sync_all())

--- a/lib/finelog/rust/src/store/object_store/provider.rs
+++ b/lib/finelog/rust/src/store/object_store/provider.rs
@@ -12,7 +12,7 @@ use object_store::{
 use sha2::{Digest, Sha256};
 
 use crate::errors::StatsError;
-use crate::store::object_store::{ObjectVersion, StoredObject};
+use crate::store::object_store::{ObjectId, ObjectVersion, StoredObject};
 
 use super::local_file::compare_and_swap as local_compare_and_swap;
 
@@ -94,6 +94,28 @@ impl Provider {
 
     pub(super) fn local_root(&self) -> Option<&Path> {
         self.local_root.as_deref()
+    }
+
+    /// Provider-relative physical path for one validated logical object ID.
+    pub(super) fn object_path(&self, id: &ObjectId) -> OsPath {
+        OsPath::from_iter(
+            self.prefix_parts()
+                .chain(id.as_str().split('/').filter(|part| !part.is_empty())),
+        )
+    }
+
+    /// URL or filesystem path used to scan the same physical object.
+    pub(super) fn scan_url(&self, id: &ObjectId) -> String {
+        let path = self.object_path(id);
+        match self.base_url() {
+            Some(base) => format!("{base}/{path}"),
+            None => self
+                .local_root()
+                .expect("a provider without a base URL has a local root")
+                .join(path.as_ref())
+                .to_string_lossy()
+                .into_owned(),
+        }
     }
 
     /// Read the object at `path`, or `None` when it does not exist.
@@ -192,8 +214,8 @@ impl Provider {
     }
 }
 
-/// Whether `value` names an object store rather than a local directory.
-pub fn is_object_store(value: &str) -> bool {
+/// Whether `value` names a remote bucket URL rather than a local directory.
+pub fn is_remote_object_store(value: &str) -> bool {
     let value = value.trim();
     value.starts_with(GCS_SCHEME) || value.starts_with(S3_SCHEME)
 }

--- a/lib/finelog/rust/src/store/object_store/remote.rs
+++ b/lib/finelog/rust/src/store/object_store/remote.rs
@@ -71,11 +71,6 @@ impl RemoteObjectStore {
             .map(|base| (base.to_string(), Arc::clone(self.provider.backend())))
     }
 
-    /// The URL a registered scan reads `id` from.
-    pub(super) fn scan_url(&self, id: &ObjectId) -> String {
-        self.provider.scan_url(id)
-    }
-
     /// Split the configured prefix on `/` into individual path components.
     /// `OsPath::from_iter` escapes `/` *within* a single part, so a multi-segment
     /// prefix like `logs/sub` must be pushed component-by-component.
@@ -187,7 +182,7 @@ impl ObjectStore for RemoteObjectStore {
     }
 
     fn remote_scan_url(&self, id: &ObjectId) -> Option<String> {
-        Some(self.scan_url(id))
+        Some(self.provider.scan_url(id))
     }
 
     async fn list(&self, prefix: &ObjectPrefix) -> Result<Vec<ObjectMetadata>, StatsError> {

--- a/lib/finelog/rust/src/store/object_store/remote.rs
+++ b/lib/finelog/rust/src/store/object_store/remote.rs
@@ -73,24 +73,7 @@ impl RemoteObjectStore {
 
     /// The URL a registered scan reads `id` from.
     pub(super) fn scan_url(&self, id: &ObjectId) -> String {
-        let key: Vec<&str> = self
-            .prefix_parts()
-            .chain(id.as_str().split('/').filter(|part| !part.is_empty()))
-            .collect();
-        match self.provider.base_url() {
-            Some(base) => format!("{base}/{}", key.join("/")),
-            None => {
-                let mut path = self
-                    .provider
-                    .local_root()
-                    .expect("a provider without a base URL has a local root")
-                    .to_path_buf();
-                for part in key {
-                    path.push(part);
-                }
-                path.to_string_lossy().into_owned()
-            }
-        }
+        self.provider.scan_url(id)
     }
 
     /// Split the configured prefix on `/` into individual path components.
@@ -136,13 +119,13 @@ impl RemoteObjectStore {
 impl ObjectStore for RemoteObjectStore {
     async fn read(&self, id: &ObjectId) -> Result<Option<StoredObject>, StatsError> {
         self.provider
-            .get_path(self.canonical(id.as_str()), "object")
+            .get_path(self.provider.object_path(id), "object")
             .await
     }
 
     /// Create an immutable object, accepting an identical retry.
     async fn write(&self, id: &ObjectId, bytes: bytes::Bytes) -> Result<ObjectVersion, StatsError> {
-        let path = self.canonical(id.as_str());
+        let path = self.provider.object_path(id);
         let content_sha256 = Sha256::digest(&bytes).into();
         let byte_size = bytes.len() as u64;
         let result = self
@@ -194,7 +177,7 @@ impl ObjectStore for RemoteObjectStore {
             .map(|root| local_object_path(root, id));
         self.provider
             .compare_and_swap_path(
-                self.canonical(id.as_str()),
+                self.provider.object_path(id),
                 local_path,
                 expected,
                 bytes,
@@ -231,7 +214,7 @@ impl ObjectStore for RemoteObjectStore {
     }
 
     async fn delete(&self, id: &ObjectId) -> Result<(), StatsError> {
-        let path = self.canonical(id.as_str());
+        let path = self.provider.object_path(id);
         match self.provider.backend().delete(&path).await {
             Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
             Err(error) => Err(StatsError::Internal(format!(

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -1012,8 +1012,8 @@ impl Store {
             let declared_schema = stored_form(table_spec.schema.clone());
             let prospective_schema = match self.catalog.get_live(name) {
                 Some(existing) => match registration {
-                    SchemaRegistration::Additive => merge_schemas(&existing.schema, &stored),
-                    SchemaRegistration::Managed => merge_managed_schema(&existing.schema, &stored),
+                    SchemaRegistration::Additive => merge_schemas(&existing.schema, stored),
+                    SchemaRegistration::Managed => merge_managed_schema(&existing.schema, stored),
                 }?,
                 None => stored.clone(),
             };

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -30,7 +30,9 @@ use crate::policies::{
     physical_partition_policy_for, schema_for_namespace, segment_indexes_enabled_for,
     storage_policy_for, PolicyRegistry,
 };
-use crate::proto::finelog::stats::{ColumnType, L0Mode, SchemaView, TableSpecView};
+use crate::proto::finelog::stats::{
+    ColumnType, L0Mode, NamespaceCatalog, SchemaView, TableSpecView,
+};
 use crate::query::provider::NamespaceProvider;
 use crate::query::RegisteredProvider;
 use crate::store::catalog::{Catalog, PublishedObjectSegment, RegisteredNamespace, SpecLifecycle};
@@ -99,6 +101,12 @@ enum SchemaRegistration {
 enum BatchAlignment {
     Strict,
     ForwardCompatible,
+}
+
+struct RecoveredProjection {
+    schema: Schema,
+    policy: StoragePolicy,
+    segments: Vec<PublishedObjectSegment>,
 }
 
 impl BatchAlignment {
@@ -566,7 +574,43 @@ impl Store {
             );
             return Ok(false);
         }
-        let schema_spec = state
+        let recovered = self.recovered_projection(namespace, &state)?;
+        // The claimed state stays authoritative whatever the projection does:
+        // it is rebuildable, so a failure leaves the table unready rather than
+        // undoing or blocking the durable revision.
+        if let Err(error) = self.catalog.replace_with_published_snapshot(
+            namespace,
+            recovered.schema.clone(),
+            recovered.policy.clone(),
+            &state,
+            &recovered.segments,
+        ) {
+            tracing::error!(
+                namespace,
+                %error,
+                remote_revision,
+                "rebuilding the local projection from the claimed state failed"
+            );
+            self.mark_table_unready(namespace, &error.to_string());
+            return Ok(false);
+        }
+        let (prior, _controller) = self.tables.take(namespace);
+        if let Some(prior) = prior {
+            prior.shutdown(TABLE_LIFECYCLE_SHUTDOWN_TIMEOUT).await;
+        }
+        // The rebuilt runtime seeds its sequence high-water mark from the
+        // projection of the claimed state.
+        self.tables
+            .register(namespace, recovered.schema, recovered.policy)?;
+        Ok(true)
+    }
+
+    fn recovered_projection(
+        &self,
+        namespace: &str,
+        state: &NamespaceCatalog,
+    ) -> Result<RecoveredProjection, StatsError> {
+        let spec = state
             .retained_table_specs
             .iter()
             .find(|spec| spec.version == state.active_table_spec_version)
@@ -582,7 +626,7 @@ impl Store {
                     "table state for {namespace:?} has no retained TableSpec"
                 ))
             })?;
-        let schema_proto = schema_spec.logical_schema.as_option().ok_or_else(|| {
+        let schema_proto = spec.logical_schema.as_option().ok_or_else(|| {
             StatsError::Internal(format!(
                 "table state TableSpec for {namespace:?} has no logical schema"
             ))
@@ -594,16 +638,28 @@ impl Store {
             ))
         })?;
         let schema = stored_form(schema_from_proto_view(&schema_view)?);
-        let policy = schema_spec
+        let policy = spec
             .operating_policy
             .as_option()
             .and_then(|operating| operating.local_cache.as_option())
             .map(StoragePolicy::from_proto_owned)
             .unwrap_or_default();
+        Ok(RecoveredProjection {
+            schema,
+            policy,
+            segments: self.recovered_segments(namespace, state)?,
+        })
+    }
+
+    fn recovered_segments(
+        &self,
+        namespace: &str,
+        state: &NamespaceCatalog,
+    ) -> Result<Vec<PublishedObjectSegment>, StatsError> {
         let object_store = self.object_store.as_ref().ok_or_else(|| {
             StatsError::Internal("table state store configured without an object store".to_string())
         })?;
-        let mut published_segments = HashMap::<String, PublishedObjectSegment>::new();
+        let mut published = HashMap::<String, PublishedObjectSegment>::new();
         for version in &state.version_segments {
             for segment in version
                 .live_segments
@@ -622,11 +678,6 @@ impl Store {
                 {
                     Ok(reference) => reference,
                     Err(error) if table_spec_version == 0 => {
-                        // A version-0 entry can point into the legacy archive
-                        // rather than the object layout (an archive-only row
-                        // retained until retirement). Its bytes are not
-                        // recoverable from the object store; the entry is
-                        // rollback bookkeeping, not a projection row.
                         tracing::debug!(
                             namespace,
                             %error,
@@ -641,9 +692,10 @@ impl Store {
                         "table state segment for {namespace:?} references another table"
                     ))
                 })?;
-                // Recovery names the file a later query would localize; it
-                // never downloads or opens it.
-                let local_path = object_store.planned_local_path(&reference.id)?;
+                let path = object_store
+                    .planned_local_path(&reference.id)?
+                    .to_string_lossy()
+                    .into_owned();
                 let partition = segment
                     .partition_json
                     .as_deref()
@@ -654,8 +706,7 @@ impl Store {
                             "table state segment for {namespace:?} has invalid partition metadata: {error}"
                         ))
                     })?;
-                let path = local_path.to_string_lossy().into_owned();
-                published_segments
+                published
                     .entry(path.clone())
                     .or_insert_with(|| PublishedObjectSegment {
                         row: crate::store::types::SegmentRow {
@@ -682,34 +733,7 @@ impl Store {
                     });
             }
         }
-        let published_segments: Vec<_> = published_segments.into_values().collect();
-        // The claimed state stays authoritative whatever the projection does:
-        // it is rebuildable, so a failure leaves the table unready rather than
-        // undoing or blocking the durable revision.
-        if let Err(error) = self.catalog.replace_with_published_snapshot(
-            namespace,
-            schema.clone(),
-            policy.clone(),
-            &state,
-            &published_segments,
-        ) {
-            tracing::error!(
-                namespace,
-                %error,
-                remote_revision,
-                "rebuilding the local projection from the claimed state failed"
-            );
-            self.mark_table_unready(namespace, &error.to_string());
-            return Ok(false);
-        }
-        let (prior, _controller) = self.tables.take(namespace);
-        if let Some(prior) = prior {
-            prior.shutdown(TABLE_LIFECYCLE_SHUTDOWN_TIMEOUT).await;
-        }
-        // The rebuilt runtime seeds its sequence high-water mark from the
-        // projection of the claimed state.
-        self.tables.register(namespace, schema, policy)?;
-        Ok(true)
+        Ok(published.into_values().collect())
     }
 
     fn rehydrate_from_catalog(&self) -> Result<(), StatsError> {
@@ -947,6 +971,37 @@ impl Store {
             None => self.spec_for_legacy_schema_evolution(name, &stored, registration)?,
         };
         let table_spec = table_spec.or(evolved_spec.as_ref());
+        self.validate_registration_spec(name, &stored, &policy, registration, table_spec)?;
+        let stored_for_merge = stored.clone();
+        let had_engine = self.tables.contains(name);
+        let (effective_schema, effective_policy) =
+            self.catalog
+                .register_or_evolve(
+                    name,
+                    stored,
+                    policy,
+                    move |existing_schema| match registration {
+                        SchemaRegistration::Additive => {
+                            merge_schemas(existing_schema, &stored_for_merge)
+                        }
+                        SchemaRegistration::Managed => {
+                            merge_managed_schema(existing_schema, &stored_for_merge)
+                        }
+                    },
+                )?;
+        self.sync_registered_runtime(name, &effective_schema, effective_policy, had_engine)?;
+        let spec_lifecycle = self.commit_registered_spec(name, table_spec)?;
+        Ok((effective_schema, spec_lifecycle))
+    }
+
+    fn validate_registration_spec(
+        &self,
+        name: &str,
+        stored: &Schema,
+        policy: &StoragePolicy,
+        registration: SchemaRegistration,
+        table_spec: Option<&ValidatedTableSpec>,
+    ) -> Result<(), StatsError> {
         if let Some(table_spec) = table_spec {
             self.catalog.validate_table_spec_registration(
                 name,
@@ -978,51 +1033,39 @@ impl Store {
                 )));
             }
         }
+        Ok(())
+    }
 
-        // `merge_schemas` (pure) raises SchemaConflict on a column-type change.
-        // The catalog applies the empty-policy-keeps-existing rule and persists
-        // under a single lock; we only supply the schema-merge decision.
-        let stored_for_merge = stored.clone();
-        let had_engine = self.tables.contains(name);
-        let (effective_schema, effective_policy) =
-            self.catalog
-                .register_or_evolve(
-                    name,
-                    stored,
-                    policy,
-                    move |existing_schema| match registration {
-                        SchemaRegistration::Additive => {
-                            merge_schemas(existing_schema, &stored_for_merge)
-                        }
-                        SchemaRegistration::Managed => {
-                            merge_managed_schema(existing_schema, &stored_for_merge)
-                        }
-                    },
-                )?;
-        // (Re)build the engine on fresh registration or when the effective schema
-        // evolved. The engine re-opens on the same dir, adopting existing
-        // segments and recovering next_seq, so an additive evolution keeps the
-        // already-flushed data visible. A runtime registration starts maintenance
-        // immediately after construction.
+    fn sync_registered_runtime(
+        &self,
+        name: &str,
+        effective_schema: &Schema,
+        effective_policy: StoragePolicy,
+        had_engine: bool,
+    ) -> Result<(), StatsError> {
         let needs_engine = !had_engine
             || self
                 .tables
                 .get(name)
-                .map(|table| table.schema() != &effective_schema)
+                .map(|table| table.schema() != effective_schema)
                 .unwrap_or(true);
         if needs_engine {
             self.tables
-                .register(name, effective_schema.clone(), effective_policy)?;
+                .register(name, effective_schema.clone(), effective_policy)
+                .map(|_| ())
         } else {
-            // Runtime kept; push the (possibly updated) policy onto it so a
-            // policy-only re-register takes effect on the next eviction tick.
             if let Some(table) = self.tables.get(name) {
                 table.update_policy(effective_policy);
             }
+            Ok(())
         }
-        // Registration is a synchronous RPC path, so its committed revision is
-        // owed to the table's maintenance loop, which publishes it or a later
-        // revision containing it.
+    }
+
+    fn commit_registered_spec(
+        &self,
+        name: &str,
+        table_spec: Option<&ValidatedTableSpec>,
+    ) -> Result<Option<SpecLifecycle>, StatsError> {
         let controller = self.tables.controller(name);
         let spec_lifecycle = table_spec
             .map(|table_spec| {
@@ -1046,7 +1089,7 @@ impl Store {
                 table.update_table_spec(status);
             }
         }
-        Ok((effective_schema, spec_lifecycle))
+        Ok(spec_lifecycle)
     }
 
     /// Append a pre-routed batch and return its row count and durability
@@ -1794,6 +1837,39 @@ mod tests {
         current_catalog: TableSnapshot,
     }
 
+    fn worker_ipc(rows: &[(&str, i64, i64)]) -> (SchemaRef, Vec<u8>) {
+        let batch_schema = schema_to_arrow(&worker_schema());
+        let batch = RecordBatch::try_new(
+            batch_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|(worker, _, _)| *worker)
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(_, value, _)| *value).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(_, _, value)| *value).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap();
+        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
+        (batch_schema, ipc)
+    }
+
+    async fn write_worker_rows(store: &Store, rows: &[(&str, i64, i64)]) -> (SchemaRef, i64) {
+        let (batch_schema, ipc) = worker_ipc(rows);
+        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
+        store
+            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
+            .await
+            .unwrap();
+        (batch_schema, last_seq)
+    }
+
     async fn published_object_table(tag: &str) -> PublishedObjectTableFixture {
         let data_dir = crate::test_support::unique_dir(&format!("{tag}_data"));
         let remote_dir = crate::test_support::unique_dir(&format!("{tag}_remote"));
@@ -1810,22 +1886,8 @@ mod tests {
             .unwrap();
         let initial_catalog = store.publish_object_catalog("iris.worker").await.unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["w-1", "w-2"])),
-                Arc::new(Int64Array::from(vec![128, 256])),
-                Arc::new(Int64Array::from(vec![1, 2])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let (batch_schema, last_seq) =
+            write_worker_rows(&store, &[("w-1", 128, 1), ("w-2", 256, 2)]).await;
         let paths = store.query_snapshot("iris.worker").unwrap().paths;
         let current_catalog = store.publish_object_catalog("iris.worker").await.unwrap();
         PublishedObjectTableFixture {
@@ -2662,22 +2724,7 @@ mod tests {
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let legacy_batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let legacy_ipc = crate::store::ipc::encode_ipc(&batch_schema, &[legacy_batch]).unwrap();
-        let (_, legacy_seq) = store.write_rows("iris.worker", &legacy_ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", legacy_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         let legacy_paths = store.query_snapshot("iris.worker").unwrap().paths;
         assert_eq!(legacy_paths.len(), 1);
         assert!(!legacy_paths[0].contains("/_finelog/"));
@@ -2707,21 +2754,7 @@ mod tests {
         assert_eq!(active_paths.len(), 1);
         assert_local_content_object(&data_dir, &active_paths[0]);
 
-        let current_batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["current"])),
-                Arc::new(Int64Array::from(vec![256])),
-                Arc::new(Int64Array::from(vec![2])),
-            ],
-        )
-        .unwrap();
-        let current_ipc = crate::store::ipc::encode_ipc(&batch_schema, &[current_batch]).unwrap();
-        let (_, current_seq) = store.write_rows("iris.worker", &current_ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", current_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("current", 256, 2)]).await;
 
         let aborted = store.abort_table_migration("iris.worker").await.unwrap();
         assert_eq!(aborted.active_version(), 0);
@@ -2780,22 +2813,7 @@ mod tests {
             .unwrap();
         store.publish_object_catalog("iris.worker").await.unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["existing"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("existing", 128, 1)]).await;
         let before = store.query_snapshot("iris.worker").unwrap().paths;
         assert_eq!(before.len(), 1);
         let generation_before = store
@@ -2852,22 +2870,7 @@ mod tests {
             .register_versioned_table("iris.worker", object_backed_spec(1))
             .unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["existing"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("existing", 128, 1)]).await;
 
         let rekeyed = ObjectSpec::new(2)
             .schema(worker_schema_keyed_on("mem_bytes"))
@@ -3027,22 +3030,7 @@ mod tests {
             .unwrap();
         store.publish_object_catalog("iris.worker").await.unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["existing"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("existing", 128, 1)]).await;
         let source_paths = store.query_snapshot("iris.worker").unwrap().paths;
 
         store
@@ -3079,11 +3067,20 @@ mod tests {
             .as_millis() as i64;
         assert!(deadline > now_ms + 60_000, "deadline {deadline}");
 
-        // Every query the 50 ms bound admits has expired, and the source version
-        // is still there.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Run collection at a logical time after every 50 ms query pin has
+        // expired. The one-hour rollback retention still keeps the source.
         store
-            .maintain_namespace("iris.worker", false)
+            .tables
+            .controller("iris.worker")
+            .gc_published(
+                now_ms + 1_000,
+                crate::store::state_store::object::StateGcPolicy {
+                    pin_retention_ms: 50,
+                    state_retention_ms: 3_600_000,
+                    orphan_grace_ms: 0,
+                    sweep_orphans: true,
+                },
+            )
             .await
             .unwrap();
         let observing = store.spec_lifecycle("iris.worker").unwrap();
@@ -3137,22 +3134,7 @@ mod tests {
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
 
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, last_seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", last_seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         let legacy_paths = store.query_snapshot("iris.worker").unwrap().paths;
         assert_eq!(legacy_paths.len(), 1);
 
@@ -3530,22 +3512,7 @@ mod tests {
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         let phantom_path = format!(
             "{}/iris.worker/run_id/31/seg_L2_0000000000000000900.parquet",
             data_dir.display()
@@ -3671,22 +3638,7 @@ mod tests {
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
 
         let pending = store
             .register_versioned_table("iris.worker", object_backed_spec(1))
@@ -3730,22 +3682,7 @@ mod tests {
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         store
             .register_versioned_table("iris.worker", object_backed_spec(1))
             .unwrap();
@@ -3779,7 +3716,15 @@ mod tests {
             "the retained HEAD must keep the aborted table on the maintenance GC path"
         );
         let removed = controller
-            .gc_published(crate::store::table::now_ms(), 0, 0, 0, true)
+            .gc_published(
+                crate::store::table::now_ms(),
+                crate::store::state_store::object::StateGcPolicy {
+                    pin_retention_ms: 0,
+                    state_retention_ms: 0,
+                    orphan_grace_ms: 0,
+                    sweep_orphans: true,
+                },
+            )
             .await
             .unwrap();
         assert!(removed > 0, "GC removed nothing after the abort");
@@ -3825,22 +3770,8 @@ mod tests {
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let (_, ipc) = worker_ipc(&[("legacy", 128, 1)]);
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         store
             .register_versioned_table("iris.worker", object_backed_spec(1))
             .unwrap();
@@ -3930,22 +3861,7 @@ mod tests {
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        let batch_schema = schema_to_arrow(&worker_schema());
-        let batch = RecordBatch::try_new(
-            batch_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["legacy"])),
-                Arc::new(Int64Array::from(vec![128])),
-                Arc::new(Int64Array::from(vec![1])),
-            ],
-        )
-        .unwrap();
-        let ipc = crate::store::ipc::encode_ipc(&batch_schema, &[batch]).unwrap();
-        let (_, seq) = store.write_rows("iris.worker", &ipc, None).unwrap();
-        store
-            .await_persisted("iris.worker", seq, Duration::from_secs(10))
-            .await
-            .unwrap();
+        let _ = write_worker_rows(&store, &[("legacy", 128, 1)]).await;
         store
             .register_versioned_table("iris.worker", object_backed_spec(1))
             .unwrap();
@@ -3974,6 +3890,7 @@ mod tests {
         recovered
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
+        let (_, ipc) = worker_ipc(&[("legacy", 128, 1)]);
         recovered.write_rows("iris.worker", &ipc, None).unwrap();
 
         recovered.shutdown(Duration::from_secs(1)).await;

--- a/lib/finelog/rust/src/store/table/controller.rs
+++ b/lib/finelog/rust/src/store/table/controller.rs
@@ -84,6 +84,12 @@ struct LeaseLifecycle {
     phase: MigrationPhase,
 }
 
+struct AppliedMutation<T> {
+    previous: TableRevision,
+    revision: TableRevision,
+    output: T,
+}
+
 impl LeaseLifecycle {
     fn from_status(status: &SpecLifecycle) -> Self {
         Self {
@@ -393,7 +399,11 @@ impl TableController {
     where
         F: FnOnce() -> Result<(TableRevision, T), StatsError>,
     {
-        let (previous, revision, output) = self.apply(mutation)?;
+        let AppliedMutation {
+            previous,
+            revision,
+            output,
+        } = self.apply(mutation)?;
         if !self.is_object_backed() {
             return Ok(Committed {
                 token: CommitToken::local(revision, WriterFence::UNCLAIMED),
@@ -423,7 +433,11 @@ impl TableController {
     where
         F: FnOnce() -> Result<(TableRevision, T), StatsError>,
     {
-        let (previous, revision, output) = self.apply(mutation)?;
+        let AppliedMutation {
+            previous,
+            revision,
+            output,
+        } = self.apply(mutation)?;
         let fence = if self.is_object_backed() {
             if revision > previous {
                 self.publish_local_snapshot(revision);
@@ -443,7 +457,7 @@ impl TableController {
     /// A revision that advances is owed to HEAD from the moment it is durable
     /// locally, so a failure between here and publication republishes the same
     /// revision instead of undoing it.
-    fn apply<T, F>(&self, mutation: F) -> Result<(TableRevision, TableRevision, T), CommitError>
+    fn apply<T, F>(&self, mutation: F) -> Result<AppliedMutation<T>, CommitError>
     where
         F: FnOnce() -> Result<(TableRevision, T), StatsError>,
     {
@@ -463,7 +477,11 @@ impl TableController {
                 .map_err(CommitError::NotCommitted)?;
             self.mark_publication_owed();
         }
-        Ok((previous, revision, output))
+        Ok(AppliedMutation {
+            previous,
+            revision,
+            output,
+        })
     }
 
     fn local_revision(&self) -> Result<TableRevision, StatsError> {
@@ -532,22 +550,14 @@ impl TableController {
     }
 
     /// Remove superseded state documents and unreferenced objects.
-    pub async fn gc_published(
+    pub(crate) async fn gc_published(
         &self,
         now_ms: i64,
-        pin_retention_ms: u64,
-        state_retention_ms: u64,
-        orphan_grace_ms: u64,
-        sweep_orphans: bool,
+        policy: StateGcPolicy,
     ) -> Result<usize, StatsError> {
         self.dispatch(|reply| ControllerCommand::GcStates {
             now_ms,
-            policy: StateGcPolicy {
-                pin_retention_ms,
-                state_retention_ms,
-                orphan_grace_ms,
-                sweep_orphans,
-            },
+            policy,
             reply,
         })
         .await?
@@ -905,6 +915,7 @@ impl TableController {
         let mut live = Vec::new();
         let mut retired = Vec::new();
         for version in &catalog.version_segments {
+            let version_number = version.table_spec_version.unwrap_or(0);
             let segments = version
                 .live_segments
                 .iter()
@@ -916,21 +927,38 @@ impl TableController {
                         .map(|segment| (segment, false)),
                 );
             for (segment, is_live) in segments {
-                let Some(source) = segment.source.as_option() else {
-                    continue;
-                };
-                let in_object_layout = source
-                    .object_id
-                    .as_deref()
-                    .and_then(|id| ObjectId::parse(id).ok())
-                    .and_then(|id| id.table_relative(&self.table).map(str::to_string))
-                    .is_some_and(|key| key.starts_with(&data_object_prefix));
-                if !in_object_layout {
+                let table_spec_version = segment.table_spec_version.unwrap_or(version_number);
+                if table_spec_version == 0 {
                     continue;
                 }
-                let Ok(reference) = ObjectReference::try_from(source) else {
-                    continue;
+                let Some(source) = segment.source.as_option() else {
+                    return Err(StatsError::Internal(format!(
+                        "table {:?} version {table_spec_version} segment {:?} has no source object",
+                        self.table, segment.segment_id
+                    )));
                 };
+                let reference = ObjectReference::try_from(source).map_err(|error| {
+                    StatsError::Internal(format!(
+                        "table {:?} version {table_spec_version} segment {:?} has an invalid source object: {error}",
+                        self.table, segment.segment_id
+                    ))
+                })?;
+                let relative = reference.id.table_relative(&self.table).ok_or_else(|| {
+                    StatsError::Internal(format!(
+                        "table {:?} version {table_spec_version} segment {:?} references object {:?} from another table",
+                        self.table,
+                        segment.segment_id,
+                        reference.id.as_str()
+                    ))
+                })?;
+                if !relative.starts_with(&data_object_prefix) {
+                    return Err(StatsError::Internal(format!(
+                        "table {:?} version {table_spec_version} segment {:?} source {:?} is outside the data-object prefix",
+                        self.table,
+                        segment.segment_id,
+                        reference.id.as_str()
+                    )));
+                }
                 if is_live {
                     live.push(reference);
                 } else {
@@ -1112,7 +1140,8 @@ mod tests {
     use buffa::MessageField;
 
     use crate::proto::finelog::stats::{
-        ColumnType, L0Mode, OperatingPolicy, SourceLayout, TableSpec as ProtoTableSpec,
+        CatalogSegment, ColumnType, L0Mode, OperatingPolicy, SourceLayout,
+        TableSpec as ProtoTableSpec, TableVersionSegments,
     };
     use crate::store::object_store::build_remote_object_store;
     use crate::store::schema::{schema_to_proto_owned, with_implicit_seq, Column, Schema};
@@ -1234,6 +1263,33 @@ mod tests {
         assert_eq!(published.fence(), WriterFence::new(11));
         assert!(!controller.publication_owed());
         assert!(controller.writes_ready());
+    }
+
+    #[tokio::test]
+    async fn publication_rejects_a_malformed_live_object_reference() {
+        let (controller, _states, _faults) = faulted_controller("controller_malformed_ref", 11);
+        let state = NamespaceCatalog {
+            version_segments: vec![TableVersionSegments {
+                table_spec_version: Some(1),
+                live_segments: vec![CatalogSegment {
+                    table_spec_version: Some(1),
+                    source: MessageField::some(ObjectRef {
+                        object_id: Some("not/a/canonical/object".to_string()),
+                        byte_size: Some(1),
+                        sha256: Some(vec![0; 32]),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            controller.sync_referenced_objects(&state).await,
+            Err(StatsError::Internal(_))
+        ));
     }
 
     #[tokio::test]

--- a/lib/finelog/rust/src/store/table/maintenance.rs
+++ b/lib/finelog/rust/src/store/table/maintenance.rs
@@ -25,6 +25,7 @@ use crate::store::compaction::local_driver::{self, LocalCompaction};
 use crate::store::compaction::object_driver::{self, ObjectCompaction};
 use crate::store::legacy::archive::{self, LegacyArchive};
 use crate::store::legacy::layout::{self, LocalLayout};
+use crate::store::state_store::object::StateGcPolicy;
 use crate::store::table::index_artifacts::{self, IndexBackfill, INDEX_BUNDLES_PER_TICK};
 use crate::store::table::key_bounds;
 use crate::store::table::runtime::TableRuntime;
@@ -61,22 +62,25 @@ pub enum TableWork {
     Cycle { force_compact_l0: bool },
 }
 
-/// Whether more of the dispatched work is due.
-///
-/// A cycle uses this to decide whether to keep draining, whether a migration
-/// still owns the table, and what cadence the scheduler should poll at next.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct WorkOutcome {
-    pub pending: bool,
+/// Whether the scheduler should run another cycle on its prompt cadence.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WorkOutcome {
+    #[default]
+    Complete,
+    MoreWork,
 }
 
 impl WorkOutcome {
-    fn done() -> Self {
-        Self { pending: false }
+    pub fn has_more_work(self) -> bool {
+        self == Self::MoreWork
     }
 
-    fn pending(pending: bool) -> Self {
-        Self { pending }
+    fn from_pending(pending: bool) -> Self {
+        if pending {
+            Self::MoreWork
+        } else {
+            Self::Complete
+        }
     }
 }
 
@@ -86,7 +90,7 @@ impl WorkOutcome {
 /// and nothing to make durable.
 pub async fn run(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOutcome, StatsError> {
     if !runtime.is_disk_backed() {
-        return Ok(WorkOutcome::done());
+        return Ok(WorkOutcome::Complete);
     }
     match work {
         TableWork::Cycle { force_compact_l0 } => cycle(runtime, force_compact_l0).await,
@@ -100,7 +104,7 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
     match work {
         TableWork::Flush => {
             runtime.flush().await?;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::SpecMigration => {
             let activated = |status: &SpecLifecycle| -> Result<(), StatsError> {
@@ -125,10 +129,12 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
                 on_activated: &activated,
             })
             .await?;
-            Ok(WorkOutcome::pending(owns_cycle))
+            Ok(WorkOutcome::from_pending(owns_cycle))
         }
         TableWork::Compaction { force_compact_l0 } => compact(runtime, force_compact_l0).await,
-        TableWork::KeyBounds => Ok(WorkOutcome::pending(key_bounds::maintain(runtime).await?)),
+        TableWork::KeyBounds => Ok(WorkOutcome::from_pending(
+            key_bounds::maintain(runtime).await?,
+        )),
         TableWork::IndexArtifacts => {
             let tracker = &runtime.layout_tracker;
             let layout_is_current = |path: &str| tracker.is_current(path);
@@ -137,15 +143,15 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
                 INDEX_BUNDLES_PER_TICK,
             )
             .await;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::ObjectCollection => {
             collect_objects(runtime).await?;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::LegacyArchive => {
             sync_archive(runtime).await?;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::Eviction => {
             let runtime = Arc::clone(runtime);
@@ -163,7 +169,7 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
             .map_err(|error| {
                 StatsError::Internal(format!("maintenance evict task panicked: {error}"))
             })??;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::Placement => {
             let runtime = Arc::clone(runtime);
@@ -174,11 +180,11 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
             .map_err(|error| {
                 StatsError::Internal(format!("maintenance placement task panicked: {error}"))
             })??;
-            Ok(WorkOutcome::pending(pending))
+            Ok(WorkOutcome::from_pending(pending))
         }
         TableWork::ArchivePlacement => {
             layout::advance_archive_placement(&local_layout(runtime)).await?;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::EncodingRewrite => {
             let runtime = Arc::clone(runtime);
@@ -189,7 +195,7 @@ async fn run_one(runtime: &Arc<TableRuntime>, work: TableWork) -> Result<WorkOut
             .map_err(|error| {
                 StatsError::Internal(format!("maintenance rewrite task panicked: {error}"))
             })?;
-            Ok(WorkOutcome::done())
+            Ok(WorkOutcome::Complete)
         }
         TableWork::Cycle { .. } => unreachable!("a cycle is composed, not dispatched"),
     }
@@ -207,7 +213,10 @@ async fn cycle(
 ) -> Result<WorkOutcome, StatsError> {
     let _cycle_guard = runtime.maint_lock.lock().await;
     run_one(runtime, TableWork::Flush).await?;
-    if run_one(runtime, TableWork::SpecMigration).await?.pending {
+    if run_one(runtime, TableWork::SpecMigration)
+        .await?
+        .has_more_work()
+    {
         // The migration owns the table's maintenance while it runs: placement
         // and legacy compaction would destroy the sources it rewrites. Object
         // compaction stays on: it folds only ordinary-stream objects at the
@@ -226,7 +235,7 @@ async fn cycle(
             runtime.controller.gc_objects().await?;
             run_one(runtime, TableWork::ObjectCollection).await?;
         }
-        return Ok(WorkOutcome::pending(true));
+        return Ok(WorkOutcome::MoreWork);
     }
     if runtime.policy().object_backed() {
         runtime.controller.publish_owed().await?;
@@ -234,17 +243,21 @@ async fn cycle(
         // then drains at the fast re-poll cadence through the dedicated slot
         // instead of one run per shared-queue visit, mirroring how a legacy
         // table drains its whole backlog in one cycle.
-        let bounds_pending = run_one(runtime, TableWork::KeyBounds).await?.pending;
+        let bounds_pending = run_one(runtime, TableWork::KeyBounds)
+            .await?
+            .has_more_work();
         let compacted = run_one(runtime, TableWork::Compaction { force_compact_l0 })
             .await?
-            .pending;
+            .has_more_work();
         runtime.controller.gc_objects().await?;
         run_one(runtime, TableWork::ObjectCollection).await?;
         run_one(runtime, TableWork::IndexArtifacts).await?;
-        return Ok(WorkOutcome::pending(bounds_pending || compacted));
+        return Ok(WorkOutcome::from_pending(bounds_pending || compacted));
     }
 
-    let placement_pending = run_one(runtime, TableWork::Placement).await?.pending;
+    let placement_pending = run_one(runtime, TableWork::Placement)
+        .await?
+        .has_more_work();
     run_one(runtime, TableWork::Compaction { force_compact_l0 }).await?;
     run_one(runtime, TableWork::LegacyArchive).await?;
     run_one(runtime, TableWork::ObjectCollection).await?;
@@ -257,7 +270,7 @@ async fn cycle(
     // re-compacted, so without it a table carries whatever layout it was written
     // with until eviction ages it out.
     run_one(runtime, TableWork::EncodingRewrite).await?;
-    Ok(WorkOutcome::pending(placement_pending))
+    Ok(WorkOutcome::from_pending(placement_pending))
 }
 
 /// Compact one run, or — for a legacy table — drain the planner's backlog.
@@ -282,7 +295,7 @@ async fn compact(
             force_compact_l0,
         )
         .await?;
-        return Ok(WorkOutcome::pending(compacted.has_pending_work()));
+        return Ok(WorkOutcome::from_pending(compacted.has_pending_work()));
     }
     // The legacy path decodes Parquet and takes the query-visibility write lock,
     // so the whole drain runs on the blocking pool. It checks the stop latch
@@ -291,7 +304,7 @@ async fn compact(
     // inside its timeout. Otherwise a long drain outlives the timeout, the task
     // is aborted, and its detached blocking compaction keeps unlinking inputs
     // while the replacement runtime adopts the same directory — the race that
-    // plants a phantom segment (#7361).
+    // plants a phantom segment.
     let runtime = Arc::clone(runtime);
     let single_job = layout::partitioning_is_pending(&local_layout(&runtime));
     tokio::task::spawn_blocking(move || -> Result<WorkOutcome, StatsError> {
@@ -313,7 +326,7 @@ async fn compact(
                 break;
             }
         }
-        Ok(WorkOutcome::pending(compacted))
+        Ok(WorkOutcome::from_pending(compacted))
     })
     .await
     .map_err(|error| StatsError::Internal(format!("maintenance compact task panicked: {error}")))?
@@ -372,10 +385,12 @@ async fn collect_objects(runtime: &Arc<TableRuntime>) -> Result<(), StatsError> 
         .controller
         .gc_published(
             crate::store::table::now_ms(),
-            policy.max_query_time_ms,
-            state_retention_ms,
-            orphan_grace_ms,
-            sweep_orphans,
+            StateGcPolicy {
+                pin_retention_ms: policy.max_query_time_ms,
+                state_retention_ms,
+                orphan_grace_ms,
+                sweep_orphans,
+            },
         )
         .await?;
     if removed > 0 {

--- a/lib/finelog/rust/src/store/table/segment_view.rs
+++ b/lib/finelog/rust/src/store/table/segment_view.rs
@@ -225,7 +225,7 @@ impl SegmentView {
 /// Debug-only invariant: no two entries share a path.
 ///
 /// A same-path duplicate is a phantom reference — two entries for one seq range,
-/// one of whose file a prior compaction already unlinked (#7361). It surfaces
+/// one of whose file a prior compaction already unlinked. It surfaces
 /// duplicate rows in a query and wedges compaction when the planner picks the
 /// dead entry. Compiled out of release builds; a cheap guard that trips tests
 /// the instant any mutation reintroduces a duplicate.

--- a/lib/finelog/rust/src/test_support.rs
+++ b/lib/finelog/rust/src/test_support.rs
@@ -4,6 +4,7 @@
 //! Fixtures shared by tests across the crate's modules. Module-specific ones (a served
 //! store, a Connect client) live beside the module they exercise.
 
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -224,6 +225,21 @@ impl FaultInjectingObjectStore {
         });
         self.selected(op, key)
     }
+
+    async fn execute<T, F, Fut>(&self, op: ObjectOp, key: &str, run: F) -> Result<T, StatsError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, StatsError>>,
+    {
+        match resolve(self.record(op, key)).await {
+            Proceed::Run => run().await,
+            Proceed::Reject(error) => Err(error),
+            Proceed::RunThenFail { error, gate } => {
+                run().await?;
+                Err(lost(error, gate).await)
+            }
+        }
+    }
 }
 
 /// How a faulted call proceeds once its action is known.
@@ -264,25 +280,13 @@ async fn lost(error: StatsError, gate: Option<Arc<FaultGate>>) -> StatsError {
 #[async_trait]
 impl ObjectStore for FaultInjectingObjectStore {
     async fn write(&self, id: &ObjectId, bytes: bytes::Bytes) -> Result<ObjectVersion, StatsError> {
-        match resolve(self.record(ObjectOp::Write, id.as_str())).await {
-            Proceed::Run => self.inner.write(id, bytes).await,
-            Proceed::Reject(error) => Err(error),
-            Proceed::RunThenFail { error, gate } => {
-                self.inner.write(id, bytes).await?;
-                Err(lost(error, gate).await)
-            }
-        }
+        self.execute(ObjectOp::Write, id.as_str(), || self.inner.write(id, bytes))
+            .await
     }
 
     async fn read(&self, id: &ObjectId) -> Result<Option<StoredObject>, StatsError> {
-        match resolve(self.record(ObjectOp::Read, id.as_str())).await {
-            Proceed::Run => self.inner.read(id).await,
-            Proceed::Reject(error) => Err(error),
-            Proceed::RunThenFail { error, gate } => {
-                self.inner.read(id).await?;
-                Err(lost(error, gate).await)
-            }
-        }
+        self.execute(ObjectOp::Read, id.as_str(), || self.inner.read(id))
+            .await
     }
 
     /// Staging is a local write; faults model the remote, so it always runs.
@@ -293,25 +297,17 @@ impl ObjectStore for FaultInjectingObjectStore {
     /// The upload half of a staged write is a remote write: `Write` faults
     /// apply, so an outage scenario fails uploads while staging succeeds.
     async fn upload_staged(&self, reference: &ObjectReference) -> Result<(), StatsError> {
-        match resolve(self.record(ObjectOp::Write, reference.id.as_str())).await {
-            Proceed::Run => self.inner.upload_staged(reference).await,
-            Proceed::Reject(error) => Err(error),
-            Proceed::RunThenFail { error, gate } => {
-                self.inner.upload_staged(reference).await?;
-                Err(lost(error, gate).await)
-            }
-        }
+        self.execute(ObjectOp::Write, reference.id.as_str(), || {
+            self.inner.upload_staged(reference)
+        })
+        .await
     }
 
     async fn local_path(&self, reference: &ObjectReference) -> Result<PathBuf, StatsError> {
-        match resolve(self.record(ObjectOp::LocalPath, reference.id.as_str())).await {
-            Proceed::Run => self.inner.local_path(reference).await,
-            Proceed::Reject(error) => Err(error),
-            Proceed::RunThenFail { error, gate } => {
-                self.inner.local_path(reference).await?;
-                Err(lost(error, gate).await)
-            }
-        }
+        self.execute(ObjectOp::LocalPath, reference.id.as_str(), || {
+            self.inner.local_path(reference)
+        })
+        .await
     }
 
     fn planned_local_path(&self, id: &ObjectId) -> Result<PathBuf, StatsError> {
@@ -339,14 +335,10 @@ impl ObjectStore for FaultInjectingObjectStore {
         expected: Option<&ObjectVersion>,
         bytes: bytes::Bytes,
     ) -> Result<ObjectVersion, StatsError> {
-        match resolve(self.record(ObjectOp::CompareAndSwap, id.as_str())).await {
-            Proceed::Run => self.inner.compare_and_swap(id, expected, bytes).await,
-            Proceed::Reject(error) => Err(error),
-            Proceed::RunThenFail { error, gate } => {
-                self.inner.compare_and_swap(id, expected, bytes).await?;
-                Err(lost(error, gate).await)
-            }
-        }
+        self.execute(ObjectOp::CompareAndSwap, id.as_str(), || {
+            self.inner.compare_and_swap(id, expected, bytes)
+        })
+        .await
     }
 
     async fn delete(&self, id: &ObjectId) -> Result<(), StatsError> {

--- a/lib/finelog/scripts/migrate_table.py
+++ b/lib/finelog/scripts/migrate_table.py
@@ -33,6 +33,7 @@ digest mismatch. ``abort`` calls AbortTableMigration.
 
 import json
 import time
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -59,6 +60,29 @@ NESTED_TYPES = {
     stats_pb2.COLUMN_TYPE_INT64_LIST,
     stats_pb2.COLUMN_TYPE_MAP,
 }
+
+
+@dataclass(frozen=True)
+class MigrationBaseline:
+    captured_at: str
+    frozen_max_seq: int
+    min_seq_at_baseline: int
+    window_start: int
+    bytes_window_start: int
+    row_count_reported: int
+    full_count_at_frozen: int
+    column_digests: dict[str, dict[str, object]]
+    latency_probes: dict[str, str]
+    latency_ms: dict[str, list[float]]
+    active_version_at_baseline: int
+
+    @classmethod
+    def read(cls, path: Path) -> "MigrationBaseline":
+        return cls(**json.loads(path.read_text()))
+
+    def write(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2, sort_keys=True))
 
 
 def _state_path(name: str, namespace: str) -> Path:
@@ -239,22 +263,21 @@ def baseline_cmd(name: str, namespace: str, window: int, request_timeout: float)
                 raise
             active_version = 0
 
-    state = {
-        "captured_at": datetime.now(UTC).isoformat(),
-        "frozen_max_seq": frozen,
-        "min_seq_at_baseline": info.min_seq,
-        "window_start": window_start,
-        "bytes_window_start": bytes_window_start,
-        "row_count_reported": info.row_count,
-        "full_count_at_frozen": full_count,
-        "column_digests": digests,
-        "latency_probes": probes,
-        "latency_ms": latencies,
-        "active_version_at_baseline": active_version,
-    }
+    state = MigrationBaseline(
+        captured_at=datetime.now(UTC).isoformat(),
+        frozen_max_seq=frozen,
+        min_seq_at_baseline=info.min_seq,
+        window_start=window_start,
+        bytes_window_start=bytes_window_start,
+        row_count_reported=info.row_count,
+        full_count_at_frozen=full_count,
+        column_digests=digests,
+        latency_probes=probes,
+        latency_ms=latencies,
+        active_version_at_baseline=active_version,
+    )
     path = _state_path(name, namespace)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    state.write(path)
     click.echo(f"baseline written to {path}")
     click.echo(f"full_count_at_frozen={full_count}")
     for label, runs in latencies.items():
@@ -315,10 +338,10 @@ def validate_cmd(name: str, namespace: str, request_timeout: float) -> None:
     path = _state_path(name, namespace)
     if not path.is_file():
         raise click.ClickException(f"no baseline recorded at {path}")
-    state = json.loads(path.read_text())
-    frozen = state["frozen_max_seq"]
-    window_start = state["window_start"]
-    bytes_window_start = state["bytes_window_start"]
+    state = MigrationBaseline.read(path)
+    frozen = state.frozen_max_seq
+    window_start = state.window_start
+    bytes_window_start = state.bytes_window_start
 
     with _open_cli_client(name, DEFAULT_TUNNEL_TIMEOUT, request_timeout) as client:
         _print_status(client, namespace)
@@ -328,16 +351,16 @@ def validate_cmd(name: str, namespace: str, request_timeout: float) -> None:
                 f"WARNING: min_seq advanced past the digest window start ({info.min_seq} > {window_start}); "
                 "window digests are no longer comparable"
             )
-        count_floor = min(info.min_seq, state["min_seq_at_baseline"])
+        count_floor = min(info.min_seq, state.min_seq_at_baseline)
         full_count = _full_count(client, namespace, count_floor, frozen)
         digests = _column_digests(client, namespace, window_start, bytes_window_start, frozen)
-        latencies = _measure_latencies(client, state["latency_probes"])
+        latencies = _measure_latencies(client, state.latency_probes)
 
-    drift = full_count - state["full_count_at_frozen"]
-    click.echo(f"full_count_at_frozen: baseline={state['full_count_at_frozen']} now={full_count} drift={drift}")
+    drift = full_count - state.full_count_at_frozen
+    click.echo(f"full_count_at_frozen: baseline={state.full_count_at_frozen} now={full_count} drift={drift}")
 
     mismatches = []
-    for column, expected in state["column_digests"].items():
+    for column, expected in state.column_digests.items():
         actual = digests.get(column)
         if not _digests_equal(expected, actual):
             mismatches.append(column)
@@ -346,7 +369,7 @@ def validate_cmd(name: str, namespace: str, request_timeout: float) -> None:
         click.echo(f"window digests match on all {len(digests)} columns")
 
     for label, runs in latencies.items():
-        click.echo(f"latency {label}: baseline={state['latency_ms'][label]} now={runs} ms")
+        click.echo(f"latency {label}: baseline={state.latency_ms[label]} now={runs} ms")
 
     if mismatches:
         raise click.ClickException(f"digest mismatch on: {', '.join(mismatches)}")

--- a/lib/finelog/src/finelog/client/object_query_client.py
+++ b/lib/finelog/src/finelog/client/object_query_client.py
@@ -215,6 +215,8 @@ def _validated_active_spec(
     )
     if spec is None:
         raise StatsError(f"catalog for namespace {namespace!r} has no retained TableSpec {active_version}")
+    if not spec.HasField("logical_schema"):
+        raise StatsError(f"catalog for namespace {namespace!r} TableSpec {active_version} has no logical schema")
     if spec.operating_policy.l0_mode != stats_pb2.L0_MODE_OBJECT_STORE:
         raise StatsError(f"namespace {namespace!r} active TableSpec {active_version} is not object-backed")
     return active_version, spec

--- a/lib/finelog/src/finelog/client/object_query_client.py
+++ b/lib/finelog/src/finelog/client/object_query_client.py
@@ -3,21 +3,23 @@
 
 """Client-directed SQL over immutable per-table Finelog catalog snapshots."""
 
-import base64
 import hashlib
-import json
 import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePosixPath
+from typing import TypeVar
 
 import duckdb
 import pyarrow as pa
+from google.protobuf import json_format
+from google.protobuf.message import Message
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath
 
 from finelog.errors import QueryResultTooLargeError, QueryTimeoutError, StatsError
+from finelog.rpc import finelog_stats_pb2 as stats_pb2
 
 
 @dataclass(frozen=True)
@@ -40,6 +42,7 @@ class CatalogPin:
 _OBJECT_CATALOG_ROOT = ("_finelog", "tables")
 # Mirrors the server's TABLE_STATE_FORMAT_VERSION.
 _SUPPORTED_CATALOG_FORMAT = 1
+_MessageT = TypeVar("_MessageT", bound=Message)
 
 
 class ObjectQueryClient:
@@ -108,93 +111,46 @@ class ObjectQueryClient:
         """Load one immutable catalog projection for a direct query."""
         if not namespace or "/" in namespace or namespace in {".", ".."}:
             raise ValueError(f"invalid namespace {namespace!r}")
-        table_root = self._table_root(namespace)
-        head = self._read_json(table_root / "HEAD.json", "HEAD")
-        catalog_ref = _mapping(head.get("catalog"), "HEAD.catalog")
-        catalog_id = _table_object_id(catalog_ref.get("objectId"), namespace, "HEAD.catalog.objectId")
-        catalog_path = self._root / catalog_id
-        catalog_bytes = self._read_bytes(catalog_path)
-        expected_sha = _base64_bytes(catalog_ref.get("sha256"), "HEAD.catalog.sha256")
-        if hashlib.sha256(catalog_bytes).digest() != expected_sha:
-            raise StatsError(f"catalog checksum mismatch for namespace {namespace!r}")
-        try:
-            catalog = json.loads(catalog_bytes)
-        except (TypeError, json.JSONDecodeError) as error:
-            raise StatsError(f"invalid catalog JSON for namespace {namespace!r}: {error}") from error
-
-        if head.get("tombstoned"):
-            raise StatsError(f"namespace {namespace!r} was deleted")
-
-        head_format = _integer(head.get("formatVersion"), "HEAD.formatVersion")
-        catalog_format = _integer(catalog.get("formatVersion"), "catalog.formatVersion")
-        if head_format != _SUPPORTED_CATALOG_FORMAT or catalog_format != _SUPPORTED_CATALOG_FORMAT:
-            raise StatsError(
-                f"unsupported object catalog format for namespace {namespace!r}: "
-                f"HEAD={head_format}, catalog={catalog_format}"
-            )
-
-        generation = _integer(catalog.get("catalogGeneration"), "catalog.catalogGeneration")
-        head_generation = _integer(head.get("catalogGeneration"), "HEAD.catalogGeneration")
-        active_version = _integer(catalog.get("activeTableSpecVersion"), "catalog.activeTableSpecVersion")
-        if active_version == 0:
-            raise StatsError(
-                f"namespace {namespace!r} is still using its legacy query version; "
-                "client-directed reads become available after object-store activation"
-            )
-        if (
-            head.get("namespace") != namespace
-            or catalog.get("namespace") != namespace
-            or generation != head_generation
-            or active_version != _integer(head.get("activeTableSpecVersion"), "HEAD.activeTableSpecVersion")
-        ):
-            raise StatsError(f"HEAD/catalog identity mismatch for namespace {namespace!r}")
-
+        head, catalog = self._load_catalog(namespace)
+        active_version, spec = _validated_active_spec(namespace, head, catalog)
         object_uris = tuple(
             self._object_uri(
                 _table_object_id(
-                    _mapping(
-                        _mapping(segment, "directQuerySegments[]").get("source"),
-                        "directQuerySegments[].source",
-                    ).get("objectId"),
+                    segment.source.object_id,
                     namespace,
                     "directQuerySegments[].source.objectId",
                 ),
             )
-            for segment in _sequence(
-                catalog.get("directQuerySegments", []),
-                "catalog.directQuerySegments",
-            )
+            for segment in catalog.direct_query_segments
         )
-        spec = next(
-            (
-                _mapping(item, "retainedTableSpecs[]")
-                for item in _sequence(catalog.get("retainedTableSpecs"), "catalog.retainedTableSpecs")
-                if _integer(
-                    _mapping(item, "retainedTableSpecs[]").get("version"),
-                    "retainedTableSpecs[].version",
-                )
-                == active_version
-            ),
-            None,
-        )
-        if spec is None:
-            raise StatsError(f"catalog for namespace {namespace!r} has no retained TableSpec {active_version}")
-        operating_policy = _mapping(spec.get("operatingPolicy"), "TableSpec.operatingPolicy")
-        if operating_policy.get("l0Mode") != "L0_MODE_OBJECT_STORE":
-            raise StatsError(f"namespace {namespace!r} active TableSpec {active_version} is not object-backed")
-        columns = _catalog_columns(_mapping(spec.get("logicalSchema"), "TableSpec.logicalSchema"))
-        max_query_time_ms = _integer(catalog.get("maxQueryTimeMs"), "catalog.maxQueryTimeMs")
-        if max_query_time_ms == 0:
+        if catalog.max_query_time_ms == 0:
             raise StatsError(f"catalog for namespace {namespace!r} has no direct-query lifetime")
         return CatalogPin(
             namespace=namespace,
-            catalog_generation=generation,
+            catalog_generation=catalog.catalog_generation,
             table_spec_version=active_version,
-            max_query_time_ms=max_query_time_ms,
-            high_water=_integer(catalog.get("directQueryHighWater", 0), "catalog.directQueryHighWater"),
+            max_query_time_ms=catalog.max_query_time_ms,
+            high_water=catalog.direct_query_high_water,
             object_uris=object_uris,
-            columns=columns,
+            columns=_catalog_columns(spec.logical_schema),
         )
+
+    def _load_catalog(self, namespace: str) -> tuple[stats_pb2.CatalogHead, stats_pb2.NamespaceCatalog]:
+        table_root = self._table_root(namespace)
+        head = self._read_message(table_root / "HEAD.json", "HEAD", stats_pb2.CatalogHead())
+        if head.tombstoned:
+            raise StatsError(f"namespace {namespace!r} was deleted")
+        catalog_id = _table_object_id(head.catalog.object_id, namespace, "HEAD.catalog.objectId")
+        catalog_path = self._root / catalog_id
+        catalog_bytes = self._read_bytes(catalog_path)
+        if hashlib.sha256(catalog_bytes).digest() != head.catalog.sha256:
+            raise StatsError(f"catalog checksum mismatch for namespace {namespace!r}")
+        catalog = _parse_message(
+            catalog_bytes,
+            stats_pb2.NamespaceCatalog(),
+            f"catalog for namespace {namespace!r}",
+        )
+        return head, catalog
 
     def _register_namespace(self, connection: duckdb.DuckDBPyConnection, pin: CatalogPin) -> None:
         escaped_namespace = pin.namespace.replace('"', '""')
@@ -219,44 +175,49 @@ class ObjectQueryClient:
         except OSError as error:
             raise StatsError(f"read object catalog {str(path)!r}: {error}") from error
 
-    def _read_json(self, path: StoragePath, kind: str) -> dict[str, object]:
-        try:
-            return _mapping(json.loads(self._read_bytes(path)), kind)
-        except (TypeError, json.JSONDecodeError) as error:
-            raise StatsError(f"invalid {kind} JSON at {str(path)!r}: {error}") from error
+    def _read_message(self, path: StoragePath, kind: str, message: _MessageT) -> _MessageT:
+        return _parse_message(self._read_bytes(path), message, f"{kind} at {str(path)!r}")
 
 
-def _mapping(value: object, field: str) -> dict[str, object]:
-    if not isinstance(value, dict):
-        raise StatsError(f"{field} must be an object")
-    return value
-
-
-def _sequence(value: object, field: str) -> list[object]:
-    if not isinstance(value, list):
-        raise StatsError(f"{field} must be an array")
-    return value
-
-
-def _integer(value: object, field: str) -> int:
-    if isinstance(value, bool):
-        raise StatsError(f"{field} must be an integer")
+def _parse_message(data: bytes, message: _MessageT, description: str) -> _MessageT:
     try:
-        result = int(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError) as error:
-        raise StatsError(f"{field} must be an integer") from error
-    if result < 0:
-        raise StatsError(f"{field} must not be negative")
-    return result
+        return json_format.Parse(data.decode(), message)
+    except (UnicodeDecodeError, json_format.ParseError) as error:
+        raise StatsError(f"invalid {description} JSON: {error}") from error
 
 
-def _base64_bytes(value: object, field: str) -> bytes:
-    if not isinstance(value, str):
-        raise StatsError(f"{field} must be base64 text")
-    try:
-        return base64.b64decode(value, validate=True)
-    except ValueError as error:
-        raise StatsError(f"{field} must be valid base64") from error
+def _validated_active_spec(
+    namespace: str,
+    head: stats_pb2.CatalogHead,
+    catalog: stats_pb2.NamespaceCatalog,
+) -> tuple[int, stats_pb2.TableSpec]:
+    if head.format_version != _SUPPORTED_CATALOG_FORMAT or catalog.format_version != _SUPPORTED_CATALOG_FORMAT:
+        raise StatsError(
+            f"unsupported object catalog format for namespace {namespace!r}: "
+            f"HEAD={head.format_version}, catalog={catalog.format_version}"
+        )
+    active_version = catalog.active_table_spec_version
+    if active_version == 0:
+        raise StatsError(
+            f"namespace {namespace!r} is still using its legacy query version; "
+            "client-directed reads become available after object-store activation"
+        )
+    if (
+        head.namespace != namespace
+        or catalog.namespace != namespace
+        or catalog.catalog_generation != head.catalog_generation
+        or active_version != head.active_table_spec_version
+    ):
+        raise StatsError(f"HEAD/catalog identity mismatch for namespace {namespace!r}")
+    spec = next(
+        (item for item in catalog.retained_table_specs if item.version == active_version),
+        None,
+    )
+    if spec is None:
+        raise StatsError(f"catalog for namespace {namespace!r} has no retained TableSpec {active_version}")
+    if spec.operating_policy.l0_mode != stats_pb2.L0_MODE_OBJECT_STORE:
+        raise StatsError(f"namespace {namespace!r} active TableSpec {active_version} is not object-backed")
+    return active_version, spec
 
 
 def _table_object_id(value: object, namespace: str, field: str) -> str:
@@ -271,31 +232,28 @@ def _table_object_id(value: object, namespace: str, field: str) -> str:
     return str(path)
 
 
-_DUCKDB_TYPES = {
-    "COLUMN_TYPE_STRING": "VARCHAR",
-    "COLUMN_TYPE_INT64": "BIGINT",
-    "COLUMN_TYPE_FLOAT64": "DOUBLE",
-    "COLUMN_TYPE_BOOL": "BOOLEAN",
-    "COLUMN_TYPE_TIMESTAMP_MS": "TIMESTAMP_MS",
-    "COLUMN_TYPE_BYTES": "BLOB",
-    "COLUMN_TYPE_INT32": "INTEGER",
-    "COLUMN_TYPE_MAP": "MAP(VARCHAR, VARCHAR)",
-    "COLUMN_TYPE_FLOAT64_LIST": "DOUBLE[]",
-    "COLUMN_TYPE_INT64_LIST": "BIGINT[]",
+_DUCKDB_TYPES: dict[int, str] = {
+    stats_pb2.COLUMN_TYPE_STRING: "VARCHAR",
+    stats_pb2.COLUMN_TYPE_INT64: "BIGINT",
+    stats_pb2.COLUMN_TYPE_FLOAT64: "DOUBLE",
+    stats_pb2.COLUMN_TYPE_BOOL: "BOOLEAN",
+    stats_pb2.COLUMN_TYPE_TIMESTAMP_MS: "TIMESTAMP_MS",
+    stats_pb2.COLUMN_TYPE_BYTES: "BLOB",
+    stats_pb2.COLUMN_TYPE_INT32: "INTEGER",
+    stats_pb2.COLUMN_TYPE_MAP: "MAP(VARCHAR, VARCHAR)",
+    stats_pb2.COLUMN_TYPE_FLOAT64_LIST: "DOUBLE[]",
+    stats_pb2.COLUMN_TYPE_INT64_LIST: "BIGINT[]",
 }
 
 
-def _catalog_columns(logical_schema: dict[str, object]) -> tuple[CatalogColumn, ...]:
+def _catalog_columns(logical_schema: stats_pb2.Schema) -> tuple[CatalogColumn, ...]:
     declarations = [CatalogColumn("seq", "BIGINT")]
-    for raw in _sequence(logical_schema.get("columns", []), "logicalSchema.columns"):
-        column = _mapping(raw, "logicalSchema.columns[]")
-        name = column.get("name")
-        type_name = column.get("type")
-        if not isinstance(name, str) or not name:
+    for column in logical_schema.columns:
+        if not column.name:
             raise StatsError("logicalSchema column name must be non-empty")
-        if not isinstance(type_name, str) or type_name not in _DUCKDB_TYPES:
-            raise StatsError(f"unsupported logicalSchema type {type_name!r}")
-        declarations.append(CatalogColumn(name, _DUCKDB_TYPES[type_name]))
+        if column.type not in _DUCKDB_TYPES:
+            raise StatsError(f"unsupported logicalSchema type {column.type!r}")
+        declarations.append(CatalogColumn(column.name, _DUCKDB_TYPES[column.type]))
     if all(column.name != "cluster" for column in declarations):
         declarations.append(CatalogColumn("cluster", "VARCHAR"))
     return tuple(declarations)

--- a/lib/finelog/tests/test_object_query_client.py
+++ b/lib/finelog/tests/test_object_query_client.py
@@ -23,6 +23,7 @@ def _write_catalog(
     active_version: int = 1,
     l0_mode: str = "L0_MODE_OBJECT_STORE",
     object_id_override: str | None = None,
+    include_logical_schema: bool = True,
 ) -> Path:
     namespace = "iris.worker"
     table_root = root / "_finelog" / "tables" / namespace
@@ -41,6 +42,17 @@ def _write_catalog(
         ),
         object_path,
     )
+    retained_spec: dict[str, object] = {
+        "version": "1",
+        "operatingPolicy": {"l0Mode": l0_mode},
+    }
+    if include_logical_schema:
+        retained_spec["logicalSchema"] = {
+            "columns": [
+                {"name": "worker_id", "type": "COLUMN_TYPE_STRING"},
+                {"name": "mem_bytes", "type": "COLUMN_TYPE_INT64"},
+            ]
+        }
     catalog = {
         "formatVersion": "1",
         "namespace": namespace,
@@ -49,18 +61,7 @@ def _write_catalog(
         "desiredTableSpecVersion": "0",
         "maxQueryTimeMs": "600000",
         "directQueryHighWater": "2",
-        "retainedTableSpecs": [
-            {
-                "version": "1",
-                "logicalSchema": {
-                    "columns": [
-                        {"name": "worker_id", "type": "COLUMN_TYPE_STRING"},
-                        {"name": "mem_bytes", "type": "COLUMN_TYPE_INT64"},
-                    ]
-                },
-                "operatingPolicy": {"l0Mode": l0_mode},
-            }
-        ],
+        "retainedTableSpecs": [retained_spec],
         "versionSegments": [
             {
                 "tableSpecVersion": str(active_version),
@@ -213,3 +214,10 @@ def test_object_query_rejects_catalog_without_an_active_object_version(
             'SELECT * FROM "iris.worker"',
             namespaces=["iris.worker"],
         )
+
+
+def test_object_query_rejects_active_spec_without_logical_schema(tmp_path: Path) -> None:
+    _write_catalog(tmp_path, include_logical_schema=False)
+
+    with pytest.raises(StatsError, match="has no logical schema"):
+        ObjectQueryClient(str(tmp_path)).pin_catalog("iris.worker")


### PR DESCRIPTION
Object-backed Finelog now fails closed when durable catalog state cannot be interpreted or updated. Boot recovery rejects malformed live object references, direct queries reject incomplete active schemas, legacy eviction changes the live view only after its catalog mutation succeeds, and scheduler and staging-cleanup errors are reported. Kubernetes passes the configured object-cache limit into each server.

The object-store provider owns validated object locations for storage and querying. Durable state transitions carry explicit queue, lease, mutation, garbage-collection, migration, and work results, reducing ambiguous state at recovery, registration, compaction, and maintenance boundaries. Tests use shared fixtures and logical or condition-based synchronization.

Catalog migration 0006 and the reserved protobuf slots remain unchanged because their intermediate forms reached live catalogs before #8748 merged.

Fixes #8909
Fixes #8837
Fixes #8882