### PR TITLE
Fix vLLM dashboard time-series framing

### DIFF
--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -460,8 +460,8 @@
     {
       "id": 3,
       "type": "timeseries",
-      "title": "Running, waiting, and iteration tokens",
-      "description": "Per-bin request gauges and mean tokens processed per vLLM engine iteration. KV-cache uses a separate unweighted replica view because no capacity weight is stored.",
+      "title": "In-flight, running, waiting, and iteration tokens",
+      "description": "Per-bin request gauges, including in-flight requests as running plus waiting, and mean tokens processed per vLLM engine iteration. KV-cache uses a separate unweighted replica view because no capacity weight is stored.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"

--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -308,6 +308,12 @@ WITH base AS (
            END AS value
     FROM gauge_replica_bins
     GROUP BY 1, 2
+), request_in_flight_bins AS (
+    SELECT t, SUM(value) AS value
+    FROM canonical_gauge_bins
+    WHERE name IN ('num_requests_running', 'num_requests_waiting')
+    GROUP BY 1
+    HAVING COUNT(*) = 2
 ), raw_gauge_peaks AS (
     SELECT name, MAX(value) AS peak
     FROM canonical_gauge_samples
@@ -680,6 +686,20 @@ WITH base AS (
 
     SELECT t AS t,
            'saturation' AS section,
+           'num_requests_in_flight' AS metric,
+           'value' AS stat,
+           'num_requests_in_flight' AS series,
+           value AS value,
+           'requests' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM request_in_flight_bins
+
+    UNION ALL
+
+    SELECT t AS t,
+           'saturation' AS section,
            'iteration_tokens' AS metric,
            'mean' AS stat,
            'iteration tokens per engine step' AS series,
@@ -867,10 +887,10 @@ SELECT t, section, metric, stat, series, value, unit, status, samples, gap_secon
 FROM output
 ORDER BY section,
          CASE WHEN section = 'telemetry_health' AND metric = 'collector' THEN 0 ELSE 1 END,
+         t,
          metric,
          stat,
-         series,
-         t
+         series
 LIMIT {VLLM_MAX_RESULT_ROWS}
 """.strip()
     return VllmOverviewQuery(

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -28,7 +28,12 @@ def test_dashboard_vllm_overview_end_to_end():
     cumulative = {"source_temporality": "cumulative_snapshot"}
     snapshot = {"source_temporality": "current_snapshot"}
     samples = [
-        sample("generation_tokens_total", value, timestamp, **cumulative) for timestamp, value in ((0, 0), (15_000, 150))
+        sample("generation_tokens_total", value, timestamp, **cumulative)
+        for timestamp, value in ((0, 0), (15_000, 150), (30_000, 300))
+    ]
+    samples += [
+        sample("prompt_tokens_total", value, timestamp, **cumulative)
+        for timestamp, value in ((0, 0), (15_000, 30), (30_000, 60))
     ]
     samples += [
         sample("request_success_total", value, timestamp, finished_reason="stop", **cumulative)
@@ -40,9 +45,16 @@ def test_dashboard_vllm_overview_end_to_end():
             sample(f"request_time_per_output_token_seconds_{component}", value, timestamp, **labels)
             for timestamp, value in ((0, 0), (15_000, final))
         ]
-    samples.append(sample("num_requests_running", 2, 15_000, **snapshot))
+    samples += [
+        sample("num_requests_running", 2, 15_000, **snapshot),
+        sample("num_requests_waiting", 1, 15_000, **snapshot),
+    ]
     samples += [
         sample("num_requests_running", 1, timestamp, engine="physical-b", engine_index="1", **snapshot)
+        for timestamp in range(0, 240_000, 15_000)
+    ]
+    samples += [
+        sample("num_requests_waiting", 0, timestamp, engine="physical-b", engine_index="1", **snapshot)
         for timestamp in range(0, 240_000, 15_000)
     ]
     database.executemany(
@@ -63,15 +75,28 @@ def test_dashboard_vllm_overview_end_to_end():
 
     with TestClient(app) as client:
         response = client.get(f"/finelog/marin{path}", params={**params, "view": "token_rate"})
+        saturation = client.get(f"/finelog/marin{path}", params={**params, "view": "saturation"})
         all_rows = client.get(f"/finelog/marin{path}", params=params)
 
     assert response.status_code == 200
-    assert [(row["metric"], row["value"]) for row in response.json()] == [("generated_tokens", 10)]
+    assert saturation.status_code == 200
+    assert all_rows.status_code == 200
+    token_rows = response.json()
+    saturation_rows = saturation.json()
+    assert [row["t"] for row in token_rows] == sorted(row["t"] for row in token_rows)
+    assert [row["t"] for row in saturation_rows] == sorted(row["t"] for row in saturation_rows)
+    assert {(row["metric"], row["t"]): row["value"] for row in token_rows} == {
+        ("generated_tokens", 15_000): 10,
+        ("generated_tokens", 30_000): 10,
+        ("prompt_tokens", 15_000): 2,
+        ("prompt_tokens", 30_000): 2,
+    }
     rows = all_rows.json()
     assert {row["section"] for row in rows} == VLLM_OVERVIEW_SECTIONS
     values = {(row["section"], row["metric"], row["stat"], row["series"], row["t"]): row["value"] for row in rows}
     assert values[("request_outcome", "requests", "total", "stop", None)] == 1
     assert values[("latency", "tpot", "mean_over_time", "time per output token", 15_000)] == 0.1
     assert values[("saturation", "num_requests_running", "value", "num_requests_running", 15_000)] == 3
+    assert values[("saturation", "num_requests_in_flight", "value", "num_requests_in_flight", 15_000)] == 4
     freshness = {row["series"].rsplit(":", 1)[-1]: row["status"] for row in rows if row["section"] == "freshness_detail"}
     assert freshness == {"physical-a": "stale_or_stopped", "physical-b": "fresh"}


### PR DESCRIPTION
Order vLLM overview time-series rows by timestamp before their series dimensions. Infinity's long-to-wide conversion requires globally ascending timestamps. The previous series-major response made Grafana draw legitimate zero-valued waiting and prompt-rate series as shark teeth in other lines.

Add an in-flight request series computed as running plus waiting from the gauges already collected for the overview. For the historical `grug-megatron-snowball-r5-final-2` window, the generated query returned all 40 token-rate rows and 84 saturation rows in nondecreasing timestamp order, including 21 in-flight points.

In-flight counts requests accepted by vLLM. It does not estimate active prefill and decode counts or include prompts still held upstream by MarinSkyRL.
