### PR TITLE
[docs] Fix the README tutorial example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can check out the [full script](https://github.com/marin-community/marin/blo
 
 ```python
 from fray.cluster import ResourceConfig
-from levanter.optim import AdamConfig
+from levanter.optim.config import AdamConfig
 from marin.execution.lazy import lower
 from marin.execution.step_runner import StepRunner
 from marin.experiment.data import tokenized
@@ -99,18 +99,19 @@ tinystories_tokenized = tokenized(
     source="roneneldan/TinyStories",
     tokenizer=marin_tokenizer,
     sample_count=1000,  # cap at 1 000 samples per shard to keep the tutorial fast
+    version="2026.06.28",
 )
 
 # 2. Train the model — depends on the tokenized dataset above.
 nano_tinystories_model = train_lm(
     name="checkpoints/marin-nano-tinystories",
-    version="v1",
+    version="2026.06.28",
     model=llama_nano,
     optimizer=AdamConfig(learning_rate=6e-4, weight_decay=0.1),
     # Steps can depend on other steps: nano_tinystories_model depends on tinystories_tokenized
     datasets={tinystories_tokenized: 1.0},
     batch_size=4,
-    seq_len=2048,
+    seq_len=512,
     num_train_steps=100,
     z_loss_weight=None,
     evals=None,  # no point evaluating such a tiny model


### PR DESCRIPTION
The README's TinyStories example could not run as written. `levanter.optim`
does not export `AdamConfig`; it is defined in `levanter.optim.config`. The
`tokenized` call passed no `version`, and `resolve_version` raises rather than
defaulting when no `BuildContext` is active, so the script failed before it
built a step graph. `seq_len` was 2048 while `llama_nano.max_seq_len` is 512.

`docs/tutorials/first-experiment.md` and
`experiments/tutorials/train_tiny_model.py` already carry all three fixes; only
the README copy had drifted, and nothing checks the three against each other.
`docs/index.md` includes this block, so the published docs showed the same
errors.

The three defects were confirmed against the source: `levanter.optim` has no
`AdamConfig` attribute, `resolve_version` raises without an ambient
`BuildContext`, and `llama_nano.max_seq_len` is 512. `mkdocs build --strict`
passes. The example was not executed end to end.
