### PR TITLE
[grafana] Split inference overview from diagnostics

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -223,8 +223,24 @@ of repeating the Kubernetes object name.
 | Workload | Runs | `runs.json` | How is each Levanter training run doing? | cluster, run |
 | Workload | RL runs | `rl_runs.json` | How is one reinforcement-learning run doing? | cluster, run |
 | Workload | Training run | `training.json` | Is one training run on track? | run |
-| Workload | Inference telemetry | `inference.json` | How did one vLLM serve behave? | identity kind, serve |
+| Workload | Inference overview | `inference_overview.json` | Is inference progressing, and are responses slow or queues growing? | identity kind, serve |
+| Workload | Inference diagnostics | `inference.json` | Which engines, request stages, or workload changes explain the slowdown? | identity kind, serve |
 | Services | Infra | `infra.json` | Are nightly runs, main CI, workers, and hero training healthy? | none |
+
+The two inference dashboards keep the selected identity and time range when
+linked. The existing `marin-inference` UID now opens diagnostics, preserving old
+links and panel IDs; `marin-inference-overview` is the entry point from Home.
+Shared charts use the existing panel-fragment stitcher. Both dashboards read
+the cached `/v1/vllm/overview` result; no new collector or metric is required.
+
+Inference rates describe the observed engines, not upstream demand. Running
+requests are admitted to scheduling, not a GPU batch size; iteration tokens mix
+prefill and decode work. Histogram counts show the available observations, and
+request-completion histograms exclude unfinished requests. Quantiles are bucket
+upper bounds, not interpolated percentiles. Missing observations stay missing,
+and freshness covers only producers that emitted records. Use RL phase timing
+and the accelerator dashboards for context before diagnosing starvation or GPU
+inefficiency. Older runs may lack engine-resolved histograms or publication health.
 
 `home.json` is provisioned as the default home dashboard
 (`GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/home.json`,

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -141,9 +141,9 @@
       "includeVars": true,
       "keepTime": true,
       "targetBlank": false,
-      "title": "Inference",
+      "title": "Inference overview",
       "type": "link",
-      "url": "/d/marin-inference"
+      "url": "/d/marin-inference-overview"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -381,6 +381,22 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "engine\\signal"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Engine / producer"
+              },
+              {
+                "id": "custom.width",
+                "value": 500
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "running_mean"
             },
             "properties": [

--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -1,7 +1,7 @@
 {
   "uid": "marin-inference",
-  "title": "Inference telemetry",
-  "description": "Bounded, reset-aware views over standalone and MarinSkyRL-embedded vLLM telemetry on the marin hub. Pick an identity kind and then a serve from the dropdown; the bridge enforces the identity, seven-day range, bucket, and result caps server-side. Summary panels are window aggregates; token rate, request pressure, iteration occupancy, KV-cache use, and TPOT have a time axis.",
+  "title": "Inference diagnostics",
+  "description": "Why is inference slow? Request scheduling, token throughput, engine differences, latency stages and tails, workload length, and telemetry trust. The original inference UID and panel IDs are retained.",
   "tags": [
     "marin",
     "inference",
@@ -107,23 +107,341 @@
   },
   "panels": [
     {
-      "id": 1,
-      "type": "table",
-      "title": "Worst replica freshness",
-      "description": "Reports the stalest producer/resource identity, so a stopped replica cannot be hidden by a healthy peer. Explicitly distinguishes no matching records, a range ending after the last sample, an in-range scrape/export gap, and continuous samples.",
+      "type": "text",
+      "title": "",
+      "options": {
+        "mode": "markdown",
+        "content": "Requests are not GPU batch size. Compare **running/waiting**, **iteration tokens**, and **time per output token** over the same rollout phase. These metrics do not split in-flight requests into prefill vs decode, expose ready upstream work, or measure CUDA-graph/kernel efficiency. Use **RL runs** for phase timing and **Fleet accelerators** for GPU context."
+      },
+      "id": 12,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 3
+      }
+    },
+    {
+      "panelRef": "inference_requests",
+      "id": 3,
+      "gridPos": {
+        "x": 0,
+        "y": 3,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_tokens",
+      "id": 2,
+      "gridPos": {
+        "x": 12,
+        "y": 3,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens per engine iteration (mean)",
+      "description": "Histogram-weighted mean tokens scheduled per engine iteration, mixing prefill chunks and decode tokens. This is neither request batch size nor GPU utilization. It does not separate prefill and decode occupancy.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
       },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "noValue": "No samples",
+          "displayName": "${__field.labels.series}",
+          "custom": {
+            "drawStyle": "line",
+            "showPoints": "auto",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "saturation"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "metric",
+              "text": "metric",
+              "type": "string"
+            }
+          ],
+          "filterExpression": "metric == 'iteration_tokens'"
+        }
+      ],
+      "id": 13,
       "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 0,
-        "y": 0
+        "y": 10,
+        "w": 8,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_tpot",
+      "id": 11,
+      "gridPos": {
+        "x": 8,
+        "y": 10,
+        "w": 8,
+        "h": 7
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency stages (mean)",
+      "description": "Histogram-weighted means. Queue, prefill and decode describe request stages; end-to-end and TTFT overlap with them and must not be summed. Completed-request measurements exclude unfinished requests; missing observations remain gaps.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "noValue": "No samples",
+          "displayName": "${__field.labels.series}",
+          "custom": {
+            "drawStyle": "line",
+            "showPoints": "auto",
+            "spanNulls": false
+          }
+        },
         "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "latency"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "metric",
+              "text": "metric",
+              "type": "string"
+            },
+            {
+              "selector": "stat",
+              "text": "stat",
+              "type": "string"
+            }
+          ],
+          "filterExpression": "stat == 'mean_over_time' && metric != 'tpot' && metric != 'inter_token_latency'"
+        }
+      ],
+      "id": 14,
+      "gridPos": {
+        "x": 16,
+        "y": 10,
+        "w": 8,
+        "h": 7
+      }
+    },
+    {
+      "type": "table",
+      "title": "Engine comparison (observed samples)",
+      "description": "Up to 128 observed identities per signal, keyed by cluster, service, resource and engine. Legacy identities may cover more than one physical DP engine. Running/waiting are sample means; KV is raw peak; tokens/s is the mean over bins with valid deltas, not the whole wall-clock window. Missing cells are unknown, not idle. Narrow to one rollout phase before comparing; check freshness below for unequal coverage.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No samples",
+          "custom": {
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "running_mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Running (mean)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "waiting_mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Waiting (mean)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kv_cache_peak"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KV-cache (peak)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "generated_tokens_per_second"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Generated tokens/s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kv_cache_peak"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
       },
       "targets": [
         {
@@ -158,105 +476,14 @@
               },
               {
                 "key": "view",
-                "value": "freshness"
+                "value": "engine_summary"
               }
             ]
           },
           "columns": [
             {
               "selector": "series",
-              "text": "producer/resource",
-              "type": "string"
-            },
-            {
-              "selector": "status",
-              "text": "status",
-              "type": "string"
-            },
-            {
-              "selector": "t",
-              "text": "last sample",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "value",
-              "text": "age at range end (s)",
-              "type": "number"
-            },
-            {
-              "selector": "gap_seconds",
-              "text": "largest sample gap (s)",
-              "type": "number"
-            },
-            {
-              "selector": "samples",
-              "text": "replica samples",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 10,
-      "type": "table",
-      "title": "Telemetry publication health",
-      "description": "Reports known collection or publication loss in the selected window. Fresh zero-valued evidence is healthy, any positive loss is incomplete, and absent or stale evidence is unknown. Embedded evidence is selected only from service=marinskyrl rows with metric_source=vllm; Ray health never stands in for vLLM health. The best-effort health signal cannot prove its own delivery.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "telemetry_health"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "status",
-              "text": "status",
+              "text": "engine",
               "type": "string"
             },
             {
@@ -265,13 +492,112 @@
               "type": "string"
             },
             {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "signal",
+            "rowField": "engine",
+            "valueField": "value",
+            "emptyValue": "null"
+          }
+        }
+      ],
+      "id": 15,
+      "gridPos": {
+        "x": 0,
+        "y": 17,
+        "w": 24,
+        "h": 8
+      }
+    },
+    {
+      "panelRef": "inference_kv",
+      "id": 5,
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Saturation average and peak",
+      "description": "Averages retain the binned serve-wide request-count and unweighted replica KV-cache semantics. KV-cache peak is the maximum raw replica sample, before adaptive time-bin averaging.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 25,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "saturation_summary"
+              }
+            ]
+          },
+          "columns": [
+            {
               "selector": "series",
-              "text": "stage / reason",
+              "text": "metric",
+              "type": "string"
+            },
+            {
+              "selector": "stat",
+              "text": "stat",
               "type": "string"
             },
             {
               "selector": "value",
-              "text": "window value",
+              "text": "value",
               "type": "number"
             },
             {
@@ -284,6 +610,233 @@
       ]
     },
     {
+      "panelRef": "inference_preemptions",
+      "id": 4,
+      "gridPos": {
+        "x": 20,
+        "y": 25,
+        "w": 4,
+        "h": 7
+      }
+    },
+    {
+      "type": "table",
+      "title": "Latency distribution in selected window",
+      "description": "Mean and p50/p90/p99 bucket upper bounds, merged from per-producer histogram deltas, never averaged percentiles. Counts are observations for that family, not unique requests across rows. A reset or incomplete stored component invalidates that producer/family sample; an unbounded quantile is null. Completed-request histograms omit unfinished requests. Queue, prefill, decode, TTFT and end-to-end timings overlap: do not add them.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No samples",
+          "custom": {
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "latency"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "metric",
+              "text": "latency",
+              "type": "string"
+            },
+            {
+              "selector": "stat",
+              "text": "stat",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "seconds",
+              "type": "number"
+            },
+            {
+              "selector": "samples",
+              "text": "observations",
+              "type": "number"
+            }
+          ],
+          "filterExpression": "stat != 'mean_over_time'"
+        }
+      ],
+      "id": 7,
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "type": "table",
+      "title": "Output length of finished requests",
+      "description": "Mean and p50/p90/p99 bucket upper bounds of generated tokens per finished request, with observation counts. Long unfinished requests are absent. A heavier output-length tail can prolong a synchronous rollout; this is not proof of dispatch starvation. Old runs may lack coherent histograms.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No samples",
+          "custom": {
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "workload"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "stat",
+              "text": "stat",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "tokens/request",
+              "type": "number"
+            },
+            {
+              "selector": "samples",
+              "text": "observations",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "id": 16,
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 6,
+        "h": 8
+      }
+    },
+    {
+      "panelRef": "inference_outcomes",
+      "id": 8,
+      "gridPos": {
+        "x": 18,
+        "y": 32,
+        "w": 6,
+        "h": 8
+      }
+    },
+    {
+      "panelRef": "inference_freshness",
+      "id": 1,
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 8,
+        "h": 6
+      }
+    },
+    {
+      "panelRef": "inference_health",
+      "id": 10,
+      "gridPos": {
+        "x": 8,
+        "y": 40,
+        "w": 8,
+        "h": 6
+      }
+    },
+    {
       "id": 9,
       "type": "table",
       "title": "Replica freshness detail",
@@ -293,10 +846,10 @@
         "uid": "finelog-marin"
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 16,
-        "y": 0
+        "y": 40,
+        "w": 8,
+        "h": 6
       },
       "fieldConfig": {
         "defaults": {},
@@ -373,728 +926,19 @@
           ]
         }
       ]
-    },
-    {
-      "id": 2,
-      "type": "timeseries",
-      "title": "Prompt and generated token rate",
-      "description": "Per-bucket rates from reset-aware cumulative snapshot deltas, summed only after replica-local deltas are computed.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 5
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "tps",
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "token_rate"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "series",
-              "text": "series",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "tokens/s",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "type": "timeseries",
-      "title": "In-flight, running, waiting, and iteration tokens",
-      "description": "Per-bin request gauges, including in-flight requests as running plus waiting, and mean tokens processed per vLLM engine iteration. KV-cache uses a separate unweighted replica view because no capacity weight is stored.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 5
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none",
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never"
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "iteration_tokens"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "custom.axisLabel",
-                "value": "tokens / iteration"
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "filterExpression": "metric != 'kv_cache_usage'",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "saturation"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "metric",
-              "text": "metric",
-              "type": "string"
-            },
-            {
-              "selector": "series",
-              "text": "series",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "type": "barchart",
-      "title": "Window totals",
-      "description": "Prompt/generated tokens and preemptions over the selected range, as magnitudes rather than a three-row table. Native Rigging counter rows are summed directly; imported Prometheus counters use reset-aware deltas.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 13
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "axisPlacement": "auto"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "counter_total"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "series",
-              "text": "metric",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "total",
-              "type": "number"
-            }
-          ]
-        }
-      ],
-      "options": {
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "showValue": "auto",
-        "stacking": "none",
-        "legend": {
-          "showLegend": false,
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": []
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      }
-    },
-    {
-      "id": 5,
-      "type": "timeseries",
-      "title": "KV-cache usage",
-      "description": "Unweighted average of per-replica KV-cache usage for each time bin. A capacity-weighted serve-wide percentage is not available in the stored family.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 13
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "filterExpression": "metric == 'kv_cache_usage'",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "saturation"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "metric",
-              "text": "metric",
-              "type": "string"
-            },
-            {
-              "selector": "series",
-              "text": "series",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "usage",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "type": "table",
-      "title": "Saturation average and peak",
-      "description": "Averages retain the binned serve-wide request-count and unweighted replica KV-cache semantics. KV-cache peak is the maximum raw replica sample, before adaptive time-bin averaging.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 13
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "saturation_summary"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "series",
-              "text": "metric",
-              "type": "string"
-            },
-            {
-              "selector": "stat",
-              "text": "stat",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            },
-            {
-              "selector": "unit",
-              "text": "unit",
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 7,
-      "type": "table",
-      "title": "Reset-aware latency evidence",
-      "description": "TTFT, request TPOT, inter-token latency, queue, and end-to-end means from _sum/_count deltas plus p50/p90/p99 upper-bound estimates from bucket deltas. A reset or missing predecessor in any stored component invalidates the complete replica/family sample; a null quantile means the stored finite buckets do not bound it.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 20
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "filterExpression": "stat != 'mean_over_time'",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "latency"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "series",
-              "text": "latency",
-              "type": "string"
-            },
-            {
-              "selector": "stat",
-              "text": "stat",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "seconds",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 11,
-      "type": "timeseries",
-      "title": "Time per output token",
-      "description": "Reset-aware mean request time per output token in bins where requests finished. Empty bins mean no completed request supplied a TPOT observation.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 20
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "always"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "filterExpression": "metric == 'tpot' && stat == 'mean_over_time'",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "latency"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "series",
-              "text": "series",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "seconds/token",
-              "type": "number"
-            },
-            {
-              "selector": "metric",
-              "text": "metric",
-              "type": "string"
-            },
-            {
-              "selector": "stat",
-              "text": "stat",
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 8,
-      "type": "barchart",
-      "title": "Request outcomes",
-      "description": "Reset-aware request_success_total grouped by the stored finish/outcome label, plus compatible failure and timeout counter families when a vLLM version exposes them. Preemptions are in Window totals.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 20
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "lineWidth": 1,
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "axisPlacement": "auto"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/v1/vllm/overview",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "identity_kind",
-                "value": "${identity_kind}"
-              },
-              {
-                "key": "identity",
-                "value": "${identity}"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              },
-              {
-                "key": "bucket_ms",
-                "value": "${__interval_ms}"
-              },
-              {
-                "key": "view",
-                "value": "request_outcome"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "series",
-              "text": "outcome",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "requests",
-              "type": "number"
-            }
-          ]
-        }
-      ],
-      "options": {
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "showValue": "auto",
-        "stacking": "none",
-        "legend": {
-          "showLegend": false,
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": []
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      }
     }
   ],
   "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Inference overview",
+      "type": "link",
+      "url": "/d/marin-inference-overview"
+    },
     {
       "asDropdown": false,
       "icon": "dashboard",

--- a/infra/grafana/dashboards/inference_overview.json
+++ b/infra/grafana/dashboards/inference_overview.json
@@ -1,0 +1,508 @@
+{
+  "uid": "marin-inference-overview",
+  "title": "Inference overview",
+  "description": "Is inference progressing, and is there evidence of pressure or slow responses? One serve/run, existing telemetry only. Open diagnostics for engine comparisons and latency tails.",
+  "tags": [
+    "marin",
+    "inference",
+    "vllm"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "identity_kind",
+        "label": "Identity kind",
+        "type": "custom",
+        "query": "job_id,run_id,execution_uid",
+        "current": {
+          "text": "job_id",
+          "value": "job_id"
+        },
+        "options": [
+          {
+            "selected": true,
+            "text": "job_id",
+            "value": "job_id"
+          },
+          {
+            "selected": false,
+            "text": "run_id",
+            "value": "run_id"
+          },
+          {
+            "selected": false,
+            "text": "execution_uid",
+            "value": "execution_uid"
+          }
+        ]
+      },
+      {
+        "name": "identity",
+        "label": "Serve",
+        "type": "query",
+        "description": "Standalone vLLM serves and MarinSkyRL processes carrying metric_source=vllm under the selected identity kind. One identity at a time: every panel is entity-scoped.",
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "finelog-marin"
+        },
+        "definition": "distinct ${identity_kind} from standalone or embedded vLLM telemetry",
+        "query": {
+          "queryType": "infinity",
+          "refId": "variable-identity",
+          "infinityQuery": {
+            "refId": "variable-identity",
+            "type": "json",
+            "source": "url",
+            "format": "table",
+            "parser": "backend",
+            "url": "/query",
+            "url_options": {
+              "method": "GET",
+              "params": [
+                {
+                  "key": "sql",
+                  "value": "WITH telemetry AS (SELECT job_id, run_id, execution_uid, timestamp_ms FROM \"telemetry_v1.vllm\" WHERE service = 'vllm' UNION ALL SELECT job_id, run_id, execution_uid, timestamp_ms FROM \"telemetry_v1.marinskyrl\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'metric_source') = 'vllm') SELECT DISTINCT CASE '${identity_kind}' WHEN 'job_id' THEN job_id WHEN 'run_id' THEN run_id WHEN 'execution_uid' THEN execution_uid END AS value FROM telemetry WHERE timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) AND CASE '${identity_kind}' WHEN 'job_id' THEN job_id WHEN 'run_id' THEN run_id WHEN 'execution_uid' THEN execution_uid END IS NOT NULL ORDER BY 1"
+                },
+                {
+                  "key": "from",
+                  "value": "${__from}"
+                },
+                {
+                  "key": "to",
+                  "value": "${__to}"
+                }
+              ]
+            },
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1,
+        "regex": "",
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "",
+      "options": {
+        "mode": "markdown",
+        "content": "Read progress, response speed, and pressure together. **No data is not zero.** In RL, low throughput may be an intentional phase boundary; these charts do not prove upstream starvation. Open **Inference diagnostics** with the same serve and time range for engine differences, latency tails, and telemetry detail."
+      },
+      "id": 12,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 3
+      }
+    },
+    {
+      "panelRef": "inference_tokens",
+      "id": 2,
+      "gridPos": {
+        "x": 0,
+        "y": 3,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Finished requests/s by outcome",
+      "description": "Rate of engine finishes, not incoming demand. Includes every stored finish reason; stop and length are not failures by definition. Counter resets and missing predecessors do not become negative rates.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "noValue": "No samples",
+          "displayName": "${__field.labels.series}",
+          "custom": {
+            "drawStyle": "line",
+            "showPoints": "auto",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "request_rate"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "id": 13,
+      "gridPos": {
+        "x": 12,
+        "y": 3,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_requests",
+      "id": 3,
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Time to first token (mean)",
+      "description": "Histogram-weighted mean TTFT. Lower is better. Includes time before the first token; it is not pure GPU prefill time. In-flight requests without a first token are not represented yet. Compare with queue and prefill timing in diagnostics.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "noValue": "No samples",
+          "displayName": "${__field.labels.series}",
+          "custom": {
+            "drawStyle": "line",
+            "showPoints": "auto",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/v1/vllm/overview",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "identity_kind",
+                "value": "${identity_kind}"
+              },
+              {
+                "key": "identity",
+                "value": "${identity}"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              },
+              {
+                "key": "bucket_ms",
+                "value": "${__interval_ms}"
+              },
+              {
+                "key": "view",
+                "value": "latency"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "metric",
+              "text": "metric",
+              "type": "string"
+            },
+            {
+              "selector": "stat",
+              "text": "stat",
+              "type": "string"
+            }
+          ],
+          "filterExpression": "metric == 'ttft' && stat == 'mean_over_time'"
+        }
+      ],
+      "id": 14,
+      "gridPos": {
+        "x": 12,
+        "y": 10,
+        "w": 6,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_tpot",
+      "id": 11,
+      "gridPos": {
+        "x": 18,
+        "y": 10,
+        "w": 6,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_kv",
+      "id": 5,
+      "gridPos": {
+        "x": 0,
+        "y": 17,
+        "w": 12,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_outcomes",
+      "id": 8,
+      "gridPos": {
+        "x": 12,
+        "y": 17,
+        "w": 8,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_preemptions",
+      "id": 4,
+      "gridPos": {
+        "x": 20,
+        "y": 17,
+        "w": 4,
+        "h": 7
+      }
+    },
+    {
+      "panelRef": "inference_freshness",
+      "id": 1,
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 5
+      }
+    },
+    {
+      "panelRef": "inference_health",
+      "id": 10,
+      "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 12,
+        "h": 5
+      }
+    }
+  ],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Inference diagnostics",
+      "type": "link",
+      "url": "/d/marin-inference"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Home",
+      "type": "link",
+      "url": "/d/marin-home"
+    },
+    {
+      "linkRef": "fleet_accelerators_without_vars"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Node details",
+      "type": "link",
+      "url": "/d/marin-nodes"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Node pools",
+      "type": "link",
+      "url": "/d/marin-node-pools"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Jobs",
+      "type": "link",
+      "url": "/d/marin-jobs"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Runs",
+      "type": "link",
+      "url": "/d/marin-runs"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "RL runs",
+      "type": "link",
+      "url": "/d/marin-rl-runs"
+    },
+    {
+      "linkRef": "fleet_health_without_vars"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Training run",
+      "type": "link",
+      "url": "/d/marin-training"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Infra",
+      "type": "link",
+      "url": "/d/infra"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_freshness.json
+++ b/infra/grafana/dashboards/panels/inference_freshness.json
@@ -10,6 +10,21 @@
     "defaults": {},
     "overrides": []
   },
+  "transformations": [
+    {
+      "id": "organize",
+      "options": {
+        "indexByName": {
+          "status": 0,
+          "age at range end (s)": 1,
+          "largest sample gap (s)": 2,
+          "last sample": 3,
+          "replica samples": 4,
+          "producer/resource": 5
+        }
+      }
+    }
+  ],
   "targets": [
     {
       "refId": "A",

--- a/infra/grafana/dashboards/panels/inference_freshness.json
+++ b/infra/grafana/dashboards/panels/inference_freshness.json
@@ -1,0 +1,84 @@
+{
+  "type": "table",
+  "title": "Telemetry freshness (observed producers)",
+  "description": "Reports the stalest producer/resource identity, so a stopped replica cannot be hidden by a healthy peer. Explicitly distinguishes no matching records, a range ending after the last sample, an in-range scrape/export gap, and continuous samples. Age is relative to the selected range end, not wall-clock now. Only identities that emitted records are known; this is not expected-replica coverage.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": []
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "freshness"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "series",
+          "text": "producer/resource",
+          "type": "string"
+        },
+        {
+          "selector": "status",
+          "text": "status",
+          "type": "string"
+        },
+        {
+          "selector": "t",
+          "text": "last sample",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "value",
+          "text": "age at range end (s)",
+          "type": "number"
+        },
+        {
+          "selector": "gap_seconds",
+          "text": "largest sample gap (s)",
+          "type": "number"
+        },
+        {
+          "selector": "samples",
+          "text": "replica samples",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_health.json
+++ b/infra/grafana/dashboards/panels/inference_health.json
@@ -1,0 +1,79 @@
+{
+  "type": "table",
+  "title": "Telemetry publication health",
+  "description": "Reports known collection or publication loss in the selected window. Fresh zero-valued evidence is healthy, any positive loss is incomplete, and absent or stale evidence is unknown. Embedded evidence is selected only from service=marinskyrl rows with metric_source=vllm; Ray health never stands in for vLLM health. The best-effort health signal cannot prove its own delivery. Unknown is not healthy. Older runs may have no publication-health records.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": []
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "telemetry_health"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "status",
+          "text": "status",
+          "type": "string"
+        },
+        {
+          "selector": "metric",
+          "text": "signal",
+          "type": "string"
+        },
+        {
+          "selector": "series",
+          "text": "stage / reason",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "window value",
+          "type": "number"
+        },
+        {
+          "selector": "unit",
+          "text": "unit",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_health.json
+++ b/infra/grafana/dashboards/panels/inference_health.json
@@ -10,6 +10,20 @@
     "defaults": {},
     "overrides": []
   },
+  "transformations": [
+    {
+      "id": "organize",
+      "options": {
+        "indexByName": {
+          "status": 0,
+          "signal": 1,
+          "window value": 2,
+          "unit": 3,
+          "stage / reason": 4
+        }
+      }
+    }
+  ],
   "targets": [
     {
       "refId": "A",

--- a/infra/grafana/dashboards/panels/inference_kv.json
+++ b/infra/grafana/dashboards/panels/inference_kv.json
@@ -1,0 +1,122 @@
+{
+  "type": "timeseries",
+  "title": "KV-cache usage: mean and busiest engine",
+  "description": "Mean is the unweighted average of observed per-engine fractions; peak is the maximum raw engine sample in each bin. No capacity-weighted fleet percentage is available. Compare with waiting and preemptions; cache pressure alone does not identify the cause of latency.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit",
+      "min": 0,
+      "noValue": "No samples",
+      "displayName": "${__field.labels.series}",
+      "custom": {
+        "drawStyle": "line",
+        "showPoints": "auto",
+        "spanNulls": false
+      },
+      "max": 1
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "kv_cache_usage"
+        },
+        "properties": [
+          {
+            "id": "displayName",
+            "value": "Engine mean"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "kv_cache_usage_peak"
+        },
+        "properties": [
+          {
+            "id": "displayName",
+            "value": "Busiest engine"
+          }
+        ]
+      }
+    ]
+  },
+  "options": {
+    "legend": {
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "timeseries",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "saturation"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "t",
+          "text": "time",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "series",
+          "text": "series",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "value",
+          "type": "number"
+        },
+        {
+          "selector": "metric",
+          "text": "metric",
+          "type": "string"
+        }
+      ],
+      "filterExpression": "metric == 'kv_cache_usage' || metric == 'kv_cache_usage_peak'"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_outcomes.json
+++ b/infra/grafana/dashboards/panels/inference_outcomes.json
@@ -1,0 +1,87 @@
+{
+  "type": "barchart",
+  "title": "Finished requests by outcome",
+  "description": "Window totals by the stored finish reason, including stop, length limit, abort, or error when emitted. request_success_total is a metric name, not proof that every finish was successful. Missing error/timeout families cannot prove zero failures. These are engine finishes, not upstream arrivals.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "lineWidth": 1,
+        "fillOpacity": 80,
+        "gradientMode": "none",
+        "axisPlacement": "auto"
+      }
+    },
+    "overrides": []
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "request_outcome"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "series",
+          "text": "outcome",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "requests",
+          "type": "number"
+        }
+      ]
+    }
+  ],
+  "options": {
+    "orientation": "horizontal",
+    "xTickLabelRotation": 0,
+    "showValue": "auto",
+    "stacking": "none",
+    "legend": {
+      "showLegend": false,
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "tooltip": {
+      "mode": "single",
+      "sort": "none"
+    }
+  }
+}

--- a/infra/grafana/dashboards/panels/inference_preemptions.json
+++ b/infra/grafana/dashboards/panels/inference_preemptions.json
@@ -1,0 +1,84 @@
+{
+  "type": "stat",
+  "title": "Preemptions in selected window",
+  "description": "Reset-aware counter total. Preemption can indicate KV-cache pressure; it is not a failed request. Missing records stay unknown, not zero.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "unit": "short",
+      "decimals": 0,
+      "noValue": "No samples",
+      "color": {
+        "mode": "fixed",
+        "fixedColor": "blue"
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "values": false,
+      "calcs": [
+        "lastNotNull"
+      ],
+      "fields": ""
+    },
+    "colorMode": "none",
+    "graphMode": "none"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "counter_total"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "value",
+          "text": "preemptions",
+          "type": "number"
+        },
+        {
+          "selector": "metric",
+          "text": "metric",
+          "type": "string"
+        }
+      ],
+      "filterExpression": "metric == 'preemptions'"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_preemptions.json
+++ b/infra/grafana/dashboards/panels/inference_preemptions.json
@@ -1,6 +1,6 @@
 {
   "type": "stat",
-  "title": "Preemptions in selected window",
+  "title": "Preemptions",
   "description": "Reset-aware counter total. Preemption can indicate KV-cache pressure; it is not a failed request. Missing records stay unknown, not zero.",
   "datasource": {
     "type": "yesoreyeram-infinity-datasource",

--- a/infra/grafana/dashboards/panels/inference_requests.json
+++ b/infra/grafana/dashboards/panels/inference_requests.json
@@ -1,0 +1,133 @@
+{
+  "type": "timeseries",
+  "title": "In-flight, running, and waiting requests",
+  "description": "Fleet request counts: in flight = running + waiting. Running means admitted to vLLM scheduling, not all executing in one GPU batch. One iteration can contain prefill chunks and decode tokens from many requests. A draining curve does not distinguish an intentional rollout barrier from missing upstream work; use RL phase timing for context.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "unit": "none",
+      "min": 0,
+      "noValue": "No samples",
+      "displayName": "${__field.labels.series}",
+      "custom": {
+        "drawStyle": "line",
+        "showPoints": "auto",
+        "spanNulls": false
+      }
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "num_requests_in_flight"
+        },
+        "properties": [
+          {
+            "id": "displayName",
+            "value": "In flight"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "num_requests_running"
+        },
+        "properties": [
+          {
+            "id": "displayName",
+            "value": "Running"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "num_requests_waiting"
+        },
+        "properties": [
+          {
+            "id": "displayName",
+            "value": "Waiting"
+          }
+        ]
+      }
+    ]
+  },
+  "options": {
+    "legend": {
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "timeseries",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "saturation"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "t",
+          "text": "time",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "series",
+          "text": "series",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "value",
+          "type": "number"
+        },
+        {
+          "selector": "metric",
+          "text": "metric",
+          "type": "string"
+        }
+      ],
+      "filterExpression": "metric == 'num_requests_running' || metric == 'num_requests_waiting' || metric == 'num_requests_in_flight'"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_tokens.json
+++ b/infra/grafana/dashboards/panels/inference_tokens.json
@@ -1,0 +1,90 @@
+{
+  "type": "timeseries",
+  "title": "Prompt and generated tokens/s",
+  "description": "Fleet throughput, not tokens/s per request. Counter deltas are computed per producer before summing. A falling rate can reflect fewer active requests, slower decoding, or rollout phase changes. Missing samples are not filled with zero.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "unit": "tps",
+      "min": 0,
+      "noValue": "No samples",
+      "displayName": "${__field.labels.series}",
+      "custom": {
+        "drawStyle": "line",
+        "showPoints": "auto",
+        "spanNulls": false
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "timeseries",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "token_rate"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "t",
+          "text": "time",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "series",
+          "text": "series",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "value",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/inference_tpot.json
+++ b/infra/grafana/dashboards/panels/inference_tpot.json
@@ -1,0 +1,101 @@
+{
+  "type": "timeseries",
+  "title": "Time per output token (mean)",
+  "description": "Mean request TPOT from histogram sum/count deltas. Lower is faster per request; this is not aggregate tokens/s or GPU utilization. Observations arrive when requests finish, so unfinished long requests are absent. A gap can mean no observations or missing telemetry. Window tails and observation counts are in diagnostics.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "unit": "s",
+      "min": 0,
+      "noValue": "No samples",
+      "displayName": "${__field.labels.series}",
+      "custom": {
+        "drawStyle": "line",
+        "showPoints": "auto",
+        "spanNulls": false
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "timeseries",
+      "parser": "backend",
+      "url": "/v1/vllm/overview",
+      "url_options": {
+        "method": "GET",
+        "params": [
+          {
+            "key": "identity_kind",
+            "value": "${identity_kind}"
+          },
+          {
+            "key": "identity",
+            "value": "${identity}"
+          },
+          {
+            "key": "from",
+            "value": "${__from}"
+          },
+          {
+            "key": "to",
+            "value": "${__to}"
+          },
+          {
+            "key": "bucket_ms",
+            "value": "${__interval_ms}"
+          },
+          {
+            "key": "view",
+            "value": "latency"
+          }
+        ]
+      },
+      "columns": [
+        {
+          "selector": "t",
+          "text": "time",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "series",
+          "text": "series",
+          "type": "string"
+        },
+        {
+          "selector": "value",
+          "text": "value",
+          "type": "number"
+        },
+        {
+          "selector": "metric",
+          "text": "metric",
+          "type": "string"
+        },
+        {
+          "selector": "stat",
+          "text": "stat",
+          "type": "string"
+        }
+      ],
+      "filterExpression": "metric == 'tpot' && stat == 'mean_over_time'"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -830,7 +830,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "Engine queue and KV-cache",
-      "description": "Requests running and queued at the inference engines, with KV-cache occupancy on the right axis.\n\nQueued high with KV-cache low is a scheduling limit, so add engines or raise the concurrency cap. Both high is a real KV-cache limit.\n\nThe preemptions panel says whether that limit cost anything. Values are averaged across engines. Data from telemetry_v1.vllm, and from engines embedded in the trainer in telemetry_v1.marinskyrl.",
+      "description": "Requests running and queued at the inference engines, with KV-cache occupancy on the right axis.\n\nA growing queue with low KV usage can suggest a scheduling or compute limit; high KV usage and preemptions support cache pressure. Neither pattern alone identifies the cause or the right concurrency setting. A draining queue may be an intentional rollout boundary, not upstream starvation.\n\nValues here are averaged across engines, unlike the fleet sums in Inference overview and diagnostics. Data from telemetry_v1.vllm, and from engines embedded in the trainer in telemetry_v1.marinskyrl.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"

--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 VLLM_MAX_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
-VLLM_MAX_POINTS = 720
+# Leave room for latency/outcome series and bounded producer tables in the shared result.
+VLLM_MAX_POINTS = 360
 VLLM_MAX_RESULT_ROWS = 10_000
 VLLM_MIN_BUCKET_MS = 15_000
 VLLM_SCRAPE_INTERVAL_MS = 60_000
@@ -20,14 +21,17 @@ VLLM_MAX_IDENTITY_LENGTH = 512
 VLLM_OVERVIEW_SECTIONS = frozenset(
     {
         "counter_total",
+        "engine_summary",
         "freshness",
         "freshness_detail",
         "latency",
         "request_outcome",
+        "request_rate",
         "saturation",
         "saturation_summary",
         "telemetry_health",
         "token_rate",
+        "workload",
     }
 )
 
@@ -72,7 +76,10 @@ _HISTOGRAM_FAMILIES = (
     ("request_time_per_output_token_seconds", "tpot"),
     ("inter_token_latency_seconds", "inter_token_latency"),
     ("request_queue_time_seconds", "queue"),
+    ("request_prefill_time_seconds", "prefill"),
+    ("request_decode_time_seconds", "decode"),
     ("e2e_request_latency_seconds", "e2e"),
+    ("request_generation_tokens", "output_tokens"),
     ("iteration_tokens_total", "iteration_tokens"),
 )
 _HISTOGRAM_COMPONENTS = ("bucket", "count", "sum")
@@ -215,6 +222,12 @@ WITH base AS (
            ) AS previous_value
     FROM base
     WHERE json_get(attributes_json, 'source_temporality') = 'cumulative_snapshot'
+      -- Reject legacy mixed-engine histograms before computing their unused deltas.
+      AND (
+          name NOT IN ({histogram_names})
+          OR service = 'vllm'
+          OR json_get(attributes_json, 'engine_index') IS NOT NULL
+      )
 ), increments AS (
     SELECT origin_cluster,
            service,
@@ -249,15 +262,22 @@ WITH base AS (
                    ELSE {bucket_ms}
                END AS t,
            name,
+           origin_cluster,
            service,
+           resource_attributes_json,
+           COALESCE(json_get(attributes_json, 'engine'), resource_attributes_json) AS producer_identity,
            SUM(delta) AS delta
     FROM increments
     WHERE name IN ({token_counters})
       AND delta IS NOT NULL
-    GROUP BY 1, 2, 3
+    GROUP BY 1, 2, 3, 4, 5, 6
 ), token_source_rates AS (
     SELECT t,
            name,
+           origin_cluster,
+           service,
+           resource_attributes_json,
+           producer_identity,
            delta / (CASE WHEN service = 'vllm' THEN {standalone_bucket_ms} ELSE {bucket_ms} END / 1000.0) AS value
     FROM token_bins
 ), token_rates AS (
@@ -280,6 +300,7 @@ WITH base AS (
            service,
            resource_attributes_json,
            COALESCE(json_get(attributes_json, 'engine'), attributes_json) AS producer_identity,
+           COALESCE(json_get(attributes_json, 'engine'), resource_attributes_json) AS engine_identity,
            value
     FROM base
     WHERE timestamp_ms >= {start_ms}
@@ -318,6 +339,42 @@ WITH base AS (
     SELECT name, MAX(value) AS peak
     FROM canonical_gauge_samples
     GROUP BY 1
+), kv_peak_bins AS (
+    SELECT {start_ms} + (timestamp_ms - {start_ms})
+               - (timestamp_ms - {start_ms}) % CASE
+                   WHEN service = 'vllm' THEN {standalone_bucket_ms}
+                   ELSE {bucket_ms}
+               END AS t,
+           MAX(value) AS value
+    FROM canonical_gauge_samples
+    WHERE name = 'kv_cache_usage'
+    GROUP BY 1
+), engine_stats AS (
+    SELECT engine_identity || ' @ ' || origin_cluster || ':' || service || ':' || resource_attributes_json AS series,
+           CASE name
+               WHEN 'num_requests_running' THEN 'running_mean'
+               WHEN 'num_requests_waiting' THEN 'waiting_mean'
+               ELSE 'kv_cache_peak'
+           END AS metric,
+           CASE WHEN name = 'kv_cache_usage' THEN MAX(value) ELSE AVG(value) END AS value,
+           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END AS unit,
+           COUNT(*) AS samples
+    FROM canonical_gauge_samples
+    GROUP BY 1, 2, 4, name
+
+    UNION ALL
+
+    SELECT producer_identity || ' @ ' || origin_cluster || ':' || service || ':' || resource_attributes_json AS series,
+           'generated_tokens_per_second' AS metric,
+           AVG(value) AS value,
+           'tokens/s' AS unit,
+           COUNT(*) AS samples
+    FROM token_source_rates
+    WHERE name = 'generation_tokens_total'
+    GROUP BY 1
+), ranked_engine_stats AS (
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY metric ORDER BY series) AS producer_rank
+    FROM engine_stats
 ), gauge_stats AS (
     SELECT bins.name,
            AVG(bins.value) AS average,
@@ -406,16 +463,19 @@ WITH base AS (
     SELECT {start_ms} + (sample_t - {start_ms}) - (sample_t - {start_ms}) % {bucket_ms} AS t,
            family,
            SUM(CASE WHEN component = 'sum' THEN delta ELSE 0 END)
-               / NULLIF(SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END), 0) AS mean
+               / NULLIF(SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END), 0) AS mean,
+           SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END) AS samples
     FROM coherent_histogram_increments
     GROUP BY 1, 2
     HAVING SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END) > 0
 ), histogram_means AS (
     SELECT family,
            SUM(CASE WHEN component = 'sum' THEN delta ELSE 0 END)
-               / NULLIF(SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END), 0) AS mean
+               / NULLIF(SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END), 0) AS mean,
+           SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END) AS samples
     FROM coherent_histogram_increments
     GROUP BY 1
+    HAVING SUM(CASE WHEN component = 'count' THEN delta ELSE 0 END) > 0
 ), histogram_buckets AS (
     SELECT family, upper_bound, SUM(delta) AS bucket_count
     FROM coherent_histogram_increments
@@ -444,30 +504,55 @@ WITH base AS (
     FROM histogram_ranked_buckets
     GROUP BY 1
 ), histogram_stats AS (
-    SELECT means.family, means.mean, quantiles.p50, quantiles.p90, quantiles.p99
+    SELECT means.family, means.mean, means.samples, quantiles.p50, quantiles.p90, quantiles.p99
     FROM histogram_means AS means
     LEFT JOIN histogram_quantiles AS quantiles USING (family)
 ), histogram_evidence AS (
-    SELECT family, 'mean' AS stat, mean AS value FROM histogram_stats
-    UNION ALL
-    SELECT family, 'p50', p50 FROM histogram_stats
-    UNION ALL
-    SELECT family, 'p90', p90 FROM histogram_stats
-    UNION ALL
-    SELECT family, 'p99', p99 FROM histogram_stats
-), outcome_totals AS (
-    SELECT COALESCE(
+    SELECT family,
+           quantile.stat,
+           CASE quantile.stat
+               WHEN 'mean' THEN mean
+               WHEN 'p50' THEN p50
+               WHEN 'p90' THEN p90
+               ELSE p99
+           END AS value,
+           samples
+    FROM histogram_stats
+    -- A UNION per statistic would repeat the histogram pipeline in Finelog's plan.
+    CROSS JOIN (VALUES ('mean'), ('p50'), ('p90'), ('p99')) AS quantile(stat)
+), outcome_increments AS (
+    SELECT timestamp_ms,
+           service,
+           COALESCE(
                json_get(attributes_json, 'finished_reason'),
                json_get(attributes_json, 'finish_reason'),
                json_get(attributes_json, 'outcome'),
                json_get(attributes_json, 'status'),
                name
            ) AS outcome,
-           SUM(delta) AS value
+           delta
     FROM increments
     WHERE name IN ({outcome_counters})
       AND delta IS NOT NULL
+), outcome_totals AS (
+    SELECT outcome, SUM(delta) AS value
+    FROM outcome_increments
     GROUP BY 1
+), outcome_source_rates AS (
+    SELECT {start_ms} + (timestamp_ms - {start_ms})
+               - (timestamp_ms - {start_ms}) % CASE
+                   WHEN service = 'vllm' THEN {standalone_bucket_ms}
+                   ELSE {bucket_ms}
+               END AS t,
+           outcome,
+           service,
+           SUM(delta) / (CASE WHEN service = 'vllm' THEN {standalone_bucket_ms} ELSE {bucket_ms} END / 1000.0) AS value
+    FROM outcome_increments
+    GROUP BY 1, 2, 3
+), outcome_rates AS (
+    SELECT t, outcome, SUM(value) AS value
+    FROM outcome_source_rates
+    GROUP BY 1, 2
 ), collector_polls AS (
     SELECT COUNT(*) AS polls,
            SUM(CASE WHEN value <= 0 THEN 1 ELSE 0 END) AS unavailable_polls,
@@ -700,6 +785,35 @@ WITH base AS (
 
     SELECT t AS t,
            'saturation' AS section,
+           'kv_cache_usage_peak' AS metric,
+           'value' AS stat,
+           'kv_cache_usage_peak' AS series,
+           value AS value,
+           'ratio' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM kv_peak_bins
+
+    UNION ALL
+
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'engine_summary' AS section,
+           metric AS metric,
+           'observed' AS stat,
+           series AS series,
+           value AS value,
+           unit AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(samples AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM ranked_engine_stats
+    WHERE producer_rank <= {VLLM_MAX_FRESHNESS_DETAILS}
+
+    UNION ALL
+
+    SELECT t AS t,
+           'saturation' AS section,
            'iteration_tokens' AS metric,
            'mean' AS stat,
            'iteration tokens per engine step' AS series,
@@ -742,14 +856,14 @@ WITH base AS (
     UNION ALL
 
     SELECT CAST(NULL AS BIGINT) AS t,
-           'latency' AS section,
+           CASE WHEN family = 'output_tokens' THEN 'workload' ELSE 'latency' END AS section,
            family AS metric,
            stat AS stat,
            family AS series,
            value AS value,
-           's' AS unit,
+           CASE WHEN family = 'output_tokens' THEN 'tokens' ELSE 's' END AS unit,
            CAST(NULL AS VARCHAR) AS status,
-           CAST(NULL AS BIGINT) AS samples,
+           CAST(samples AS BIGINT) AS samples,
            CAST(NULL AS DOUBLE) AS gap_seconds
     FROM histogram_evidence
     WHERE family <> 'iteration_tokens'
@@ -758,16 +872,30 @@ WITH base AS (
 
     SELECT t AS t,
            'latency' AS section,
-           'tpot' AS metric,
+           family AS metric,
            'mean_over_time' AS stat,
-           'time per output token' AS series,
+           CASE WHEN family = 'tpot' THEN 'time per output token' ELSE family END AS series,
            mean AS value,
            's' AS unit,
            CAST(NULL AS VARCHAR) AS status,
-           CAST(NULL AS BIGINT) AS samples,
+           CAST(samples AS BIGINT) AS samples,
            CAST(NULL AS DOUBLE) AS gap_seconds
     FROM histogram_time_means
-    WHERE family = 'tpot'
+    WHERE family NOT IN ('iteration_tokens', 'output_tokens')
+
+    UNION ALL
+
+    SELECT t AS t,
+           'request_rate' AS section,
+           'requests' AS metric,
+           'rate' AS stat,
+           outcome AS series,
+           value AS value,
+           'requests/s' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
+    FROM outcome_rates
 
     UNION ALL
 
@@ -891,7 +1019,7 @@ ORDER BY section,
          metric,
          stat,
          series
-LIMIT {VLLM_MAX_RESULT_ROWS}
+LIMIT {VLLM_MAX_RESULT_ROWS + 1}
 """.strip()
     return VllmOverviewQuery(
         sql=sql,

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -6,14 +6,17 @@ from pathlib import Path
 from types import SimpleNamespace as Record
 
 import duckdb
+import pytest
 from config import ClusterTarget
 from conftest import bridge_config
+from dashboard_stitch import stitch_all
 from server import create_app
 from starlette.testclient import TestClient
 from vllm_observability import VLLM_OVERVIEW_SECTIONS
 
 
-def test_dashboard_vllm_overview_end_to_end():
+@pytest.mark.parametrize("invalid_histogram", ["reset", "missing_component"])
+def test_dashboard_vllm_overview_end_to_end(invalid_histogram):
     database = duckdb.connect()
     columns = """cluster VARCHAR, service VARCHAR, job_id VARCHAR, name VARCHAR, kind VARCHAR,
         value DOUBLE, resource_attributes_json VARCHAR, attributes_json VARCHAR, timestamp_ms BIGINT, seq BIGINT"""
@@ -39,15 +42,34 @@ def test_dashboard_vllm_overview_end_to_end():
         sample("request_success_total", value, timestamp, finished_reason="stop", **cumulative)
         for timestamp, value in ((0, 0), (15_000, 1))
     ]
-    for component, final in (("sum", 0.1), ("count", 1), ("bucket", 1)):
-        labels = {**cumulative, **({"le": "0.1"} if component == "bucket" else {})}
-        samples += [
-            sample(f"request_time_per_output_token_seconds_{component}", value, timestamp, **labels)
-            for timestamp, value in ((0, 0), (15_000, final))
-        ]
+    for family, mean in (
+        ("request_time_per_output_token_seconds", 0.1),
+        ("time_to_first_token_seconds", 2),
+        ("request_prefill_time_seconds", 1),
+        ("request_decode_time_seconds", 10),
+        ("request_generation_tokens", 100),
+    ):
+        for component, final in (("sum", mean), ("count", 1), ("bucket", 1)):
+            labels = {**cumulative, **({"le": str(mean)} if component == "bucket" else {})}
+            samples += [
+                sample(f"{family}_{component}", value, timestamp, **labels)
+                for timestamp, value in ((0, 0), (15_000, final))
+            ]
+    # A second engine must not skew the fleet mean/tails with a reset or partial scrape.
+    for component in ("sum", "count", "bucket"):
+        labels = {**cumulative, "engine": "physical-b", "engine_index": "1"}
+        if component == "bucket":
+            labels["le"] = "100"
+        samples.append(sample(f"request_prefill_time_seconds_{component}", 10, 0, **labels))
+        if invalid_histogram == "missing_component" and component == "count":
+            continue
+        value = 5 if invalid_histogram == "reset" and component == "sum" else 110
+        samples.append(sample(f"request_prefill_time_seconds_{component}", value, 15_000, **labels))
     samples += [
         sample("num_requests_running", 2, 15_000, **snapshot),
         sample("num_requests_waiting", 1, 15_000, **snapshot),
+        sample("kv_cache_usage_perc", 0.25, 15_000, **snapshot),
+        sample("kv_cache_usage_perc", 0.75, 15_000, engine="physical-b", engine_index="1", **snapshot),
     ]
     samples += [
         sample("num_requests_running", 1, timestamp, engine="physical-b", engine_index="1", **snapshot)
@@ -68,15 +90,25 @@ def test_dashboard_vllm_overview_end_to_end():
         query=lambda sql, *, max_rows: database.execute(sql).fetch_arrow_table(),
     )
     app = create_app(bridge_config(), {"marin": source}, {}, None, None, None)
-    dashboard = json.loads((Path(__file__).parents[1] / "dashboards" / "inference.json").read_text())
-    targets = (target for panel in dashboard["panels"] for target in panel.get("targets", []))
-    path = next(target["url"] for target in targets if target.get("url") == "/v1/vllm/overview")
+    dashboard_dir = Path(__file__).parents[1] / "dashboards"
+    dashboards = stitch_all(dashboard_dir, dashboard_dir / "panels")
+    path = "/v1/vllm/overview"
     params = {"identity_kind": "job_id", "identity": "/train", "from": 0, "to": 240_000, "bucket_ms": 15_000}
 
     with TestClient(app) as client:
         response = client.get(f"/finelog/marin{path}", params={**params, "view": "token_rate"})
         saturation = client.get(f"/finelog/marin{path}", params={**params, "view": "saturation"})
         all_rows = client.get(f"/finelog/marin{path}", params=params)
+        # Exercise the provisioned panel requests, including the new overview and shared fragments.
+        for filename in ("inference.json", "inference_overview.json"):
+            for panel in dashboards[filename]["panels"]:
+                for target in panel.get("targets", []):
+                    view = next(p["value"] for p in target["url_options"]["params"] if p["key"] == "view")
+                    result = client.get(f"/finelog/marin{target['url']}", params={**params, "view": view})
+                    assert result.status_code == 200, panel["title"]
+                    for row in result.json():
+                        assert row["section"] == view
+                        assert all(column["selector"] in row for column in target["columns"])
 
     assert response.status_code == 200
     assert saturation.status_code == 200
@@ -95,8 +127,30 @@ def test_dashboard_vllm_overview_end_to_end():
     assert {row["section"] for row in rows} == VLLM_OVERVIEW_SECTIONS
     values = {(row["section"], row["metric"], row["stat"], row["series"], row["t"]): row["value"] for row in rows}
     assert values[("request_outcome", "requests", "total", "stop", None)] == 1
+    assert values[("request_rate", "requests", "rate", "stop", 15_000)] == pytest.approx(1 / 15)
     assert values[("latency", "tpot", "mean_over_time", "time per output token", 15_000)] == 0.1
+    assert values[("latency", "ttft", "mean_over_time", "ttft", 15_000)] == 2
+    assert values[("latency", "prefill", "mean", "prefill", None)] == 1
+    assert values[("latency", "prefill", "p90", "prefill", None)] == 1
+    assert values[("latency", "decode", "mean", "decode", None)] == 10
+    assert values[("workload", "output_tokens", "mean", "output_tokens", None)] == 100
+    histogram_rows = [row for row in rows if row["section"] in ("latency", "workload")]
+    assert all(row["samples"] == 1 for row in histogram_rows)
+    assert all(row["unit"] == "tokens" for row in histogram_rows if row["metric"] == "output_tokens")
     assert values[("saturation", "num_requests_running", "value", "num_requests_running", 15_000)] == 3
     assert values[("saturation", "num_requests_in_flight", "value", "num_requests_in_flight", 15_000)] == 4
+    assert values[("saturation", "kv_cache_usage", "value", "kv_cache_usage", 15_000)] == 0.5
+    assert values[("saturation", "kv_cache_usage_peak", "value", "kv_cache_usage_peak", 15_000)] == 0.75
+    engines = {
+        (row["series"].split(" @ ", 1)[0], row["metric"]): row["value"]
+        for row in rows
+        if row["section"] == "engine_summary"
+    }
+    assert engines[("physical-a", "running_mean")] == 2
+    assert engines[("physical-b", "running_mean")] == 1
+    assert engines[("physical-a", "waiting_mean")] == 1
+    assert engines[("physical-b", "kv_cache_peak")] == 0.75
+    assert engines[("physical-a", "generated_tokens_per_second")] == 10
+    assert ("physical-b", "generated_tokens_per_second") not in engines  # Missing is not idle.
     freshness = {row["series"].rsplit(":", 1)[-1]: row["status"] for row in rows if row["section"] == "freshness_detail"}
     assert freshness == {"physical-a": "stale_or_stopped", "physical-b": "fresh"}


### PR DESCRIPTION
Split inference telemetry into linked overview and diagnostics dashboards. The overview shows progress, response speed, queueing, cache pressure, and telemetry health. Diagnostics adds engine comparisons, latency stages and tails, and output lengths. Diagnostics retains the existing `marin-inference` UID and all original panel IDs, so old panel links still work. Links between the two views retain the selected serve and time range.

Separate request counts from tokens per engine iteration, and fleet throughput from per-request token latency. Show finished-request rates by outcome without treating them as arrival demand. Missing observations remain missing. The descriptions explain why draining requests alone cannot distinguish an intentional RL batch barrier from upstream starvation.

Read existing Finelog records only: no new telemetry, vLLM changes, or GPU experiments. Extend the shared bounded query and reuse panel fragments. Expand histogram statistics in one pass to avoid repeating the aggregation in Finelog's query plan.

All 256 Grafana tests pass. Candidate queries complete against both the historical Snowball run and a recent run with per-engine telemetry. The real Grafana Infinity datasource accepts every panel target, and browser previews render both dashboards with those query results. The 136 existing non-freshness rows match the historical baseline within floating-point tolerance. Historical latency panels show no samples where stored histograms cannot be attributed to individual engines. These checks do not deploy the dashboards.
