### PR TITLE
[iac] Let Marina deployments manage scheduler jobs

### DIFF
--- a/infra/pulumi/src/iac/gcp/marina.py
+++ b/infra/pulumi/src/iac/gcp/marina.py
@@ -40,6 +40,8 @@ def iam_grants(project: str, principals: Mapping[str, GcpEncryptedMember]) -> Gc
     iap_agent = f"serviceAccount:service-{_PROJECT_NUMBER}@gcp-sa-iap.iam.gserviceaccount.com"
     return GcpIamGrantSet(
         project_grants=(
+            # Marina's Pulumi program manages one Scheduler trigger per app-declared runner.
+            GcpRoleGrant(role="roles/cloudscheduler.admin", members=(deploy_account,)),
             GcpRoleGrant(role="roles/cloudsql.client", members=(runtime_account, _READER_GROUP)),
             GcpRoleGrant(role="roles/cloudsql.instanceUser", members=(runtime_account, _READER_GROUP)),
             GcpRoleGrant(role="roles/compute.viewer", members=(runtime_account,)),


### PR DESCRIPTION
Grant project-level `roles/cloudscheduler.admin` on `hai-gcp-models` to `marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com`. Marina's Pulumi program creates, updates, and deletes Scheduler triggers as app-declared runners change. [Merged-main rollout 33920055992](https://github.com/marin-community/marin/actions/runs/33920055992) failed on missing `cloudscheduler.jobs.create` and required a manual owner recovery.

Cloud Scheduler Admin is Google's narrowest predefined role containing the create, update, and delete permissions needed to reconcile the trigger lifecycle. The grant can manage every Scheduler job in the project; Google does not provide resource-level IAM for individual Scheduler jobs. The current jobs and application stack are converged, so applying this change should add only the IAM binding and let CI manage later runner changes.

A reviewer should run the `review-grant` workflow, then apply the `marin` Pulumi stack. The failure and recovery are recorded in https://marina.oa.dev/echo/wiki/339.
