### PR TITLE
[marina] Rebuild applets before publishing

### DIFF
--- a/.agents/skills/marina-applet/SKILL.md
+++ b/.agents/skills/marina-applet/SKILL.md
@@ -42,8 +42,8 @@ client state. For Vue applets:
 Keep the source `index.html`, `package.json`, the Vite configuration, and `src/`
 beside `applet.toml`. They are local build inputs and are not uploaded. A
 typical manifest uses `build_command = "npm ci && npm run build"`. Marina runs
-that command only when `dist/index.html` is absent; run the build explicitly
-before publishing when a previous `dist/` exists.
+that command before every publish by default. Use `--no-build` only when the
+existing `dist/` has already been built and validated.
 
 Use the applet's implicit Postgres schema for mutable or queryable data. Do not
 create or attach a separate database. Load simple scalar tables with the CLI,
@@ -85,8 +85,9 @@ local filesystem persistence.
 
 Inspect existing Marina and repository helpers before introducing a framework
 or dependency. Build frontend output locally; Marina does not install applet
-dependencies. A manifest `build_command` may create `dist/index.html` when
-`marina publish` runs with its default `--build` behavior.
+dependencies. `marina publish` runs a declared `build_command` before packaging
+by default, and the command may create `dist/index.html`. Pass `--no-build` to
+reuse an existing validated `dist/`.
 
 Validate the exact package without changing server state:
 

--- a/.agents/skills/marina-applet/SKILL.md
+++ b/.agents/skills/marina-applet/SKILL.md
@@ -27,6 +27,24 @@ so both `/a/<uuid>/` and `/a/<uuid>/v/<revision>/` work.
 The source directory may omit `dist/index.html` only when `applet.toml` has a
 `build_command` that creates it before packaging.
 
+Use plain HTML and JavaScript for a small single-view applet. Use Vue with Vite
+when the applet needs multiple views, reusable components, or substantial
+client state. For Vue applets:
+
+- Set Vite's `base` to `"./"` so built asset URLs remain relative.
+- Use `createWebHashHistory()` when the app has client-side routes. This avoids
+  hard-coding an applet UUID or revision into the router base.
+- Use relative backend calls such as `fetch("api/results")` and
+  `fetch("query", ...)`; do not start applet-owned URLs with `/`.
+- Bundle dependencies into `dist/`. Marina's content security policy does not
+  allow scripts loaded from a third-party CDN.
+
+Keep the source `index.html`, `package.json`, the Vite configuration, and `src/`
+beside `applet.toml`. They are local build inputs and are not uploaded. A
+typical manifest uses `build_command = "npm ci && npm run build"`. Marina runs
+that command only when `dist/index.html` is absent; run the build explicitly
+before publishing when a previous `dist/` exists.
+
 Use the applet's implicit Postgres schema for mutable or queryable data. Do not
 create or attach a separate database. Load simple scalar tables with the CLI,
 or add `server/` when the applet needs parameterized business logic, custom

--- a/infra/marina/README.md
+++ b/infra/marina/README.md
@@ -190,6 +190,60 @@ description = "Browse generated math problem sets."
 python_entrypoint = "server.app:create_api"
 ```
 
+### Vue and other built frontends
+
+Marina serves any frontend that builds into `dist/`. Plain HTML and JavaScript
+fit a small single-view applet. Vue with Vite fits applets with multiple views,
+reusable components, or substantial client state. Keep frontend sources beside
+the files Marina packages:
+
+```text
+my-applet/
+  applet.toml
+  package.json
+  package-lock.json
+  index.html                # Vite source entry
+  vite.config.ts
+  src/
+  dist/                     # generated and uploaded
+  server/                   # optional and uploaded
+```
+
+Configure Vite to emit relative asset URLs:
+
+```ts
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  plugins: [vue()],
+});
+```
+
+Use `createWebHashHistory()` from `vue-router` for client-side routes. Hash
+routes keep the server path at the applet revision root and avoid a router base
+that contains the generated UUID and revision. Use relative backend URLs such
+as `fetch("api/results")` and `fetch("query", ...)`; a leading `/` escapes the
+applet prefix. Bundle dependencies into `dist/` because the applet content
+security policy permits scripts from the applet origin only.
+
+The manifest may build a missing `dist/index.html` locally:
+
+```toml
+build_command = "npm ci && npm run build"
+```
+
+`marina publish` runs `build_command` only when `dist/index.html` is absent. If
+`dist/` already exists, build it explicitly before publishing so an old bundle
+is not reused:
+
+```bash
+npm ci
+npm run build
+uv run marina publish .
+```
+
 Publish a built directory:
 
 ```bash

--- a/infra/marina/README.md
+++ b/infra/marina/README.md
@@ -228,20 +228,19 @@ as `fetch("api/results")` and `fetch("query", ...)`; a leading `/` escapes the
 applet prefix. Bundle dependencies into `dist/` because the applet content
 security policy permits scripts from the applet origin only.
 
-The manifest may build a missing `dist/index.html` locally:
+The manifest may define its local build:
 
 ```toml
 build_command = "npm ci && npm run build"
 ```
 
-`marina publish` runs `build_command` only when `dist/index.html` is absent. If
-`dist/` already exists, build it explicitly before publishing so an old bundle
-is not reused:
+`marina publish` runs a declared `build_command` before every publish by
+default, including when `dist/index.html` already exists. Pass `--no-build`
+only to reuse an existing bundle that has already been built and validated:
 
 ```bash
-npm ci
-npm run build
 uv run marina publish .
+uv run marina publish . --no-build
 ```
 
 Publish a built directory:

--- a/infra/marina/src/marina/cli.py
+++ b/infra/marina/src/marina/cli.py
@@ -176,10 +176,10 @@ def _publish_package(app_dir: Path, *, build: bool) -> tuple[bytes, AppletPackag
     if not manifest_path.is_file():
         raise click.UsageError(f"{app_dir} has no {APPLET_MANIFEST}")
     manifest = parse_applet_manifest(manifest_path.read_bytes())
-    if not (app_dir / "dist" / "index.html").is_file() and build:
-        if manifest.build_command is None:
-            raise click.UsageError("dist/index.html is absent and applet.toml has no build_command")
+    if build and manifest.build_command is not None:
         subprocess.run(manifest.build_command, shell=True, cwd=app_dir, check=True)
+    elif build and not (app_dir / "dist" / "index.html").is_file():
+        raise click.UsageError("dist/index.html is absent and applet.toml has no build_command")
     try:
         payload = package_applet(app_dir)
     except ValueError as error:
@@ -249,7 +249,7 @@ def _serve_local_applet(payload: bytes, *, json_output: bool) -> None:
 @click.option("--url", "service_url", default=DEFAULT_MARINA_URL, show_default=True)
 @click.option("--update", "applet_id", default=None, help="Applet UUID to update.")
 @click.option("--base-version", type=int, default=None, help="Current version required by an update.")
-@click.option("--build/--no-build", default=True, help="Run build_command when dist/index.html is absent.")
+@click.option("--build/--no-build", default=True, help="Run a declared build_command before packaging.")
 @click.option("--local", is_flag=True, help="Run this applet against disposable Postgres and Marina.")
 @click.option("--dry-run", is_flag=True, help="Validate and print package contents without publishing.")
 @click.option("--json", "json_output", is_flag=True, help="Print the publish result as JSON.")


### PR DESCRIPTION
Run a declared applet `build_command` before every normal publish, including when `dist/index.html` already exists. `--no-build` remains the explicit path for reusing a prebuilt bundle, so normal publishes do not silently reuse stale Vue or Vite output.

Document Vue and Vite applets in the Marina README and `marina-applet` skill. The guidance uses Vite `base: "./"`, Vue Router `createWebHashHistory()`, and relative backend calls so one `dist/` works below both current and revision URLs. JavaScript dependencies must be bundled because the applet policy sets `script-src 'self'`.
