### PR TITLE
[inference] Pass local model paths to vLLM

### DIFF
--- a/lib/marin/src/marin/inference/model_preparation.py
+++ b/lib/marin/src/marin/inference/model_preparation.py
@@ -4,6 +4,7 @@
 """Model path resolution and automatic inference sharding."""
 
 import json
+from urllib.parse import unquote, urlsplit
 
 from levanter.model_cache import resolve_cached_model_path
 from rigging.filesystem.storage_path import StoragePath
@@ -12,6 +13,17 @@ from transformers import AutoConfig
 from marin.inference.vllm_server import _is_object_store_path
 
 _MODEL_CACHE_PREFIX = "quick-serve-models"
+
+
+def _vllm_model_path(path: str) -> str:
+    """Return a local filesystem path instead of a ``file://`` storage URI."""
+
+    parsed = urlsplit(path)
+    if parsed.scheme != "file":
+        return path
+    if parsed.netloc not in ("", "localhost"):
+        raise ValueError(f"vLLM cannot serve a non-local file URI: {path!r}")
+    return unquote(parsed.path)
 
 
 def select_tensor_parallel_size(
@@ -62,7 +74,8 @@ def resolve_model_path(model: str, cache_ttl_days: int, revision: str | None = N
     """Resolve and optionally mirror an HF model to the region-local cache."""
 
     if revision is None or _is_object_store_path(model):
-        return resolve_cached_model_path(model, cache_ttl_days=cache_ttl_days, cache_prefix=_MODEL_CACHE_PREFIX)
+        resolved = resolve_cached_model_path(model, cache_ttl_days=cache_ttl_days, cache_prefix=_MODEL_CACHE_PREFIX)
+        return _vllm_model_path(resolved)
     pinned_model = f"{model}@{revision}"
     resolved = resolve_cached_model_path(
         pinned_model,
@@ -70,4 +83,4 @@ def resolve_model_path(model: str, cache_ttl_days: int, revision: str | None = N
         cache_prefix=_MODEL_CACHE_PREFIX,
     )
     # With caching disabled, vLLM receives the bare model plus its separate revision argument.
-    return model if resolved == pinned_model else resolved
+    return model if resolved == pinned_model else _vllm_model_path(resolved)

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -126,6 +126,16 @@ def test_resolve_model_path_includes_revision_in_cache_key(monkeypatch):
     assert observed == [("Qwen/Qwen3-0.6B@abc123", 14, "quick-serve-models")]
 
 
+@pytest.mark.parametrize("revision", [None, "abc123"])
+def test_resolve_model_path_returns_filesystem_path_for_local_cache(monkeypatch, revision):
+    monkeypatch.setattr(
+        "marin.inference.model_preparation.resolve_cached_model_path",
+        lambda *_args, **_kwargs: "file:///models/cached%20model",
+    )
+
+    assert resolve_model_path("Qwen/Qwen3-0.6B", 14, revision) == "/models/cached model"
+
+
 def test_vllm_backend_serves_the_pinned_revision(monkeypatch):
     observed: dict[str, object] = {}
 


### PR DESCRIPTION
Convert `file://` cache results to decoded filesystem paths before starting vLLM. Transformers 5 treats file URIs as Hugging Face repository IDs, so pinned Hugging Face evaluations failed after the cache download and before endpoint registration.