### PR TITLE
[eval] Score verified agent timeouts

### DIFF
--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -66,6 +66,7 @@ DEFAULT_MIN_COMPLETION_RATE = 0.9
 # Error labels for ungraded trials that carry no exception of their own.
 _UNKNOWN_ERROR = "unknown"
 _MISSING_RESULT_ERROR = "no_result_written"
+_SCORE_BEARING_EXCEPTIONS = frozenset({"AgentTimeoutError"})
 
 _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
@@ -74,10 +75,10 @@ _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 class HarborTrial:
     """One finished Harbor trial, normalized off its ``result.json``.
 
-    ``scored`` is whether the trial is a usable measurement: a verifier graded it and the trial raised
-    no exception. A trial whose agent timed out part-way is often still verified, and scores zero
-    because it was cut short rather than because the model was wrong -- counting that as a wrong
-    answer is the imputation the coverage accounting exists to avoid, so it is an ungraded item.
+    ``scored`` is whether the trial is a usable measurement: a verifier graded it and it either
+    completed normally or ended with a score-bearing exception. Agent timeouts are passthrough
+    outcomes when Harbor still invokes the verifier; a timeout without a verifier result remains
+    ungraded.
     """
 
     task_id: str
@@ -187,14 +188,16 @@ def _read_trial(result_file: StoragePath) -> HarborTrial:
     reward = rewards.get("reward", 0.0)
     reward = float(reward) if isinstance(reward, int | float) else 0.0
     exc = data.get("exception_info")
-    error = {"type": exc.get("exception_type"), "message": exc.get("exception_message")} if exc else None
+    exception_type = exc.get("exception_type") if exc else None
+    error = {"type": exception_type, "message": exc.get("exception_message")} if exc else None
+    scored = verifier_result is not None and (error is None or exception_type in _SCORE_BEARING_EXCEPTIONS)
     trajectory_file = trial_dir / "agent" / "trajectory.json"
     trajectory_path = str(trajectory_file) if trajectory_file.exists() else None
     return HarborTrial(
         task_id=task_id,
         trial_id=trial_dir.name,
         reward=reward,
-        scored=verifier_result is not None and error is None,
+        scored=scored,
         status="failed" if exc else "completed",
         trajectory_path=trajectory_path,
         error=error,
@@ -407,8 +410,9 @@ def _evaluation_outcome(
 
     A run clearing the gate keeps its aggregate and its per-trial error distribution, so a downstream
     reader can tell the model's score apart from the infrastructure quality behind it. A run below the
-    gate fails as an infrastructure failure -- agent and verifier timeouts are not evaluation outcomes
-    -- and still records its coverage so the rejection is legible as counts rather than as prose.
+    gate fails as an infrastructure failure and still records its coverage so the rejection is legible
+    as counts rather than as prose. A verified agent timeout is a score-bearing outcome; verifier
+    timeouts and agent timeouts without a verifier result remain ungraded.
 
     A run whose attempted-trial count is unknown has no rate to gate on. It is admitted with its
     coverage left unreported, which downstream widens to "completeness unknown" rather than treating

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -66,6 +66,8 @@ DEFAULT_MIN_COMPLETION_RATE = 0.9
 # Error labels for ungraded trials that carry no exception of their own.
 _UNKNOWN_ERROR = "unknown"
 _MISSING_RESULT_ERROR = "no_result_written"
+
+# Exceptions that remain score-bearing when the verifier produced a result.
 _SCORE_BEARING_EXCEPTIONS = frozenset({"AgentTimeoutError"})
 
 _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -569,6 +569,34 @@ def test_harbor_executor_admits_a_batch_that_clears_the_completion_gate(tmp_path
     assert coverage.errors == {"AgentTimeoutError": 1}
 
 
+def test_harbor_executor_counts_verified_agent_timeouts_as_scored(tmp_path, monkeypatch):
+    def run_driver(_config, overlay, _driver_env, _backend_state) -> None:
+        job_dir = Path(overlay.jobs_dir) / overlay.job_name
+        _write_job_record(job_dir, 10)
+        for index in range(10):
+            trial_dir = job_dir / f"trial-{index}"
+            trial_dir.mkdir(parents=True, exist_ok=True)
+            result = {
+                "task_name": f"task-{index}",
+                "verifier_result": {"rewards": {"reward": 1.0 if index >= 7 else 0.0}},
+            }
+            if index < 4:
+                result["exception_info"] = {"exception_type": "AgentTimeoutError"}
+            trial_dir.joinpath("result.json").write_text(json.dumps(result))
+
+    monkeypatch.setattr("marin.evaluation.harbor.runner.run_harbor_driver", run_driver)
+    executor = _harbor_executor(f"timeout-{tmp_path.name}")
+
+    outcome = executor(_inference_session(), str(tmp_path), {})
+
+    dataset = executor.config.record_dataset
+    assert outcome.metrics[dataset]["total"] == 10.0
+    assert outcome.metrics[dataset]["accuracy"] == pytest.approx(0.3)
+    coverage = outcome.coverage[dataset]
+    assert (coverage.n_attempted, coverage.n_scored) == (10, 10)
+    assert coverage.errors == {}
+
+
 def test_an_unreadable_job_record_reports_unknown_coverage_rather_than_complete(tmp_path, monkeypatch):
     """Without Harbor's job record there is no denominator. Falling back to the number of results
     found would certify exactly the interrupted runs as complete, so coverage stays unreported and


### PR DESCRIPTION
Count an `AgentTimeoutError` as a valid Harbor evaluation sample when the verifier produced a reward. Unverified timeouts and other exceptions remain infrastructure attrition.

OT-TBLite rejected a 100-trial evaluation with 100 verifier results because 30 trials ended in score-bearing agent timeouts. The new regression test covers the aggregate score and completion gate.

Part of #8151
