### PR TITLE
[levanter] Add RMNP with input dim normalization

### DIFF
--- a/lib/levanter/config/gpt2_small_fast_rmnp.yaml
+++ b/lib/levanter/config/gpt2_small_fast_rmnp.yaml
@@ -1,0 +1,26 @@
+data: !include data/openwebtext_source.yaml
+model:
+  type: gpt2
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  max_seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+train_seq_len: 1024
+trainer:
+  tracker:
+    - type: wandb
+      project: "levanter"
+      tags: [ "openwebtext", "gpt2", "itest"]
+
+  mp: p=f32,c=bfloat16
+  per_device_parallelism: -1
+
+  train_batch_size: 256
+  num_train_steps: 20000
+
+optimizer:
+  type: rmnp
+  learning_rate: 3E-3
+  weight_decay: 0.05

--- a/lib/levanter/src/levanter/optim/rmnp.py
+++ b/lib/levanter/src/levanter/optim/rmnp.py
@@ -1,0 +1,168 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+from dataclasses import dataclass
+from functools import partial
+from typing import NamedTuple, Optional
+
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+import haliax
+
+from levanter.optim.config import OptimizerConfig
+from levanter.optim.util import (
+    label_linear_like_module,
+    map_flattened_linear_layers,
+)
+from levanter.utils.jax_utils import leaf_key_paths
+
+
+@OptimizerConfig.register_subclass("rmnp")
+@dataclass(frozen=True)
+class RMNPConfig(OptimizerConfig):
+    """
+    RMNP optimizer configuration: Row-Momentum Normalized Preconditioning.
+    cf:
+    Original Implementation: https://github.com/Dominator-Index/RMNP
+    """
+
+    lr: float = 0.02
+    adam_lr: float = 6e-4  # Adam LR
+    momentum: float = 0.95
+    nesterov: bool = True
+    weight_decay: float = 0.0
+    adam_weight_decay: Optional[float] = None
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    rmnp_epsilon: float = 1e-8
+    max_grad_norm: float = 1.0
+    # Kimi scales the learning rate for every d_1 * d_2 module by 0.2 * jnp.sqrt{\max{d_1, d_2}}, instead of the jnp.sqrt{\max{1, d_1/d_2}} as in the original nanogpt speedrun.
+    # When this scaling is enabled, it is recommended to use learning rate and weight decay similar to adam
+    use_kimi_scaling: bool = False
+
+    def build(self, num_train_steps):
+        """
+        Creates the optimizer.
+        """
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def rmnp_transform():
+                components = []
+                components.append(
+                    scale_with_rmnp(
+                        self.momentum,
+                        self.nesterov,
+                        self.rmnp_epsilon,
+                        self.use_kimi_scaling,
+                    )
+                )
+                if self.weight_decay > 0:
+                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-learning_rate))
+                optimizer = optax.chain(*components)
+                return optimizer
+
+            def adamw_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                adam_weight_decay = self.adam_weight_decay if self.adam_weight_decay is not None else self.weight_decay
+                if adam_weight_decay > 0:
+                    components.append(optax.add_decayed_weights(adam_weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-adam_lr))
+                optimizer = optax.chain(*components)
+                return optimizer
+
+            transformations = {
+                "rmnp": rmnp_transform(),
+                "adamw": adamw_transform(),
+            }
+
+            return optax.multi_transform(
+                transformations, partial(self.create_mask, use_kimi_scaling=self.use_kimi_scaling)
+            )
+
+        return optax.inject_hyperparams(optimizer)(learning_rate=learning_rate_schedule, adam_lr=adam_lr_schedule)
+
+    def create_mask(self, params, use_kimi_scaling=True):
+        """
+        Creates a mask that labels parameters as 'rmnp' or 'adamw' based on their
+        dimensionality and module path, using AdamW for Embedding and lm_head parameters.
+        """
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            if "Embedding" in path_str or "lm_head" in path_str:
+                return "adamw"
+            elif isinstance(param, haliax.nn.Linear):
+                # rmnp for linear layers
+                return label_linear_like_module(param, weight_label="rmnp", bias_label="adamw")
+            else:
+                return "adamw"
+
+        return haliax.tree_util.tree_map(mask_fn, params, paths, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
+
+
+class ScaleByRMNPState(NamedTuple):
+    """State for the RMNP algorithm."""
+
+    momentum_buffer: optax.Updates
+
+
+def scale_with_rmnp(momentum=0.95, nesterov=True, rmnp_eps=1e-8, use_kimi_scaling=False):
+    def init_fn(params):
+        momentum_buffer = otu.tree_zeros_like(params)
+        return ScaleByRMNPState(momentum_buffer=momentum_buffer)
+
+    def update_fn(updates, state, params=None):
+        buf = state.momentum_buffer
+        buf = jax.tree.map(
+            lambda m, g: None if g is None else momentum * m + g,
+            buf,
+            updates,
+            is_leaf=lambda x: x is None,
+        )
+        if nesterov:
+            updates = jax.tree.map(
+                lambda m, g: None if g is None else momentum * m + g,
+                buf,
+                updates,
+                is_leaf=lambda x: x is None,
+            )
+        else:
+            updates = buf
+
+        def transform_linear_layer(layer: haliax.nn.Linear):
+            assert layer.weight.ndim == 2
+            array = layer.weight.array
+            # Normalize each output's update over its logical input dimension.
+            input_axis = -1 if layer._out_first else -2
+            row_norm = jnp.linalg.norm(array, axis=input_axis, keepdims=True)
+            updated_weight_array = array / jnp.maximum(row_norm, rmnp_eps)
+
+            if not use_kimi_scaling:
+                # Preserve sqrt(Out/In) in either physical storage layout.
+                out_dim, in_dim = array.shape if layer._out_first else array.shape[::-1]
+                scale = jnp.sqrt(jnp.maximum(1, out_dim / in_dim))
+            else:
+                scale = 0.2 * jnp.sqrt(jnp.maximum(updated_weight_array.shape[0], updated_weight_array.shape[1]))
+            updated_weight_array *= scale
+
+            updated_weight = dataclasses.replace(layer.weight, array=updated_weight_array)
+
+            return dataclasses.replace(layer, weight=updated_weight)  # type: ignore
+
+        updates = map_flattened_linear_layers(transform_linear_layer, updates)
+
+        return updates, ScaleByRMNPState(momentum_buffer=buf)
+
+    return optax.GradientTransformation(init_fn, update_fn)


### PR DESCRIPTION
Add RMNP based on Muon. **RMNP replaces Newton-Schulz orthogonalization with input dim normalization.** Retain Muon's momentum, Nesterov update, weight decay, learning-rate schedules, AdamW parameter routing, and scaling options. Leave the existing Muon implementation and configuration unchanged.

Respect both input-first and output-first Linear weight layouts when normalizing updates and computing the default sqrt(max(1, Out/In)) scale. Provide a GPT-2 Small configuration with a matrix learning rate of 3e-3. The AdamW learning-rate default remains 6e-4.

RMNP is introduced in [RMNP: Row-Momentum Normalized Preconditioning for Scalable Matrix-Based Optimization](https://icml.cc/virtual/2026/poster/65683). See the [project website](https://dominator-index.github.io/RMNP-Project-Page/) and [GitHub codebase](https://github.com/Dominator-Index/RMNP).
