### PR TITLE
[rigging] Anchor relative local storage roots

### DIFF
--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -138,9 +138,21 @@ MARIN_PREFIX=local_store uv run python my_experiment.py
 ```
 
 `MARIN_PREFIX` sets the root directory for all outputs. It can be a local path or anything
-[fsspec](https://filesystem-spec.readthedocs.io/en/latest/) supports (e.g. `gs://`). If
+[fsspec](https://filesystem-spec.readthedocs.io/en/latest/) supports (e.g. `gs://`). A
+relative path such as `local_store` resolves against the directory you run from. If
 you already exported `MARIN_PREFIX` in your shell, just run `uv run python my_experiment.py`.
 See [Understanding `MARIN_PREFIX`](../explanations/marin-prefix.md).
+
+Training reports metrics to Weights & Biases. Without an explicit `run_id`, `train_lm` names
+the W&B run ID after the last segment of the output path, which here is the version
+`2026.06.28`. A second person following this tutorial against the same project reuses that
+ID and can get a `403` when W&B attempts to resume the existing run. Either
+keep the run local with `WANDB_MODE=offline`, or pass `run_id="<your-name>-nano-tinystories"`
+to `train_lm` so the run is yours:
+
+```bash
+MARIN_PREFIX=local_store WANDB_MODE=offline uv run python my_experiment.py
+```
 
 This takes a few minutes on a CPU. The output ends with something like:
 

--- a/lib/rigging/src/rigging/filesystem/cluster_config.py
+++ b/lib/rigging/src/rigging/filesystem/cluster_config.py
@@ -167,15 +167,14 @@ class DataConfig:
         from ``region_buckets[<gcs metadata region>]`` > ``{scheme}://marin-{region}``
         for a detected-but-unmapped region > :data:`_DEFAULT_LOCAL_PREFIX`.
 
-        The env/explicit value is canonicalized through :class:`StoragePath` (trailing
-        ``/`` stripped, interior ``//`` collapsed) so downstream joins never double the
-        separator.
+        The configured value is canonicalized so downstream joins do not duplicate
+        separators. Relative local paths are anchored at the working directory.
         """
         env_prefix = os.environ.get(_MARIN_PREFIX_ENV)
         if env_prefix:
-            return StoragePath.normalize(env_prefix)
+            return _canonical_root(env_prefix)
         if self.root is not None:
-            return StoragePath.normalize(self.root)
+            return _canonical_root(self.root)
         region = region_from_metadata()
         if region is not None:
             spec = self.region_buckets.get(region)
@@ -183,6 +182,14 @@ class DataConfig:
                 return f"{self.scheme}://{spec.name}"
             return f"{self.scheme}://marin-{region}"
         return _DEFAULT_LOCAL_PREFIX
+
+
+def _canonical_root(prefix: str) -> str:
+    """Canonicalize a root and anchor relative local paths at the working directory."""
+    path = StoragePath(prefix)
+    if path.is_local and not path.rooted:
+        return StoragePath.normalize(os.path.abspath(prefix))
+    return str(path)
 
 
 # The marin cluster's storage layout lives in ``config/marin.yaml`` (loaded as

--- a/lib/rigging/tests/test_cluster_config.py
+++ b/lib/rigging/tests/test_cluster_config.py
@@ -4,6 +4,8 @@
 """Tests for the cluster DataConfig: the active-config accessor, YAML loading and
 field-default parsing, and prefix resolution."""
 
+import os
+
 import pytest
 import rigging.filesystem.cluster_config as fs
 from rigging.filesystem.cluster_config import (
@@ -113,6 +115,18 @@ def test_resolved_root_strips_trailing_slash(monkeypatch):
     monkeypatch.delenv("MARIN_PREFIX", raising=False)
     config = DataConfig(region_buckets={}, scheme="s3", root="s3://marin-na/marin/")
     assert config.resolved_root() == "s3://marin-na/marin"
+
+
+def test_resolved_root_anchors_relative_local_prefix(monkeypatch, tmp_path):
+    """A relative local prefix resolves against the working directory, so every path derived
+    from the root is absolute and cannot be re-rooted a second time."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MARIN_PREFIX", "local_store/")
+    assert DataConfig(region_buckets={}).resolved_root() == os.path.join(os.getcwd(), "local_store")
+
+    monkeypatch.delenv("MARIN_PREFIX", raising=False)
+    config = DataConfig(region_buckets={}, root="local_store")
+    assert config.resolved_root() == os.path.join(os.getcwd(), "local_store")
 
 
 def test_resolved_root_uses_explicit_root(monkeypatch):

--- a/tests/execution/test_lazy.py
+++ b/tests/execution/test_lazy.py
@@ -386,6 +386,17 @@ def test_consumer_reads_dependency_value_via_ctx_resolved(tmp_path, monkeypatch)
     assert saved.tokenizer == "llama3"
 
 
+def test_consumer_resolves_dependency_under_relative_prefix(tmp_path, monkeypatch):
+    """A relative ``MARIN_PREFIX`` (the tutorials' ``local_store``) must resolve a dependency's
+    record. The dep's path is joined onto the prefix and still looks relative, so an unanchored
+    prefix was applied again on read and the record came back missing."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MARIN_PREFIX", "local_store")
+    run(echo_consumer())
+    saved = TokenizerEcho.raw_load(f"{tmp_path}/local_store/checkpoints/echo/2026.06.28")
+    assert saved.tokenizer == "llama3"
+
+
 def test_resolved_caches_the_loaded_artifact(tmp_path, monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
     tok = dclm_tokens()


### PR DESCRIPTION
Resolve relative `MARIN_PREFIX` and `DataConfig.root` values against the process working directory before deriving artifact paths. This prevents dependency reads from applying the prefix twice during local tutorial runs.

Document local prefix resolution and show how to keep tutorial W&B runs local or give them an explicit run ID.
