### PR TITLE
[docs] Document local and clustered tutorial launches

### DIFF
--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -199,14 +199,62 @@ iterating, or a calendar version to pin outputs:
 uv run python -m experiments.tutorials.train_tiny_model \
   --device cpu --dataset tinystories --version dev
 
-# Run on an Iris H100 worker.
 uv run python -m experiments.tutorials.train_tiny_model \
-  --device h100x8 --dataset wikitext --version dev --run
+  --device cpu --dataset tinystories --version dev --run
 ```
 
-If the launcher appears to do nothing, check whether `--run` was omitted. It also accepts
-`h100x1`, `gb200x1`, `gb200x4`, `v5litepod-16`, and `v6e-4`. TinyStories and WikiText
-tokenize a 1,000-document sample; `fineweb-edu` uses the checked-in pretokenized cache.
+If the launcher appears to do nothing, check whether `--run` was omitted. TinyStories and
+WikiText tokenize a 1,000-document sample; `fineweb-edu` downloads a prebuilt tokenized cache
+from Hugging Face and trains `llama_150m` from `experiments/llama.py`.
+
+### Running the launcher on a cluster
+
+The same launcher runs on an accelerator when you submit it as an Iris job. `--device`
+accepts `h100x1`, `h100x8`, `gb200x1`, `gb200x4`, `v5litepod-16`, and `v6e-4`. Run this
+from the checkout root after `iris --cluster=marin login`:
+
+```bash
+uv run iris --cluster=marin job run --cpu=1 --memory=2G --extra=cpu --region us-east5 \
+  -- python -m experiments.tutorials.train_tiny_model \
+     --device v6e-4 --dataset wikitext --version dev --run
+```
+
+`--region` pins the coordinator, and the accelerator job inherits its region so training stays
+next to the data. The selected region must offer the requested device. Omit `--region` to let
+Iris select a compatible location.
+
+The job you submit is a one-CPU coordinator that runs the launcher; it has no accelerator
+of its own. Inside it, `train_lm` requests the accelerator through Fray, Marin's job-submission
+layer, and Iris schedules that request as a second job, a child of the coordinator. The
+`--cpu` and `--memory` flags size the coordinator only. `--extra=cpu` installs the CPU
+dependency set (the `cpu` extra in `lib/marin/pyproject.toml`) on the coordinator; the child
+installs the `tpu` or `gpu` extra for its device. Do not set `MARIN_PREFIX`: the cluster
+provides one, and the `dev` version places the checkpoint under `users/<you>/checkpoints/`
+so it cannot collide with another person's run. Your `WANDB_API_KEY` is copied from your shell; see
+[Local runs versus submitted jobs](installation.md#local-runs-versus-submitted-jobs) for
+what else reaches a job.
+
+The H100 and GB200 devices live on CoreWeave clusters. Replace the GCP `--region` selector
+with a CoreWeave target and use the matching device:
+
+```bash
+uv run iris --cluster=marin job run --cpu=1 --memory=2G --extra=cpu \
+  --target-cluster cw-rno2a \
+  -- python -m experiments.tutorials.train_tiny_model \
+     --device h100x8 --dataset wikitext --version dev --run
+```
+
+For GB200, use `--target-cluster cw-us-east-08a` with `--device gb200x1` or `gb200x4`.
+`iris cluster list` shows every configured cluster. [Training on Cloud GPUs](cloud-gpu.md)
+covers the storage and credential differences.
+
+`job run` prints the job id on submission, in the form `/<username>/<job-name>`, and streams
+logs until the job ends. From another shell:
+
+```bash
+uv run iris --cluster=marin job logs -f /<username>/<job-name>
+uv run iris --cluster=marin job describe /<username>/<job-name>
+```
 
 ## Next steps
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -68,7 +68,31 @@ For example, training checkpoints usually will be written to
 
 You might find it convenient to store `WANDB_API_KEY` and `HF_TOKEN` and
 `MARIN_PREFIX` in an `.env` file, which you can load in one go with `source
-.env`.
+.env`. The file is gitignored.
+
+### Local runs versus submitted jobs
+
+The exports above configure your shell, so they apply to scripts you run
+directly and to the `iris` CLI itself. A job submitted with `iris job run`,
+the Iris job-submission command, runs in a container on the cluster and does
+not inherit your shell. Three things reach it:
+
+- `WANDB_API_KEY` and `HF_TOKEN`, which the CLI copies from your shell when
+  they are set.
+- Any variable passed as `-e KEY VALUE` on the `iris job run` command line.
+- The `env:` section of a gitignored `.marin.yaml` at the checkout root, which
+  the CLI reads when you run it from that directory:
+
+  ```yaml
+  env:
+    WANDB_ENTITY: your-entity
+    WANDB_PROJECT: marin
+  ```
+
+Leave `MARIN_PREFIX` out of `.marin.yaml`. The cluster sets it for every task
+to a bucket in the same region as the worker running the task; a value in the
+file overrides that and can send output across regions. See
+[Understanding `MARIN_PREFIX`](../explanations/marin-prefix.md).
 
 ## Hardware-specific Setup
 


### PR DESCRIPTION
Start the checked-in tiny-model launcher walkthrough with a local CPU run, then show coordinator submission through Iris for GCP and CoreWeave accelerators. Explain coordinator resources, child accelerator jobs, placement selection, log commands, and which shell variables reach submitted jobs.
