### PR TITLE
[iris] Reject conflicting cluster and location selectors

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -257,13 +257,19 @@ For machine-readable job data, use the Iris Python client (`IrisClient`) directl
 ### `job run` gotchas
 
 - **Remote jobs only see env vars you put in the job spec.** The submitter's
-  shell env is not copied into the container. Pass required values explicitly:
-  `iris job run -e HF_TOKEN "$HF_TOKEN" -e WANDB_API_KEY "$WANDB_API_KEY" -- python train.py`.
+  shell env is not copied into the container, with two exceptions: the CLI
+  forwards `HF_TOKEN` and `WANDB_API_KEY` from the shell when they are set. Pass
+  anything else explicitly (`-e KEY "$VALUE"`) or list it under `env:` in a
+  gitignored `.marin.yaml` at the checkout root.
 - **`--memory` not `--ram`** — unrecognized flags silently pass through to the command string.
 - **`-e KEY VALUE`** uses two positional args. If `$VALUE` is unset, the parser eats the next token. Always quote: `-e KEY "${VALUE}"`.
 - **`--gpu` requests hardware; `--extra gpu` requests the Python dependency extra.** Need both for GPU JAX jobs.
 - **A job that dies in BUILDING with a `uv sync` error is failing setup before your command starts.** The default is `uv sync --all-packages --no-dev`. Scope it with CLI `--sync-package <member>` or SDK `EnvironmentSpec(sync_packages=[...])`; skip setup entirely with CLI `--no-sync` or SDK `EnvironmentSpec(setup_scripts=[])` for a bring-your-own image. The build log labels each step (`[iris setup] step N/M`) so you can tell which script failed. See "Task Setup" in `AGENTS.md`.
 - **Use `--gpu` or `--tpu` to request accelerators, instead of `--region` or `--zone`.** Let Iris handle scaling group constraints. Use `--region` or `--zone` when you are trying to pin data to a particular location.
+- **`--region`/`--zone` and `--target-cluster` are exclusive.** The first two pin a
+  job to GCP locations on the hub; the third sends the whole job to a CoreWeave
+  peer, whose workers carry their own location labels. The CLI rejects the
+  combination; use one or the other, or neither.
 - **`--reserve`** is a hard zone constraint: it confines the job to a zone where the named accelerator has actually been obtained (empirically — a live, non-erroring slice in the region), and the job waits if none exists yet (an availability probe meanwhile scales the accelerator up). It does not hold capacity and does not attach accelerator devices. Use `--tpu`/`--gpu` on the task that needs hardware.
 - **`executor_main` parent jobs** (e.g., canary ferries) submit GPU sub-tasks via Fray. The parent must be CPU-only (`--cpu 1 --memory 2g`), otherwise it hogs the GPU node and deadlocks. Memory at or above 4 GB requires `--enable-extra-resources` (see "Validator opt-in" below).
 

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -252,6 +252,28 @@ def _known_regions_and_zones(config) -> tuple[set[str], set[str]]:
     return regions, zones
 
 
+_PLACEMENT_CONFLICT_HINT = (
+    "{flag} cannot be combined with --target-cluster. --region and --zone pin a job to GCP "
+    "locations on this cluster; --target-cluster sends the whole job to a peer cluster whose "
+    "workers advertise their own location labels, so a GCP region or zone matches no worker "
+    "there and the job never schedules. Pass one or the other."
+)
+
+
+def validate_placement_selector(
+    regions: tuple[str, ...] | None,
+    zone: str | None,
+    target_cluster: str | None,
+) -> None:
+    """Reject ``--target-cluster`` combined with ``--region`` or ``--zone``."""
+    if not target_cluster:
+        return
+    if regions:
+        raise click.UsageError(_PLACEMENT_CONFLICT_HINT.format(flag="--region"))
+    if zone:
+        raise click.UsageError(_PLACEMENT_CONFLICT_HINT.format(flag="--zone"))
+
+
 def validate_region_zone(
     regions: tuple[str, ...] | None,
     zone: str | None,
@@ -1021,6 +1043,7 @@ def run(
     config = ctx.obj.get("config") if ctx.obj else None
     dashboard_url = config.dashboard_url if config else None
     validate_extra_resources(tpu, gpu, memory, disk, enable_extra_resources)
+    validate_placement_selector(region or None, zone, target_cluster)
     validate_region_zone(region or None, zone, ctx.obj.get("config"))
     if no_sync and sync_package:
         raise click.UsageError("--no-sync skips setup entirely; it cannot be combined with --sync-package.")

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -105,6 +105,20 @@ def test_job_run_accepts_unconstrained_placement_with_cluster_metadata(recorded_
     assert len(recorded_job_submissions) == 1
 
 
+@pytest.mark.parametrize(("flag", "value"), [("--region", "us-central2"), ("--zone", "us-central2-b")])
+def test_job_run_rejects_placement_with_target_cluster(flag, value):
+    result = _run_cli([flag, value, "--target-cluster", "cw-rno2a"])
+    assert result.exit_code != 0
+    assert flag in result.output
+    assert "--target-cluster" in result.output
+
+
+def test_job_run_accepts_target_cluster_alone(recorded_job_submissions):
+    result = _run_cli(["--target-cluster", "cw-rno2a"])
+    assert result.exit_code == 0, result.output
+    assert len(recorded_job_submissions) == 1
+
+
 @pytest.fixture
 def recorded_bundle_exclude(monkeypatch):
     """Capture the ``bundle_exclude`` passed to ``IrisClient.remote`` by ``iris job run``."""


### PR DESCRIPTION
Reject `iris job run` invocations that combine `--target-cluster` with `--region` or `--zone`. The location selectors describe GCP placement on the hub and cannot constrain workers after the job is forwarded to a peer cluster; accepting both leaves the forwarded job unschedulable.

Update operator guidance with the exclusive placement choices.
