### PR TITLE
[levanter] Check accelerator before mesh validation

### DIFF
--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -989,19 +989,19 @@ class TrainerConfig:
         # Importing cutlass.jax may initialize the XLA backend, so install its
         # cache only after jax.distributed.initialize().
         install_cutlass_kernel_cache(cutlass_kernel_cache())
+
+        if self.require_accelerator is None:
+            self.require_accelerator = not sys.platform.startswith("darwin")
+
+        if self.require_accelerator and jax.default_backend() == "cpu":
+            raise RuntimeError("No accelerator found. Please run on a TPU or GPU.")
+
         self._validate_and_set_defaults()
 
         id = self._maybe_set_id()
         levanter.utils.logging.init_logging(self.log_dir, f"{id}.log")
         _initialize_global_tracker(self.tracker, id)
         levanter.tracker.log_summary({"hardware_topology": hardware_topology_summary()})
-
-        if self.require_accelerator is None:
-            self.require_accelerator = not sys.platform.startswith("darwin")
-
-        if self.require_accelerator:
-            if jax.default_backend() == "cpu":
-                raise RuntimeError("No accelerator found. Please run on a TPU or GPU.")
 
         if self.shutdown_at_exit is not False:
             if isinstance(self.shutdown_at_exit, bool):

--- a/lib/levanter/tests/test_trainer_startup.py
+++ b/lib/levanter/tests/test_trainer_startup.py
@@ -5,12 +5,14 @@ import json
 from types import SimpleNamespace
 
 import jax
+import pytest
 
 import levanter.tracker.tracker_fns as tracker_fns
 from levanter.distributed import DistributedConfig
 from levanter.tracker.json_file import JsonFileTrackerConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.hardware_topology import nvidia_topology_matrix_summary, tpu_topology_shape
+from levanter.utils.mesh import MeshConfig
 
 
 def test_trainer_initialize_logs_hardware_topology_to_tracker(tmp_path, monkeypatch):
@@ -42,6 +44,19 @@ def test_trainer_initialize_logs_hardware_topology_to_tracker(tmp_path, monkeypa
     assert "hardware_topology/process_index" not in summary
     assert "hardware_topology/mesh_axis_shapes" not in summary
     assert "hardware_topology/compute_axis_mapping" not in summary
+
+
+def test_trainer_initialize_reports_missing_accelerator_before_invalid_mesh(monkeypatch):
+    monkeypatch.setattr(jax, "default_backend", lambda: "cpu")
+    config = TrainerConfig(
+        train_batch_size=len(jax.devices()),
+        mesh=MeshConfig(axes={"model": len(jax.devices()) + 1}),
+        require_accelerator=True,
+        distributed=DistributedConfig(initialize_jax_distributed=False),
+    )
+
+    with pytest.raises(RuntimeError, match="No accelerator found"):
+        config.initialize()
 
 
 def test_tpu_topology_shape_uses_device_coordinate_extents():

--- a/lib/levanter/tests/test_trainer_startup.py
+++ b/lib/levanter/tests/test_trainer_startup.py
@@ -55,7 +55,7 @@ def test_trainer_initialize_reports_missing_accelerator_before_invalid_mesh(monk
         distributed=DistributedConfig(initialize_jax_distributed=False),
     )
 
-    with pytest.raises(RuntimeError, match="No accelerator found"):
+    with pytest.raises(RuntimeError):
         config.initialize()
 
 


### PR DESCRIPTION
Fail accelerator-required runs before mesh validation when JAX falls back to CPU. A TPU worker that restarts without its accelerator now reports the missing accelerator instead of a secondary mesh-shape error. The platform-dependent default for requiring an accelerator is unchanged.

Fixes #3433
