### PR TITLE
[grug] Resume MoE checkpoints across FSDP and pipeline training

### DIFF
--- a/experiments/grug/moe_pipeline/README.md
+++ b/experiments/grug/moe_pipeline/README.md
@@ -57,10 +57,17 @@ four-process H100x8 gangs with PP2, EP8, and replica axis two. Run `--phase save
 and then `--phase resume` with the same `--checkpoint-root`. Choose `--mode fsdp`
 or `--mode pp` independently for each phase; PP supports `--schedule zero_bubble`
 or `--schedule dualpipe_v`. Use `--dtype float32` for cross-mode numerical
-comparisons, or the default `bfloat16` for same-mode continuation. The first gang saves step one and an uninterrupted
+comparisons, or the default `bfloat16` for same-mode continuation. The default
+FSDP mesh uses 32 devices; `--fsdp-devices 16` selects a smaller mesh. Cross-mode
+checks allow update differences because shard-local QB quantiles and
+expert-capacity clipping depend on token grouping. Byte-sensitive checksums
+indexed by global tensor coordinates verify restoration before any update.
+`--restore-only` skips the loss evaluation. The first gang saves step one and an uninterrupted
 step-two reference; the second restores step one and compares its next step.
-Every integer leaf must match exactly, and every floating state leaf and loss
-must have relative L2 error at most 0.002. Adam counters must also equal the
+Restore checksums must match exactly and loss must have relative error at most
+0.002. Add `--compare-state` for same-mode continuation to require exact integer
+state and floating state relative L2 error at most 0.002. Cross-mode optimizer
+updates can differ because routing depends on token grouping. Adam counters must equal the
 recorded completed step. Only local shards and scalar error
 reductions are read during comparison. Disable command buffers in both gangs:
 `XLA_FLAGS='--xla_gpu_executable_terminate_timeout=300 --xla_gpu_enable_command_buffer='`.

--- a/experiments/grug/moe_pipeline/README.md
+++ b/experiments/grug/moe_pipeline/README.md
@@ -26,39 +26,38 @@ benchmark exposes these settings as `PIPELINE_CHECKPOINT_ROOT` and
 `PIPELINE_CHECKPOINT_EVERY_STEPS`. `steps` is the total target number of optimizer
 updates, including updates completed before restore.
 
-Checkpoints work with both automatic schedules. Grug validates the training
-configuration; `levanter.mpmd_checkpoint` handles MPMD array conversion and
-restore placement using Levanter's checkpoint save, load, and discovery APIs.
-Each save creates
-`step-<12-digit-completed-step>-<unique-id>/` containing Levanter's TensorStore
-Zarr3/OCDBT arrays and array manifest. `metadata.json` records the completed step,
-model and optimizer settings, and array shapes and placements. It is written only
-after every process commits its shards; directories without this marker are
-ignored during restore. An atomically published `latest.json` points to the
-committed checkpoint, so normal resumes do not list historical checkpoints.
-An existing pointer is authoritative: interruption before publishing a newer
-checkpoint leaves the previous checkpoint selected.
-If the first pointer write was interrupted, restore discovers committed metadata
-in the root. A committed checkpoint with incompatible metadata or
-missing array data raises an error. Checkpoints are retained until explicitly
-deleted. Use one writer gang per checkpoint root and a shared filesystem or
-object-store root accessible to every process.
+Checkpoints use ordinary Levanter TensorStore Zarr3/OCDBT storage and discovery.
+Each save creates `step-<12-digit-completed-step>-<unique-id>/`. Completion
+metadata is published atomically after all processes commit their shards;
+directories without that marker are ignored. Discovery selects the highest
+completed step. Use one writer gang per root and shared storage accessible to
+all processes. Checkpoints remain until explicitly deleted.
 
-The state contains each logical stage's parameters, Adam moments and integer
-count, and pending router-bias updates. Checkpoint I/O exposes existing local
-device buffers without gathering model or optimizer arrays. Restore uses abstract
-shape/sharding templates, reads only addressable shards, and reconstructs the
-compiled step's MPMD placement. Each
-process must own exactly one physical pipeline stage. Restore requires the same
-model, precision, batch and microbatch settings, schedule, logical stage split,
-mesh dimensions, and process-to-stage assignment. Changing pipeline, expert,
-replica, or data parallelism requires a separate conversion; this path does not
-reshard checkpoints across topologies.
+The saved `GrugMoeCheckpointState` contains one unsplit `params` model, one
+`opt_state` tree, and a tuple of pending router updates indexed by global layer.
+FSDP can save and load this tree with `levanter.checkpoint.save_checkpoint` and
+`load_checkpoint`. PP assembles the same paths from its stage-local buffers at
+save time, then partitions the restored tree according to the destination's
+compiled input shardings. No model or optimizer tensor is gathered across
+stages; the small replicated optimizer counters are read on every destination
+stage. Pending router biases are installed at the next step, so they are
+excluded from trainable parameters and Adam moments in both modes.
+
+The same state can move between FSDP and PP, between pipeline schedules, and
+between different layer splits or device meshes. The model and optimizer state
+structures must agree. Checkpoints written by this trainer also record and
+validate model configuration, optimizer settings, and precision; ordinary
+Levanter checkpoints without that optional metadata rely on the destination
+state template. Pipeline execution still requires each process to own exactly
+one physical stage. `levanter.mpmd_checkpoint` only adapts array buffers and
+placement; checkpoint publication and discovery use the standard Levanter APIs.
 
 [`checkpoint_smoke.py`](./checkpoint_smoke.py) tests continuation across fresh
 four-process H100x8 gangs with PP2, EP8, and replica axis two. Run `--phase save`
-and then `--phase resume` with the same `--checkpoint-root` and `--schedule
-zero_bubble` (or `dualpipe_v`). The first gang saves step one and an uninterrupted
+and then `--phase resume` with the same `--checkpoint-root`. Choose `--mode fsdp`
+or `--mode pp` independently for each phase; PP supports `--schedule zero_bubble`
+or `--schedule dualpipe_v`. Use `--dtype float32` for cross-mode numerical
+comparisons, or the default `bfloat16` for same-mode continuation. The first gang saves step one and an uninterrupted
 step-two reference; the second restores step one and compares its next step.
 Every integer leaf must match exactly, and every floating state leaf and loss
 must have relative L2 error at most 0.002. Adam counters must also equal the

--- a/experiments/grug/moe_pipeline/README.md
+++ b/experiments/grug/moe_pipeline/README.md
@@ -31,15 +31,21 @@ Checkpoints work with both automatic schedules. Each save creates
 Zarr3/OCDBT arrays and array manifest. `metadata.json` records the completed step,
 model and optimizer settings, and array shapes and placements. It is written only
 after every process commits its shards; directories without this marker are
-ignored during restore. A committed checkpoint with incompatible metadata or
+ignored during restore. An atomically published `latest.json` points to the
+committed checkpoint, so normal resumes do not list historical checkpoints.
+An existing pointer is authoritative: interruption before publishing a newer
+checkpoint leaves the previous checkpoint selected.
+If the first pointer write was interrupted, restore discovers committed metadata
+in the root. A committed checkpoint with incompatible metadata or
 missing array data raises an error. Checkpoints are retained until explicitly
 deleted. Use one writer gang per checkpoint root and a shared filesystem or
 object-store root accessible to every process.
 
 The state contains each logical stage's parameters, Adam moments and integer
 count, and pending router-bias updates. Checkpoint I/O exposes existing local
-device buffers without gathering model or optimizer arrays. Restore reads only
-addressable shards and reconstructs the compiled step's MPMD placement. Each
+device buffers without gathering model or optimizer arrays. Restore uses abstract
+shape/sharding templates, reads only addressable shards, and reconstructs the
+compiled step's MPMD placement. Each
 process must own exactly one physical pipeline stage. Restore requires the same
 model, precision, batch and microbatch settings, schedule, logical stage split,
 mesh dimensions, and process-to-stage assignment. Changing pipeline, expert,
@@ -52,7 +58,8 @@ and then `--phase resume` with the same `--checkpoint-root` and `--schedule
 zero_bubble` (or `dualpipe_v`). The first gang saves step one and an uninterrupted
 step-two reference; the second restores step one and compares its next step.
 Every integer leaf must match exactly, and every floating state leaf and loss
-must have relative L2 error at most 0.002. Only local shards and scalar error
+must have relative L2 error at most 0.002. Adam counters must also equal the
+recorded completed step. Only local shards and scalar error
 reductions are read during comparison. Disable command buffers in both gangs:
 `XLA_FLAGS='--xla_gpu_executable_terminate_timeout=300 --xla_gpu_enable_command_buffer='`.
 

--- a/experiments/grug/moe_pipeline/README.md
+++ b/experiments/grug/moe_pipeline/README.md
@@ -26,7 +26,10 @@ benchmark exposes these settings as `PIPELINE_CHECKPOINT_ROOT` and
 `PIPELINE_CHECKPOINT_EVERY_STEPS`. `steps` is the total target number of optimizer
 updates, including updates completed before restore.
 
-Checkpoints work with both automatic schedules. Each save creates
+Checkpoints work with both automatic schedules. Grug validates the training
+configuration; `levanter.mpmd_checkpoint` handles MPMD array conversion and
+restore placement using Levanter's checkpoint save, load, and discovery APIs.
+Each save creates
 `step-<12-digit-completed-step>-<unique-id>/` containing Levanter's TensorStore
 Zarr3/OCDBT arrays and array manifest. `metadata.json` records the completed step,
 model and optimizer settings, and array shapes and placements. It is written only

--- a/experiments/grug/moe_pipeline/README.md
+++ b/experiments/grug/moe_pipeline/README.md
@@ -16,10 +16,64 @@ each physical rank in JaxPP's V-shaped placement. DualPipeV requires at least `2
 microbatches. `PIPELINE_LAYERS_PER_STAGE` contains one positive layer count per logical
 stage.
 
-The canonical loop initializes fresh parameters, uses a fixed AdamW optimizer, and
-trains on synthetic token rows. It does not save or restore checkpoints. A model-specific
-training variant should replace those parts while retaining the stage split and JaxPP
-orchestration that it needs.
+The canonical loop uses a fixed AdamW optimizer and synthetic token rows. Set
+`checkpoint_root` on `GrugPipelineTrainConfig` to resume the latest completed
+checkpoint in that root, or initialize fresh parameters if none exists. Set
+`checkpoint_every_steps` to a positive interval to save periodically and on clean
+completion. An interval of zero disables saves but still permits restore. The
+trainer rejects a positive interval without a checkpoint root. The
+benchmark exposes these settings as `PIPELINE_CHECKPOINT_ROOT` and
+`PIPELINE_CHECKPOINT_EVERY_STEPS`. `steps` is the total target number of optimizer
+updates, including updates completed before restore.
+
+Checkpoints work with both automatic schedules. Each save creates
+`step-<12-digit-completed-step>-<unique-id>/` containing Levanter's TensorStore
+Zarr3/OCDBT arrays and array manifest. `metadata.json` records the completed step,
+model and optimizer settings, and array shapes and placements. It is written only
+after every process commits its shards; directories without this marker are
+ignored during restore. A committed checkpoint with incompatible metadata or
+missing array data raises an error. Checkpoints are retained until explicitly
+deleted. Use one writer gang per checkpoint root and a shared filesystem or
+object-store root accessible to every process.
+
+The state contains each logical stage's parameters, Adam moments and integer
+count, and pending router-bias updates. Checkpoint I/O exposes existing local
+device buffers without gathering model or optimizer arrays. Restore reads only
+addressable shards and reconstructs the compiled step's MPMD placement. Each
+process must own exactly one physical pipeline stage. Restore requires the same
+model, precision, batch and microbatch settings, schedule, logical stage split,
+mesh dimensions, and process-to-stage assignment. Changing pipeline, expert,
+replica, or data parallelism requires a separate conversion; this path does not
+reshard checkpoints across topologies.
+
+[`checkpoint_smoke.py`](./checkpoint_smoke.py) tests continuation across fresh
+four-process H100x8 gangs with PP2, EP8, and replica axis two. Run `--phase save`
+and then `--phase resume` with the same `--checkpoint-root` and `--schedule
+zero_bubble` (or `dualpipe_v`). The first gang saves step one and an uninterrupted
+step-two reference; the second restores step one and compares its next step.
+Every integer leaf must match exactly, and every floating state leaf and loss
+must have relative L2 error at most 0.002. Only local shards and scalar error
+reductions are read during comparison. Disable command buffers in both gangs:
+`XLA_FLAGS='--xla_gpu_executable_terminate_timeout=300 --xla_gpu_enable_command_buffer='`.
+
+For example, submit through the Iris hub to an H100 peer. Choose an unused job
+name and checkpoint root in the peer's regional storage:
+
+```bash
+uv run iris --cluster=marin job run --no-wait \
+  --enable-extra-resources --target-cluster cw-rno2a --priority batch \
+  --gpu H100x8 --replicas 4 --cpu 32 --memory 256GB --disk 64GB \
+  --timeout 3600 --extra pipeline --job-name <unique-save-job> \
+  -e IRIS_PORT_JAX 32761 -e XLA_PYTHON_CLIENT_PREALLOCATE false \
+  -e XLA_FLAGS '--xla_gpu_executable_terminate_timeout=300 --xla_gpu_enable_command_buffer=' \
+  -- python -m experiments.grug.moe_pipeline.checkpoint_smoke \
+  --checkpoint-root <shared-regional-root> --schedule zero_bubble --phase save
+```
+
+After that job succeeds, repeat with a new job name and `--phase resume`, keeping
+the checkpoint root and schedule unchanged. Use a distinct root for the
+`dualpipe_v` pair. Concurrent gangs need distinct `IRIS_PORT_JAX` values. A
+successful resume emits `CHECKPOINT_SMOKE_PASSED` with the maximum per-leaf error.
 
 The best validated Snowball 67B-A2B throughput point uses eight H100x8 replicas,
 sixteen logical stages, batch 256, 32 microbatches, sequence length 8192, and layer

--- a/experiments/grug/moe_pipeline/benchmark.py
+++ b/experiments/grug/moe_pipeline/benchmark.py
@@ -87,6 +87,8 @@ def _resolve_benchmark_config(environ: Mapping[str, str]) -> GrugPipelineTrainCo
         attention_implementation=environ.get("PIPELINE_ATTENTION", "gpu_fa4_cute"),
         moe_implementation=environ.get("PIPELINE_MOE", "ring"),
         schedule=PipelineSchedule(environ.get("PIPELINE_SCHEDULE", PipelineSchedule.ZERO_BUBBLE)),
+        checkpoint_root=environ.get("PIPELINE_CHECKPOINT_ROOT"),
+        checkpoint_every_steps=_env_int(environ, "PIPELINE_CHECKPOINT_EVERY_STEPS", 0),
     )
 
 

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -1,0 +1,137 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shard-local TensorStore checkpoints for the automatic pipeline trainer."""
+
+import json
+import uuid
+
+import jax
+import numpy as np
+from jax.experimental import multihost_utils
+from jax.sharding import NamedSharding
+from levanter.tensorstore_serialization import (
+    ReplicaRestoreMode,
+    TensorStoreReadConfig,
+    tree_deserialize_leaves_tensorstore,
+    tree_serialize_leaves_tensorstore,
+)
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+
+from experiments.grug.moe_pipeline.pipeline import GrugMoeAutomaticPipelineState, _jaxpp_modules, jaxpp
+
+_FORMAT_VERSION = 1
+
+
+def checkpoint_arrays(state: GrugMoeAutomaticPipelineState) -> GrugMoeAutomaticPipelineState:
+    """Expose existing device buffers as JAX arrays without moving any shards."""
+
+    def unwrap(value):
+        if jaxpp is None or not isinstance(value, jaxpp.MpmdArray):
+            return value
+        local = value.to_mpmd_local_array
+        arrays = [] if local is None else local if isinstance(local, list) else [local]
+        buffers = {shard.device: shard.data for array in arrays for shard in array.addressable_shards}
+        return jax.make_array_from_single_device_arrays(
+            value.shape,
+            value.sharding,
+            [buffers[device] for device in value.sharding.mesh.devices.flat if device in buffers],
+            dtype=value.dtype,
+        )
+
+    return jax.tree.map(unwrap, state)
+
+
+def _array_layout(state) -> list[dict]:
+    return [
+        {
+            "path": jax.tree_util.keystr(path),
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "spec": list(value.sharding.spec),
+            "mesh": dict(value.sharding.mesh.shape),
+            "processes": [device.process_index for device in value.sharding.mesh.devices.flat],
+        }
+        for path, value in jax.tree_util.tree_flatten_with_path(state)[0]
+    ]
+
+
+def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: int, contract: dict) -> str:
+    """Commit a completed training step after every process finishes its shard writes."""
+    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
+    path = prefix_join(root, f"step-{step:012d}-{bytes(identifier).hex()}")
+    arrays = checkpoint_arrays(state)
+    metadata = {
+        "version": _FORMAT_VERSION,
+        "step": step,
+        "contract": contract,
+        "arrays": _array_layout(arrays),
+    }
+
+    def commit():
+        with atomic_rename(prefix_join(path, "metadata.json")) as temporary_path:
+            StoragePath(temporary_path).write_text(json.dumps(metadata, sort_keys=True))
+
+    tree_serialize_leaves_tensorstore(path, arrays, commit_callback=commit)
+    return path
+
+
+def restore_checkpoint(
+    root: str,
+    state: GrugMoeAutomaticPipelineState,
+    shardings,
+    *,
+    contract: dict,
+) -> tuple[GrugMoeAutomaticPipelineState, int]:
+    """Restore the newest committed step, or return fresh state for an empty root.
+
+    The compiled step supplies the exact MPMD placement. Model configuration,
+    schedule, and process topology must match the saved checkpoint.
+    """
+    checkpoints = StoragePath(prefix_join(root, "step-*/metadata.json")).glob()
+    if not checkpoints:
+        return state, 0
+    metadata_path = max(checkpoints, key=str)
+    metadata = json.loads(metadata_path.read_text())
+    arrays = checkpoint_arrays(state)
+    expected = json.loads(json.dumps({"contract": contract, "arrays": _array_layout(arrays)}))
+    if metadata["version"] != _FORMAT_VERSION or any(metadata[key] != value for key, value in expected.items()):
+        raise ValueError(f"Checkpoint configuration or topology does not match: {metadata_path}")
+    path = str(metadata_path).rsplit("/", 1)[0]
+    # Levanter's reader expects at least one addressable shard per input array.
+    # Other stages remain empty descriptors and never enter the read plan.
+    local_arrays = jax.tree.map(lambda value: value if value.addressable_shards else None, arrays)
+    restored = tree_deserialize_leaves_tensorstore(
+        path,
+        local_arrays,
+        # Avoid restore collectives across processes that do not own this stage.
+        read_config=TensorStoreReadConfig(replica_mode=ReplicaRestoreMode.EVERY_REPLICA),
+    )
+    restored = jax.tree.map(
+        lambda original, loaded: original if loaded is None else loaded,
+        arrays,
+        restored,
+        is_leaf=lambda value: value is None,
+    )
+
+    def wrap(value, target):
+        if isinstance(target, NamedSharding):
+            return value
+        pp, _ = _jaxpp_modules()
+        buffers = {shard.device: shard.data for shard in value.addressable_shards}
+        local_arrays = []
+        for mesh_id in sorted(target.mesh_ids):
+            sharding = NamedSharding(target.mpmd_mesh.unstack[mesh_id], target.spec)
+            if sharding.addressable_devices:
+                local_arrays.append(
+                    jax.make_array_from_single_device_arrays(
+                        value.shape,
+                        sharding,
+                        [buffers[device] for device in sharding.mesh.devices.flat if device in buffers],
+                        dtype=value.dtype,
+                    )
+                )
+        return pp.MpmdArray(local_arrays, target, shape=value.shape, dtype=value.dtype)
+
+    return jax.tree.map(wrap, restored, shardings), int(metadata["step"])

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -22,6 +22,8 @@ from rigging.filesystem.storage_path import StoragePath, prefix_join
 from experiments.grug.moe_pipeline.pipeline import GrugMoeAutomaticPipelineState, _jaxpp_modules, jaxpp
 
 _FORMAT_VERSION = 1
+_METADATA_FILE = "metadata.json"
+_LATEST_FILE = "latest.json"
 
 
 def checkpoint_arrays(state: GrugMoeAutomaticPipelineState) -> GrugMoeAutomaticPipelineState:
@@ -70,9 +72,9 @@ def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: in
     }
 
     def commit():
-        with atomic_rename(prefix_join(path, "metadata.json")) as temporary_path:
+        with atomic_rename(prefix_join(path, _METADATA_FILE)) as temporary_path:
             StoragePath(temporary_path).write_text(json.dumps(metadata, sort_keys=True))
-        with atomic_rename(prefix_join(root, "latest.json")) as temporary_path:
+        with atomic_rename(prefix_join(root, _LATEST_FILE)) as temporary_path:
             StoragePath(temporary_path).write_text(json.dumps({"checkpoint": StoragePath(path).name, "step": step}))
 
     tree_serialize_leaves_tensorstore(path, arrays, commit_callback=commit)
@@ -91,15 +93,15 @@ def restore_checkpoint(
     The compiled step supplies the exact MPMD placement. Model configuration,
     schedule, and process topology must match the saved checkpoint.
     """
-    latest_path = StoragePath(prefix_join(root, "latest.json"))
+    latest_path = StoragePath(prefix_join(root, _LATEST_FILE))
     latest = None
     if latest_path.exists():
         latest = json.loads(latest_path.read_text())
-        metadata_path = StoragePath(root) / latest["checkpoint"] / "metadata.json"
+        metadata_path = StoragePath(root) / latest["checkpoint"] / _METADATA_FILE
     else:
         # Recover a fully written first checkpoint if publication of latest.json
         # was interrupted. Normal resumes need no checkpoint-directory listing.
-        checkpoints = StoragePath(prefix_join(root, "step-*/metadata.json")).glob()
+        checkpoints = (StoragePath(root) / "step-*" / _METADATA_FILE).glob()
         if not checkpoints:
             return state, 0
         metadata_path = max(checkpoints, key=str)

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -4,16 +4,14 @@
 """Canonical model and optimizer checkpoints shared by FSDP and pipeline training."""
 
 import json
-import uuid
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
-from jax.experimental import multihost_utils
-from jax.sharding import Mesh, NamedSharding
+from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
+from jaxtyping import PyTree
 from levanter import mpmd_checkpoint
 from levanter.checkpoint import discover_checkpoint_candidates
 from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
@@ -125,16 +123,22 @@ def _pipeline_state(
 
 def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: int, contract: dict) -> str:
     """Save canonical state with ordinary Levanter checkpoint publication."""
-    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
-    path = f"step-{step:012d}-{bytes(identifier).hex()}"
-    path = prefix_join(root, path)
+    path = prefix_join(root, f"step-{step}")
     return save_levanter_checkpoint(checkpoint_state(state), step, path, metadata={"training_config": contract})
 
 
 def restore_checkpoint(
-    root: str, state: GrugMoeAutomaticPipelineState, shardings, *, contract: dict
+    root: str, state: GrugMoeAutomaticPipelineState, shardings: PyTree, *, contract: dict
 ) -> tuple[GrugMoeAutomaticPipelineState, int]:
-    """Load an FSDP or PP checkpoint into the destination pipeline partition."""
+    """Load an FSDP or PP checkpoint into the destination pipeline partition.
+
+    Args:
+        root: Directory searched for the latest completed checkpoint.
+        state: Destination pipeline state used as a shape and structure template.
+        shardings: Compiled step input shardings with the same tree as state.
+        contract: Model, precision, and optimizer configuration to validate
+            against training_config metadata when the checkpoint supplies it.
+    """
     candidates = discover_checkpoint_candidates(root)
     if not candidates:
         return state, 0
@@ -144,18 +148,6 @@ def restore_checkpoint(
         raise ValueError("Checkpoint training configuration does not match")
     arrays = mpmd_checkpoint.checkpoint_arrays(state)
     canonical = checkpoint_state(arrays)
-    # A single optimizer counter becomes a copy on every destination stage.
-    # Reading these scalars on all devices avoids gathering any model tensors.
-    scalar_sharding = NamedSharding(Mesh(np.array(jax.devices()), ("checkpoint",)), P())
-    canonical = replace(
-        canonical,
-        opt_state=jax.tree.map(
-            lambda value: (
-                jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=scalar_sharding) if value.shape == () else value
-            ),
-            canonical.opt_state,
-        ),
-    )
     loaded = mpmd_checkpoint.restore_checkpoint(
         canonical, checkpoint.path, jax.tree.map(lambda value: value.sharding, canonical)
     )

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -1,158 +1,28 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shard-local TensorStore checkpoints for the automatic pipeline trainer."""
+"""Training-configuration checks for Grug pipeline checkpoints."""
 
 import json
-import uuid
 
-import jax
-import numpy as np
-from jax.experimental import multihost_utils
-from jax.sharding import NamedSharding
-from levanter.tensorstore_serialization import (
-    ReplicaRestoreMode,
-    TensorStoreReadConfig,
-    tree_deserialize_leaves_tensorstore,
-    tree_serialize_leaves_tensorstore,
-)
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.storage_path import StoragePath, prefix_join
+from levanter import mpmd_checkpoint
 
-from experiments.grug.moe_pipeline.pipeline import GrugMoeAutomaticPipelineState, _jaxpp_modules, jaxpp
-
-_FORMAT_VERSION = 1
-_METADATA_FILE = "metadata.json"
-_LATEST_FILE = "latest.json"
-
-
-def checkpoint_arrays(state: GrugMoeAutomaticPipelineState) -> GrugMoeAutomaticPipelineState:
-    """Expose existing device buffers as JAX arrays without moving any shards."""
-
-    def unwrap(value):
-        if jaxpp is None or not isinstance(value, jaxpp.MpmdArray):
-            return value
-        local = value.to_mpmd_local_array
-        arrays = [] if local is None else local if isinstance(local, list) else [local]
-        buffers = {shard.device: shard.data for array in arrays for shard in array.addressable_shards}
-        return jax.make_array_from_single_device_arrays(
-            value.shape,
-            value.sharding,
-            [buffers[device] for device in value.sharding.mesh.devices.flat if device in buffers],
-            dtype=value.dtype,
-        )
-
-    return jax.tree.map(unwrap, state)
-
-
-def _array_layout(state) -> list[dict]:
-    return [
-        {
-            "path": jax.tree_util.keystr(path),
-            "shape": list(value.shape),
-            "dtype": str(value.dtype),
-            "spec": list(value.sharding.spec),
-            "mesh": dict(value.sharding.mesh.shape),
-            "processes": [device.process_index for device in value.sharding.mesh.devices.flat],
-        }
-        for path, value in jax.tree_util.tree_flatten_with_path(state)[0]
-    ]
+from experiments.grug.moe_pipeline.pipeline import GrugMoeAutomaticPipelineState
 
 
 def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: int, contract: dict) -> str:
-    """Commit a completed training step after every process finishes its shard writes."""
-    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
-    path = prefix_join(root, f"step-{step:012d}-{bytes(identifier).hex()}")
-    arrays = checkpoint_arrays(state)
-    metadata = {
-        "version": _FORMAT_VERSION,
-        "step": step,
-        "contract": contract,
-        "arrays": _array_layout(arrays),
-    }
-
-    def commit():
-        with atomic_rename(prefix_join(path, _METADATA_FILE)) as temporary_path:
-            StoragePath(temporary_path).write_text(json.dumps(metadata, sort_keys=True))
-        with atomic_rename(prefix_join(root, _LATEST_FILE)) as temporary_path:
-            StoragePath(temporary_path).write_text(json.dumps({"checkpoint": StoragePath(path).name, "step": step}))
-
-    tree_serialize_leaves_tensorstore(path, arrays, commit_callback=commit)
-    return path
+    """Save pipeline state and the training configuration required to resume it."""
+    return mpmd_checkpoint.save_checkpoint(root, state, step=step, metadata=contract)
 
 
 def restore_checkpoint(
-    root: str,
-    state: GrugMoeAutomaticPipelineState,
-    shardings,
-    *,
-    contract: dict,
+    root: str, state: GrugMoeAutomaticPipelineState, shardings, *, contract: dict
 ) -> tuple[GrugMoeAutomaticPipelineState, int]:
-    """Restore the newest committed step, or return fresh state for an empty root.
+    """Resume only when the saved training configuration matches this run."""
+    expected = json.loads(json.dumps(contract))
 
-    The compiled step supplies the exact MPMD placement. Model configuration,
-    schedule, and process topology must match the saved checkpoint.
-    """
-    latest_path = StoragePath(prefix_join(root, _LATEST_FILE))
-    latest = None
-    if latest_path.exists():
-        latest = json.loads(latest_path.read_text())
-        metadata_path = StoragePath(root) / latest["checkpoint"] / _METADATA_FILE
-    else:
-        # Recover a fully written first checkpoint if publication of latest.json
-        # was interrupted. Normal resumes need no checkpoint-directory listing.
-        checkpoints = (StoragePath(root) / "step-*" / _METADATA_FILE).glob()
-        if not checkpoints:
-            return state, 0
-        metadata_path = max(checkpoints, key=str)
-    metadata = json.loads(metadata_path.read_text())
-    if latest is not None and latest["step"] != metadata["step"]:
-        raise ValueError(f"Checkpoint step disagrees with latest.json: {metadata_path}")
-    arrays = checkpoint_arrays(state)
-    expected = json.loads(json.dumps({"contract": contract, "arrays": _array_layout(arrays)}))
-    if metadata["version"] != _FORMAT_VERSION or any(metadata[key] != value for key, value in expected.items()):
-        raise ValueError(f"Checkpoint configuration or topology does not match: {metadata_path}")
-    path = str(metadata_path.parent)
-    # Levanter's reader expects at least one addressable shard per input array.
-    # Other stages remain empty descriptors and never enter the read plan.
-    local_arrays = jax.tree.map(
-        lambda value: (
-            jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=value.sharding)
-            if value.sharding.addressable_devices
-            else None
-        ),
-        arrays,
-    )
-    restored = tree_deserialize_leaves_tensorstore(
-        path,
-        local_arrays,
-        # Avoid restore collectives across processes that do not own this stage.
-        read_config=TensorStoreReadConfig(replica_mode=ReplicaRestoreMode.EVERY_REPLICA),
-    )
-    restored = jax.tree.map(
-        lambda original, loaded: original if loaded is None else loaded,
-        arrays,
-        restored,
-        is_leaf=lambda value: value is None,
-    )
+    def validate_metadata(metadata: dict) -> None:
+        if metadata != expected:
+            raise ValueError("Checkpoint training configuration does not match")
 
-    def wrap(value, target):
-        if isinstance(target, NamedSharding):
-            return value
-        pp, _ = _jaxpp_modules()
-        buffers = {shard.device: shard.data for shard in value.addressable_shards}
-        local_arrays = []
-        for mesh_id in sorted(target.mesh_ids):
-            sharding = NamedSharding(target.mpmd_mesh.unstack[mesh_id], target.spec)
-            if sharding.addressable_devices:
-                local_arrays.append(
-                    jax.make_array_from_single_device_arrays(
-                        value.shape,
-                        sharding,
-                        [buffers[device] for device in sharding.mesh.devices.flat if device in buffers],
-                        dtype=value.dtype,
-                    )
-                )
-        return pp.MpmdArray(local_arrays, target, shape=value.shape, dtype=value.dtype)
-
-    return jax.tree.map(wrap, restored, shardings), int(metadata["step"])
+    return mpmd_checkpoint.restore_checkpoint(root, state, shardings, validate_metadata=validate_metadata)

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -72,6 +72,8 @@ def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: in
     def commit():
         with atomic_rename(prefix_join(path, "metadata.json")) as temporary_path:
             StoragePath(temporary_path).write_text(json.dumps(metadata, sort_keys=True))
+        with atomic_rename(prefix_join(root, "latest.json")) as temporary_path:
+            StoragePath(temporary_path).write_text(json.dumps({"checkpoint": StoragePath(path).name, "step": step}))
 
     tree_serialize_leaves_tensorstore(path, arrays, commit_callback=commit)
     return path
@@ -89,19 +91,36 @@ def restore_checkpoint(
     The compiled step supplies the exact MPMD placement. Model configuration,
     schedule, and process topology must match the saved checkpoint.
     """
-    checkpoints = StoragePath(prefix_join(root, "step-*/metadata.json")).glob()
-    if not checkpoints:
-        return state, 0
-    metadata_path = max(checkpoints, key=str)
+    latest_path = StoragePath(prefix_join(root, "latest.json"))
+    latest = None
+    if latest_path.exists():
+        latest = json.loads(latest_path.read_text())
+        metadata_path = StoragePath(root) / latest["checkpoint"] / "metadata.json"
+    else:
+        # Recover a fully written first checkpoint if publication of latest.json
+        # was interrupted. Normal resumes need no checkpoint-directory listing.
+        checkpoints = StoragePath(prefix_join(root, "step-*/metadata.json")).glob()
+        if not checkpoints:
+            return state, 0
+        metadata_path = max(checkpoints, key=str)
     metadata = json.loads(metadata_path.read_text())
+    if latest is not None and latest["step"] != metadata["step"]:
+        raise ValueError(f"Checkpoint step disagrees with latest.json: {metadata_path}")
     arrays = checkpoint_arrays(state)
     expected = json.loads(json.dumps({"contract": contract, "arrays": _array_layout(arrays)}))
     if metadata["version"] != _FORMAT_VERSION or any(metadata[key] != value for key, value in expected.items()):
         raise ValueError(f"Checkpoint configuration or topology does not match: {metadata_path}")
-    path = str(metadata_path).rsplit("/", 1)[0]
+    path = str(metadata_path.parent)
     # Levanter's reader expects at least one addressable shard per input array.
     # Other stages remain empty descriptors and never enter the read plan.
-    local_arrays = jax.tree.map(lambda value: value if value.addressable_shards else None, arrays)
+    local_arrays = jax.tree.map(
+        lambda value: (
+            jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=value.sharding)
+            if value.sharding.addressable_devices
+            else None
+        ),
+        arrays,
+    )
     restored = tree_deserialize_leaves_tensorstore(
         path,
         local_arrays,

--- a/experiments/grug/moe_pipeline/checkpoint.py
+++ b/experiments/grug/moe_pipeline/checkpoint.py
@@ -1,28 +1,163 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Training-configuration checks for Grug pipeline checkpoints."""
+"""Canonical model and optimizer checkpoints shared by FSDP and pipeline training."""
 
 import json
+import uuid
+from dataclasses import dataclass, replace
 
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from jax.experimental import multihost_utils
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from levanter import mpmd_checkpoint
+from levanter.checkpoint import discover_checkpoint_candidates
+from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
+from rigging.filesystem.storage_path import prefix_join
 
-from experiments.grug.moe_pipeline.pipeline import GrugMoeAutomaticPipelineState
+from experiments.grug.moe_pipeline.model import Transformer
+from experiments.grug.moe_pipeline.pipeline import (
+    GrugMoeAutomaticPipelineState,
+    GrugMoePipelineStage,
+    split_transformer,
+)
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class GrugMoeCheckpointState:
+    """Unsplit trainable model, optimizer, and one pending router update per layer.
+
+    FSDP can save or load this tree with ordinary Levanter checkpoint APIs.
+    Router biases are excluded from params and optimizer moments; the pending
+    updates supply them at the beginning of the next training step.
+    """
+
+    params: Transformer
+    opt_state: optax.OptState
+    pending_qb_betas: tuple[jax.Array, ...]
+
+
+def _merge_stages(stages: tuple[GrugMoePipelineStage, ...]) -> Transformer:
+    return Transformer(
+        token_embed=stages[0].token_embed,
+        embed_norm=stages[0].embed_norm,
+        embed_gated_norm=stages[0].embed_gated_norm,
+        output_proj=stages[-1].output_proj,
+        blocks=tuple(block for stage in stages for block in stage.blocks),
+        final_norm=stages[-1].final_norm,
+        final_gated_norm=stages[-1].final_gated_norm,
+        config=stages[0].config,
+    )
+
+
+def _unstack_pending(value: jax.Array) -> tuple[jax.Array, ...]:
+    # The small router-update matrix is replicated within each stage. Slice
+    # its single-device buffers so nonowning processes perform no JAX work.
+    spec = (*value.sharding.spec, None, None)
+    assert spec[0] is None
+    sharding = NamedSharding(value.sharding.mesh, P(spec[1]))
+    return tuple(
+        jax.make_array_from_single_device_arrays(
+            value.shape[1:], sharding, [shard.data[i] for shard in value.addressable_shards], dtype=value.dtype
+        )
+        for i in range(value.shape[0])
+    )
+
+
+def _stack_pending(values: tuple[jax.Array, ...], sharding: NamedSharding) -> jax.Array:
+    buffers = [{shard.device: shard.data for shard in value.addressable_shards} for value in values]
+    return jax.make_array_from_single_device_arrays(
+        (len(values), *values[0].shape),
+        sharding,
+        [
+            jnp.stack([buffer[device] for buffer in buffers])
+            for device in sharding.mesh.devices.flat
+            if device in buffers[0]
+        ],
+        dtype=values[0].dtype,
+    )
+
+
+def checkpoint_state(state: GrugMoeAutomaticPipelineState) -> GrugMoeCheckpointState:
+    """Assemble stage-local buffers under global model and optimizer paths."""
+    arrays = mpmd_checkpoint.checkpoint_arrays(state)
+    optimizer = jax.tree.map(
+        lambda *values: _merge_stages(values) if isinstance(values[0], GrugMoePipelineStage) else values[0],
+        *arrays.opt_state,
+        is_leaf=lambda value: isinstance(value, GrugMoePipelineStage),
+    )
+    return GrugMoeCheckpointState(
+        params=_merge_stages(arrays.trainable_params),
+        opt_state=optimizer,
+        pending_qb_betas=tuple(beta for stage in arrays.pending_qb_betas for beta in _unstack_pending(stage)),
+    )
+
+
+def _pipeline_state(
+    canonical: GrugMoeCheckpointState, exemplar: GrugMoeAutomaticPipelineState
+) -> GrugMoeAutomaticPipelineState:
+    layer_counts = tuple(len(stage.blocks) for stage in exemplar.trainable_params)
+    stages = len(layer_counts)
+    params = split_transformer(canonical.params, stages, layer_counts=layer_counts)
+    optimizer = tuple(
+        jax.tree.map(
+            lambda value, index=index: (
+                split_transformer(value, stages, layer_counts=layer_counts)[index]
+                if isinstance(value, Transformer)
+                else value
+            ),
+            canonical.opt_state,
+            is_leaf=lambda value: isinstance(value, Transformer),
+        )
+        for index in range(stages)
+    )
+    pending = tuple(
+        _stack_pending(canonical.pending_qb_betas[stage.start_layer : stage.end_layer], target.sharding)
+        for stage, target in zip(params, exemplar.pending_qb_betas, strict=True)
+    )
+    return GrugMoeAutomaticPipelineState(params, optimizer, pending)
 
 
 def save_checkpoint(root: str, state: GrugMoeAutomaticPipelineState, *, step: int, contract: dict) -> str:
-    """Save pipeline state and the training configuration required to resume it."""
-    return mpmd_checkpoint.save_checkpoint(root, state, step=step, metadata=contract)
+    """Save canonical state with ordinary Levanter checkpoint publication."""
+    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
+    path = f"step-{step:012d}-{bytes(identifier).hex()}"
+    path = prefix_join(root, path)
+    return save_levanter_checkpoint(checkpoint_state(state), step, path, metadata={"training_config": contract})
 
 
 def restore_checkpoint(
     root: str, state: GrugMoeAutomaticPipelineState, shardings, *, contract: dict
 ) -> tuple[GrugMoeAutomaticPipelineState, int]:
-    """Resume only when the saved training configuration matches this run."""
-    expected = json.loads(json.dumps(contract))
-
-    def validate_metadata(metadata: dict) -> None:
-        if metadata != expected:
-            raise ValueError("Checkpoint training configuration does not match")
-
-    return mpmd_checkpoint.restore_checkpoint(root, state, shardings, validate_metadata=validate_metadata)
+    """Load an FSDP or PP checkpoint into the destination pipeline partition."""
+    candidates = discover_checkpoint_candidates(root)
+    if not candidates:
+        return state, 0
+    checkpoint = candidates[-1]
+    saved_config = checkpoint.metadata.get("training_config")
+    if saved_config is not None and saved_config != json.loads(json.dumps(contract)):
+        raise ValueError("Checkpoint training configuration does not match")
+    arrays = mpmd_checkpoint.checkpoint_arrays(state)
+    canonical = checkpoint_state(arrays)
+    # A single optimizer counter becomes a copy on every destination stage.
+    # Reading these scalars on all devices avoids gathering any model tensors.
+    scalar_sharding = NamedSharding(Mesh(np.array(jax.devices()), ("checkpoint",)), P())
+    canonical = replace(
+        canonical,
+        opt_state=jax.tree.map(
+            lambda value: (
+                jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=scalar_sharding) if value.shape == () else value
+            ),
+            canonical.opt_state,
+        ),
+    )
+    loaded = mpmd_checkpoint.restore_checkpoint(
+        canonical, checkpoint.path, jax.tree.map(lambda value: value.sharding, canonical)
+    )
+    restored = _pipeline_state(loaded, arrays)
+    return mpmd_checkpoint.wrap_checkpoint_arrays(restored, shardings), checkpoint.step

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -44,6 +44,7 @@ from experiments.grug.moe_pipeline.pipeline import (
 
 _RELATIVE_L2_TOLERANCE = 0.002
 _BATCH_SIZE = 128
+_FINGERPRINT_FILE = "fingerprint.json"
 
 
 def _assert_optimizer_counts(state, completed_steps: int) -> None:
@@ -289,7 +290,7 @@ def main() -> None:
         save(resume_root, state, 1)
         fingerprint = _fingerprint(state)
         if jax.process_index() == 0:
-            (StoragePath(args.checkpoint_root) / "fingerprint.json").write_text(json.dumps(fingerprint))
+            (StoragePath(args.checkpoint_root) / _FINGERPRINT_FILE).write_text(json.dumps(fingerprint))
         state, metrics = step(state, batches, denominator)
         _assert_optimizer_counts(state, 2)
         save(expected_root, state, 2)
@@ -301,7 +302,7 @@ def main() -> None:
     state, completed = restore(resume_root, state)
     assert completed == 1, f"expected checkpoint step 1, got {completed}"
     _assert_optimizer_counts(state, completed)
-    expected_fingerprint = json.loads((StoragePath(args.checkpoint_root) / "fingerprint.json").read_text())
+    expected_fingerprint = json.loads((StoragePath(args.checkpoint_root) / _FINGERPRINT_FILE).read_text())
     assert _fingerprint(state) == expected_fingerprint, "restored tensor bytes differ"
     print(f"CHECKPOINT_BYTES_PASSED mode={args.mode}", flush=True)
     if args.restore_only:

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -5,7 +5,9 @@
 
 import argparse
 import json
+from dataclasses import replace
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jmp
@@ -13,14 +15,16 @@ import numpy as np
 import optax
 from iris.runtime.jax_init import initialize_jax
 from jax.experimental import multihost_utils
-from jax.sharding import NamedSharding
+from jax.sharding import AxisType, Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
+from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
+from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
 from levanter.data.text.examples import GrugLmExample
 from levanter.mpmd_checkpoint import checkpoint_arrays
 from levanter.pipeline import reshape_batch_into_microbatches
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
-from experiments.grug.moe_pipeline.checkpoint import restore_checkpoint, save_checkpoint
+from experiments.grug.moe_pipeline.checkpoint import GrugMoeCheckpointState, restore_checkpoint, save_checkpoint
 from experiments.grug.moe_pipeline.model import BATCH_AXES, GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     TRAIN_LOSS_KEY,
@@ -37,8 +41,11 @@ _RELATIVE_L2_TOLERANCE = 0.002
 
 
 def _assert_optimizer_counts(state, completed_steps: int) -> None:
-    for stage_optimizer in state.opt_state:
-        count = stage_optimizer[0].count.to_mpmd_local_array
+    optimizers = (state.opt_state,) if isinstance(state, GrugMoeCheckpointState) else state.opt_state
+    for stage_optimizer in optimizers:
+        count = stage_optimizer[0].count
+        if not isinstance(count, jax.Array):
+            count = count.to_mpmd_local_array
         if count is not None:
             assert int(count) == completed_steps, (int(count), completed_steps)
 
@@ -68,9 +75,60 @@ def _compare(actual, expected) -> float:
     return float(relative.max())
 
 
+def _fsdp_step(optimizer, policy, mesh):
+    @jax.jit
+    def step(state, batches, denominator):
+        def loss_fn(params, batch):
+            for index, beta in enumerate(state.pending_qb_betas):
+                params = eqx.tree_at(
+                    lambda model, index=index: model.blocks[index].mlp.router_bias,
+                    params,
+                    -beta + jnp.mean(beta),
+                    is_leaf=lambda value: value is None,
+                )
+            return policy.cast_to_compute(params).next_token_loss(
+                batch.tokens, batch.loss_weight, return_router_metrics=True
+            )
+
+        gradients = jax.tree.map(jnp.zeros_like, state.params)
+        pending = tuple(jnp.zeros_like(beta) for beta in state.pending_qb_betas)
+        loss = jnp.array(0.0)
+        for index in range(batches.tokens.shape[0]):
+            batch = jax.tree.map(lambda value, index=index: value[index], batches)
+            (batch_loss, metrics), batch_gradients = jax.value_and_grad(loss_fn, has_aux=True)(state.params, batch)
+            gradients = jax.tree.map(jnp.add, gradients, batch_gradients)
+            pending = tuple(beta + update for beta, update in zip(pending, metrics["qb_beta_per_layer"], strict=True))
+            loss += batch_loss
+        microbatches = batches.tokens.shape[0]
+        gradients = jax.tree.map(lambda value: value / microbatches, gradients)
+        updates, opt_state = optimizer.update(gradients, state.opt_state, state.params)
+        return replace(
+            state,
+            params=eqx.apply_updates(state.params, updates),
+            opt_state=opt_state,
+            pending_qb_betas=tuple(beta / microbatches for beta in pending),
+        ), {TRAIN_LOSS_KEY: loss / microbatches}
+
+    def run(state, batches, denominator):
+        with jax.set_mesh(mesh):
+            return step(state, batches, denominator)
+
+    return run
+
+
+def _global_loss(value) -> float:
+    if not isinstance(value, jax.Array):
+        value = value.to_mpmd_local_array
+    local = np.nan if value is None else float(value)
+    losses = np.asarray(multihost_utils.process_allgather(np.array(local)))
+    return float(losses[np.isfinite(losses)][0])
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--checkpoint-root", required=True)
+    parser.add_argument("--mode", choices=("fsdp", "pp"), default="pp")
+    parser.add_argument("--dtype", choices=("float32", "bfloat16"), default="bfloat16")
     parser.add_argument(
         "--schedule", type=AutomaticPipelineSchedule, choices=list(AutomaticPipelineSchedule), required=True
     )
@@ -83,7 +141,14 @@ def main() -> None:
     config = GrugMoePipelineConfig(
         stages=stages, physical_stages=physical_stages if stages == 4 else None, microbatches=4
     )
-    mesh, mpmd_mesh = make_pipeline_mesh(config, expert_axis_size=8, replica_axis_size=2)
+    if args.mode == "pp":
+        mesh, mpmd_mesh = make_pipeline_mesh(config, expert_axis_size=8, replica_axis_size=2)
+    else:
+        mesh = Mesh(
+            np.array(jax.devices()).reshape(1, 4, 8, 1),
+            (*BATCH_AXES, "model"),
+            axis_types=(AxisType.Explicit,) * 4,
+        )
     model_config = GrugModelConfig(
         vocab_size=256,
         hidden_dim=128,
@@ -100,66 +165,91 @@ def main() -> None:
         moe_implementation="ring",
     )
     optimizer = optax.adamw(1e-4, b1=0.9, b2=0.95, weight_decay=0.1)
-    policy = jmp.get_policy("params=bfloat16,compute=bfloat16,output=bfloat16")
+    policy = jmp.get_policy(f"params={args.dtype},compute={args.dtype},output={args.dtype}")
     with jax.set_mesh(mesh):
         model = policy.cast_to_param(Transformer.init(model_config, key=jax.random.PRNGKey(0)))
-        state, static = initialize_mpmd_automatic_pipeline_state(
-            model,
-            optimizer,
-            mpmd_mesh,
-            num_stages=stages,
-            stage_to_mpmd_index=automatic_stage_to_mpmd_indices(config, args.schedule),
-        )
-        tokens = np.arange(64 * 16, dtype=np.int32).reshape(64, 16) % 256
-        weights = np.ones((64, 16), dtype=np.float32)
+        if args.mode == "pp":
+            state, static = initialize_mpmd_automatic_pipeline_state(
+                model,
+                optimizer,
+                mpmd_mesh,
+                num_stages=stages,
+                stage_to_mpmd_index=automatic_stage_to_mpmd_indices(config, args.schedule),
+            )
+        else:
+            for index in range(model_config.num_layers):
+                model = eqx.tree_at(lambda value, index=index: value.blocks[index].mlp.router_bias, model, None)
+            state = GrugMoeCheckpointState(
+                model,
+                optimizer.init(model),
+                tuple(jnp.zeros((model_config.num_experts,)) for _ in model.blocks),
+            )
+        tokens = np.arange(128 * 16, dtype=np.int32).reshape(128, 16) % 256
+        weights = np.ones((128, 16), dtype=np.float32)
         weights[:, -1] = 0
         sharding = NamedSharding(mesh, P(BATCH_AXES, None))
         batch = GrugLmExample(tokens=jax.device_put(tokens, sharding), loss_weight=jax.device_put(weights, sharding))
         denominator = jnp.sum(batch.loss_weight)
         batches = reshape_batch_into_microbatches(batch, config.microbatches)
-    step = make_automatic_pipeline_step(
-        optimizer,
-        policy,
-        static,
-        state,
-        batches,
-        config=config,
-        mpmd_mesh=mpmd_mesh,
-        schedule_name=args.schedule,
-    )
-    prepared = prepare_automatic_mpmd_step(step, state, batches, denominator, mpmd_mesh)
-    step, state = prepared.step, prepared.state
-    shardings = step.in_shardings[0][0]
-    contract = {"schedule": args.schedule, "shape": "reduced-h128-l4-e16-pp2-ep8-replica2-v1"}
+    if args.mode == "pp":
+        step = make_automatic_pipeline_step(
+            optimizer,
+            policy,
+            static,
+            state,
+            batches,
+            config=config,
+            mpmd_mesh=mpmd_mesh,
+            schedule_name=args.schedule,
+        )
+        prepared = prepare_automatic_mpmd_step(step, state, batches, denominator, mpmd_mesh)
+        step, state = prepared.step, prepared.state
+        batches, denominator = prepared.batches, prepared.loss_denominator
+        shardings = step.in_shardings[0][0]
+    else:
+        step = _fsdp_step(optimizer, policy, mesh)
+    contract = {"shape": "reduced-h128-l4-e16-v1"}
     resume_root = prefix_join(args.checkpoint_root, "resume")
     expected_root = prefix_join(args.checkpoint_root, "expected")
-    loss_path = StoragePath(prefix_join(args.checkpoint_root, f"loss-{jax.process_index()}.json"))
+    loss_path = StoragePath(prefix_join(args.checkpoint_root, "loss.json"))
+
+    def save(root, value, completed):
+        if args.mode == "pp":
+            return save_checkpoint(root, value, step=completed, contract=contract)
+        return save_levanter_checkpoint(value, completed, prefix_join(root, f"step-{completed}"))
+
+    def restore(root, value):
+        if args.mode == "pp":
+            return restore_checkpoint(root, value, shardings, contract=contract)
+        path = latest_checkpoint_path(root)
+        metadata = json.loads((StoragePath(path) / "metadata.json").read_text())
+        return load_checkpoint(value, path), metadata["step"]
+
     if args.phase == "save":
-        state, _ = step(state, prepared.batches, prepared.loss_denominator)
+        state, _ = step(state, batches, denominator)
         _assert_optimizer_counts(state, 1)
-        save_checkpoint(resume_root, state, step=1, contract=contract)
-        state, metrics = step(state, prepared.batches, prepared.loss_denominator)
+        save(resume_root, state, 1)
+        state, metrics = step(state, batches, denominator)
         _assert_optimizer_counts(state, 2)
-        save_checkpoint(expected_root, state, step=2, contract=contract)
-        loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
-        if loss is not None:
-            loss_path.write_text(json.dumps(float(loss)))
+        save(expected_root, state, 2)
+        loss = _global_loss(metrics[TRAIN_LOSS_KEY])
+        if jax.process_index() == 0:
+            loss_path.write_text(json.dumps(loss))
         print("CHECKPOINT_SMOKE_SAVED", flush=True)
         return
-    state, completed = restore_checkpoint(resume_root, state, shardings, contract=contract)
+    state, completed = restore(resume_root, state)
     assert completed == 1, f"expected checkpoint step 1, got {completed}"
     _assert_optimizer_counts(state, completed)
-    state, metrics = step(state, prepared.batches, prepared.loss_denominator)
-    expected, expected_step = restore_checkpoint(expected_root, state, shardings, contract=contract)
+    state, metrics = step(state, batches, denominator)
+    expected, expected_step = restore(expected_root, state)
     assert completed + 1 == expected_step == 2
     _assert_optimizer_counts(state, expected_step)
     _assert_optimizer_counts(expected, expected_step)
     maximum_error = _compare(state, expected)
-    loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
-    if loss is not None:
-        expected_loss = json.loads(loss_path.read_text())
-        loss_error = abs(float(loss) - expected_loss) / max(abs(expected_loss), np.finfo(float).tiny)
-        assert loss_error <= _RELATIVE_L2_TOLERANCE, (float(loss), expected_loss, loss_error)
+    loss = _global_loss(metrics[TRAIN_LOSS_KEY])
+    expected_loss = json.loads(loss_path.read_text())
+    loss_error = abs(loss - expected_loss) / max(abs(expected_loss), np.finfo(float).tiny)
+    assert loss_error <= _RELATIVE_L2_TOLERANCE, (loss, expected_loss, loss_error)
     print(f"CHECKPOINT_SMOKE_PASSED schedule={args.schedule} max_relative_l2={maximum_error}", flush=True)
 
 

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -16,10 +16,11 @@ from jax.experimental import multihost_utils
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from levanter.data.text.examples import GrugLmExample
+from levanter.mpmd_checkpoint import checkpoint_arrays
 from levanter.pipeline import reshape_batch_into_microbatches
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
-from experiments.grug.moe_pipeline.checkpoint import checkpoint_arrays, restore_checkpoint, save_checkpoint
+from experiments.grug.moe_pipeline.checkpoint import restore_checkpoint, save_checkpoint
 from experiments.grug.moe_pipeline.model import BATCH_AXES, GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     TRAIN_LOSS_KEY,

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -24,7 +24,12 @@ from levanter.mpmd_checkpoint import checkpoint_arrays
 from levanter.pipeline import reshape_batch_into_microbatches
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
-from experiments.grug.moe_pipeline.checkpoint import GrugMoeCheckpointState, restore_checkpoint, save_checkpoint
+from experiments.grug.moe_pipeline.checkpoint import (
+    GrugMoeCheckpointState,
+    checkpoint_state,
+    restore_checkpoint,
+    save_checkpoint,
+)
 from experiments.grug.moe_pipeline.model import BATCH_AXES, GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     TRAIN_LOSS_KEY,
@@ -38,6 +43,7 @@ from experiments.grug.moe_pipeline.pipeline import (
 )
 
 _RELATIVE_L2_TOLERANCE = 0.002
+_BATCH_SIZE = 128
 
 
 def _assert_optimizer_counts(state, completed_steps: int) -> None:
@@ -86,9 +92,14 @@ def _fsdp_step(optimizer, policy, mesh):
                     -beta + jnp.mean(beta),
                     is_leaf=lambda value: value is None,
                 )
-            return policy.cast_to_compute(params).next_token_loss(
+            _, metrics = policy.cast_to_compute(params).next_token_loss(
                 batch.tokens, batch.loss_weight, return_router_metrics=True
             )
+            loss = (
+                metrics["train/cross_entropy_loss"] * jnp.sum(batch.loss_weight) / denominator
+                + metrics["train/router/aux_loss_weighted"] / batches.tokens.shape[0]
+            )
+            return loss, metrics
 
         gradients = jax.tree.map(jnp.zeros_like, state.params)
         pending = tuple(jnp.zeros_like(beta) for beta in state.pending_qb_betas)
@@ -100,14 +111,13 @@ def _fsdp_step(optimizer, policy, mesh):
             pending = tuple(beta + update for beta, update in zip(pending, metrics["qb_beta_per_layer"], strict=True))
             loss += batch_loss
         microbatches = batches.tokens.shape[0]
-        gradients = jax.tree.map(lambda value: value / microbatches, gradients)
         updates, opt_state = optimizer.update(gradients, state.opt_state, state.params)
         return replace(
             state,
             params=eqx.apply_updates(state.params, updates),
             opt_state=opt_state,
             pending_qb_betas=tuple(beta / microbatches for beta in pending),
-        ), {TRAIN_LOSS_KEY: loss / microbatches}
+        ), {TRAIN_LOSS_KEY: loss}
 
     def run(state, batches, denominator):
         with jax.set_mesh(mesh):
@@ -124,10 +134,53 @@ def _global_loss(value) -> float:
     return float(losses[np.isfinite(losses)][0])
 
 
+def _fingerprint(state) -> list[list[int]]:
+    """Compute partition-independent, byte-sensitive checksums of canonical leaves."""
+    canonical = state if isinstance(state, GrugMoeCheckpointState) else checkpoint_state(state)
+    checks = []
+    for value in jax.tree.leaves(canonical):
+        checksum = np.zeros(2, dtype=np.uint64)
+        for shard in value.addressable_shards:
+            if shard.replica_id != 0:
+                continue
+            data = np.asarray(shard.data)
+            indices = np.zeros(data.shape, dtype=np.uint64)
+            stride = 1
+            for axis in reversed(range(data.ndim)):
+                section = shard.index[axis]
+                coords = np.arange(*section.indices(value.shape[axis]), dtype=np.uint64)
+                shape = [1] * data.ndim
+                shape[axis] = len(coords)
+                indices += coords.reshape(shape) * np.uint64(stride)
+                stride *= value.shape[axis]
+            byte_indices = indices[..., None] * np.uint64(data.dtype.itemsize) + np.arange(
+                data.dtype.itemsize, dtype=np.uint64
+            )
+            bits = (
+                np.ascontiguousarray(data)
+                .reshape(-1)
+                .view(np.uint8)
+                .reshape((*data.shape, data.dtype.itemsize))
+                .astype(np.uint64)
+            )
+            weights = byte_indices + np.uint64(1)
+            checksum += np.array(
+                [np.sum(bits * weights, dtype=np.uint64), np.sum(bits * weights * weights, dtype=np.uint64)],
+                dtype=np.uint64,
+            )
+        checks.append(checksum)
+    words = np.asarray(checks).view(np.uint32)
+    gathered = np.asarray(multihost_utils.process_allgather(words)).reshape(-1, len(checks), 4).copy()
+    return gathered.view(np.uint64).sum(axis=0, dtype=np.uint64).tolist()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--checkpoint-root", required=True)
     parser.add_argument("--mode", choices=("fsdp", "pp"), default="pp")
+    parser.add_argument("--fsdp-devices", type=int, choices=(16, 32), default=32)
+    parser.add_argument("--restore-only", action="store_true")
+    parser.add_argument("--compare-state", action="store_true")
     parser.add_argument("--dtype", choices=("float32", "bfloat16"), default="bfloat16")
     parser.add_argument(
         "--schedule", type=AutomaticPipelineSchedule, choices=list(AutomaticPipelineSchedule), required=True
@@ -145,7 +198,7 @@ def main() -> None:
         mesh, mpmd_mesh = make_pipeline_mesh(config, expert_axis_size=8, replica_axis_size=2)
     else:
         mesh = Mesh(
-            np.array(jax.devices()).reshape(1, 4, 8, 1),
+            np.array(jax.devices()).reshape(4, 8)[:, : args.fsdp_devices // 4].reshape(1, args.fsdp_devices // 8, 8, 1),
             (*BATCH_AXES, "model"),
             axis_types=(AxisType.Explicit,) * 4,
         )
@@ -184,8 +237,13 @@ def main() -> None:
                 optimizer.init(model),
                 tuple(jnp.zeros((model_config.num_experts,)) for _ in model.blocks),
             )
-        tokens = np.arange(128 * 16, dtype=np.int32).reshape(128, 16) % 256
-        weights = np.ones((128, 16), dtype=np.float32)
+        tokens = (
+            np.arange(_BATCH_SIZE * model_config.max_seq_len, dtype=np.int32).reshape(
+                _BATCH_SIZE, model_config.max_seq_len
+            )
+            % model_config.vocab_size
+        )
+        weights = np.ones_like(tokens, dtype=np.float32)
         weights[:, -1] = 0
         sharding = NamedSharding(mesh, P(BATCH_AXES, None))
         batch = GrugLmExample(tokens=jax.device_put(tokens, sharding), loss_weight=jax.device_put(weights, sharding))
@@ -229,6 +287,9 @@ def main() -> None:
         state, _ = step(state, batches, denominator)
         _assert_optimizer_counts(state, 1)
         save(resume_root, state, 1)
+        fingerprint = _fingerprint(state)
+        if jax.process_index() == 0:
+            (StoragePath(args.checkpoint_root) / "fingerprint.json").write_text(json.dumps(fingerprint))
         state, metrics = step(state, batches, denominator)
         _assert_optimizer_counts(state, 2)
         save(expected_root, state, 2)
@@ -240,17 +301,29 @@ def main() -> None:
     state, completed = restore(resume_root, state)
     assert completed == 1, f"expected checkpoint step 1, got {completed}"
     _assert_optimizer_counts(state, completed)
+    expected_fingerprint = json.loads((StoragePath(args.checkpoint_root) / "fingerprint.json").read_text())
+    assert _fingerprint(state) == expected_fingerprint, "restored tensor bytes differ"
+    print(f"CHECKPOINT_BYTES_PASSED mode={args.mode}", flush=True)
+    if args.restore_only:
+        return
     state, metrics = step(state, batches, denominator)
-    expected, expected_step = restore(expected_root, state)
-    assert completed + 1 == expected_step == 2
-    _assert_optimizer_counts(state, expected_step)
-    _assert_optimizer_counts(expected, expected_step)
-    maximum_error = _compare(state, expected)
+    _assert_optimizer_counts(state, completed + 1)
     loss = _global_loss(metrics[TRAIN_LOSS_KEY])
     expected_loss = json.loads(loss_path.read_text())
     loss_error = abs(loss - expected_loss) / max(abs(expected_loss), np.finfo(float).tiny)
     assert loss_error <= _RELATIVE_L2_TOLERANCE, (loss, expected_loss, loss_error)
-    print(f"CHECKPOINT_SMOKE_PASSED schedule={args.schedule} max_relative_l2={maximum_error}", flush=True)
+    print(
+        f"CHECKPOINT_LOSS_PASSED mode={args.mode} schedule={args.schedule} "
+        f"loss={loss} expected_loss={expected_loss} relative_error={loss_error}",
+        flush=True,
+    )
+    if args.compare_state:
+        expected, expected_step = restore(expected_root, state)
+        assert completed + 1 == expected_step == 2
+        _assert_optimizer_counts(expected, expected_step)
+        maximum_error = _compare(state, expected)
+        print(f"CHECKPOINT_STATE_PASSED max_relative_l2={maximum_error}", flush=True)
+    print("CHECKPOINT_SMOKE_PASSED", flush=True)
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -1,0 +1,151 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reduced multi-process checkpoint parity test; run save then resume in fresh gangs."""
+
+import argparse
+import json
+
+import jax
+import jax.numpy as jnp
+import jmp
+import numpy as np
+import optax
+from iris.runtime.jax_init import initialize_jax
+from jax.experimental import multihost_utils
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from levanter.data.text.examples import GrugLmExample
+from levanter.pipeline import reshape_batch_into_microbatches
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+
+from experiments.grug.moe_pipeline.checkpoint import checkpoint_arrays, restore_checkpoint, save_checkpoint
+from experiments.grug.moe_pipeline.model import BATCH_AXES, GrugModelConfig, Transformer
+from experiments.grug.moe_pipeline.pipeline import (
+    TRAIN_LOSS_KEY,
+    AutomaticPipelineSchedule,
+    GrugMoePipelineConfig,
+    automatic_stage_to_mpmd_indices,
+    initialize_mpmd_automatic_pipeline_state,
+    make_automatic_pipeline_step,
+    make_pipeline_mesh,
+    prepare_automatic_mpmd_step,
+)
+
+
+def _compare(actual, expected) -> float:
+    actual_leaves, actual_tree = jax.tree.flatten(checkpoint_arrays(actual))
+    expected_leaves, expected_tree = jax.tree.flatten(checkpoint_arrays(expected))
+    assert actual_tree == expected_tree
+    errors = []
+    for value, reference in zip(actual_leaves, expected_leaves, strict=True):
+        error = np.zeros(3, dtype=np.float64)
+        for shard, expected_shard in zip(value.addressable_shards, reference.addressable_shards, strict=True):
+            observed = np.asarray(shard.data)
+            wanted = np.asarray(expected_shard.data)
+            if np.issubdtype(wanted.dtype, np.integer):
+                error[2] += np.count_nonzero(observed != wanted)
+            else:
+                difference = observed.astype(np.float64) - wanted.astype(np.float64)
+                error[0] += np.sum(difference**2)
+                error[1] += np.sum(wanted.astype(np.float64) ** 2)
+        errors.append(error)
+    totals = np.asarray(multihost_utils.process_allgather(np.asarray(errors))).reshape(-1, len(errors), 3).sum(axis=0)
+    assert np.all(totals[:, 2] == 0), "integer checkpoint state differs"
+    relative = np.sqrt(totals[:, 0] / np.maximum(totals[:, 1], np.finfo(np.float64).tiny))
+    assert np.all(relative <= 0.002), f"per-leaf relative L2 errors: {relative.tolist()}"
+    return float(relative.max())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint-root", required=True)
+    parser.add_argument(
+        "--schedule", type=AutomaticPipelineSchedule, choices=list(AutomaticPipelineSchedule), required=True
+    )
+    parser.add_argument("--phase", choices=("save", "resume"), required=True)
+    args = parser.parse_args()
+    initialize_jax()
+    assert jax.process_count() == 4 and jax.local_device_count() == 8, "requires four H100x8 processes"
+    physical_stages = 2
+    stages = 4 if args.schedule == AutomaticPipelineSchedule.DUALPIPE_V else 2
+    config = GrugMoePipelineConfig(
+        stages=stages, physical_stages=physical_stages if stages == 4 else None, microbatches=4
+    )
+    mesh, mpmd_mesh = make_pipeline_mesh(config, expert_axis_size=8, replica_axis_size=2)
+    model_config = GrugModelConfig(
+        vocab_size=256,
+        hidden_dim=128,
+        intermediate_dim=128,
+        shared_expert_intermediate_dim=128,
+        num_layers=4,
+        num_experts=16,
+        num_experts_per_token=2,
+        num_heads=1,
+        num_kv_heads=1,
+        max_seq_len=16,
+        sliding_window=16,
+        attention_implementation="reference",
+        moe_implementation="ring",
+    )
+    optimizer = optax.adamw(1e-4, b1=0.9, b2=0.95, weight_decay=0.1)
+    policy = jmp.get_policy("params=bfloat16,compute=bfloat16,output=bfloat16")
+    with jax.set_mesh(mesh):
+        model = policy.cast_to_param(Transformer.init(model_config, key=jax.random.PRNGKey(0)))
+        state, static = initialize_mpmd_automatic_pipeline_state(
+            model,
+            optimizer,
+            mpmd_mesh,
+            num_stages=stages,
+            stage_to_mpmd_index=automatic_stage_to_mpmd_indices(config, args.schedule),
+        )
+        tokens = np.arange(64 * 16, dtype=np.int32).reshape(64, 16) % 256
+        weights = np.ones((64, 16), dtype=np.float32)
+        weights[:, -1] = 0
+        sharding = NamedSharding(mesh, P(BATCH_AXES, None))
+        batch = GrugLmExample(tokens=jax.device_put(tokens, sharding), loss_weight=jax.device_put(weights, sharding))
+        denominator = jnp.sum(batch.loss_weight)
+        batches = reshape_batch_into_microbatches(batch, config.microbatches)
+    step = make_automatic_pipeline_step(
+        optimizer,
+        policy,
+        static,
+        state,
+        batches,
+        config=config,
+        mpmd_mesh=mpmd_mesh,
+        schedule_name=args.schedule,
+    )
+    prepared = prepare_automatic_mpmd_step(step, state, batches, denominator, mpmd_mesh)
+    step, state = prepared.step, prepared.state
+    shardings = step.in_shardings[0][0]
+    contract = {"schedule": args.schedule, "shape": "reduced-h128-l4-e16-pp2-ep8-replica2-v1"}
+    resume_root = prefix_join(args.checkpoint_root, "resume")
+    expected_root = prefix_join(args.checkpoint_root, "expected")
+    loss_path = StoragePath(prefix_join(args.checkpoint_root, f"loss-{jax.process_index()}.json"))
+    if args.phase == "save":
+        state, _ = step(state, prepared.batches, prepared.loss_denominator)
+        save_checkpoint(resume_root, state, step=1, contract=contract)
+        state, metrics = step(state, prepared.batches, prepared.loss_denominator)
+        save_checkpoint(expected_root, state, step=2, contract=contract)
+        loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
+        if loss is not None:
+            loss_path.write_text(json.dumps(float(loss)))
+        print("CHECKPOINT_SMOKE_SAVED", flush=True)
+        return
+    state, completed = restore_checkpoint(resume_root, state, shardings, contract=contract)
+    assert completed == 1, f"expected checkpoint step 1, got {completed}"
+    state, metrics = step(state, prepared.batches, prepared.loss_denominator)
+    expected, expected_step = restore_checkpoint(expected_root, state, shardings, contract=contract)
+    assert completed + 1 == expected_step == 2
+    maximum_error = _compare(state, expected)
+    loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
+    if loss is not None:
+        expected_loss = json.loads(loss_path.read_text())
+        loss_error = abs(float(loss) - expected_loss) / max(abs(expected_loss), np.finfo(float).tiny)
+        assert loss_error <= 0.002, (float(loss), expected_loss, loss_error)
+    print(f"CHECKPOINT_SMOKE_PASSED schedule={args.schedule} max_relative_l2={maximum_error}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/moe_pipeline/checkpoint_smoke.py
+++ b/experiments/grug/moe_pipeline/checkpoint_smoke.py
@@ -32,8 +32,18 @@ from experiments.grug.moe_pipeline.pipeline import (
     prepare_automatic_mpmd_step,
 )
 
+_RELATIVE_L2_TOLERANCE = 0.002
+
+
+def _assert_optimizer_counts(state, completed_steps: int) -> None:
+    for stage_optimizer in state.opt_state:
+        count = stage_optimizer[0].count.to_mpmd_local_array
+        if count is not None:
+            assert int(count) == completed_steps, (int(count), completed_steps)
+
 
 def _compare(actual, expected) -> float:
+    """Assert continuation parity and return the largest floating-leaf relative L2 error."""
     actual_leaves, actual_tree = jax.tree.flatten(checkpoint_arrays(actual))
     expected_leaves, expected_tree = jax.tree.flatten(checkpoint_arrays(expected))
     assert actual_tree == expected_tree
@@ -53,7 +63,7 @@ def _compare(actual, expected) -> float:
     totals = np.asarray(multihost_utils.process_allgather(np.asarray(errors))).reshape(-1, len(errors), 3).sum(axis=0)
     assert np.all(totals[:, 2] == 0), "integer checkpoint state differs"
     relative = np.sqrt(totals[:, 0] / np.maximum(totals[:, 1], np.finfo(np.float64).tiny))
-    assert np.all(relative <= 0.002), f"per-leaf relative L2 errors: {relative.tolist()}"
+    assert np.all(relative <= _RELATIVE_L2_TOLERANCE), f"per-leaf relative L2 errors: {relative.tolist()}"
     return float(relative.max())
 
 
@@ -125,8 +135,10 @@ def main() -> None:
     loss_path = StoragePath(prefix_join(args.checkpoint_root, f"loss-{jax.process_index()}.json"))
     if args.phase == "save":
         state, _ = step(state, prepared.batches, prepared.loss_denominator)
+        _assert_optimizer_counts(state, 1)
         save_checkpoint(resume_root, state, step=1, contract=contract)
         state, metrics = step(state, prepared.batches, prepared.loss_denominator)
+        _assert_optimizer_counts(state, 2)
         save_checkpoint(expected_root, state, step=2, contract=contract)
         loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
         if loss is not None:
@@ -135,15 +147,18 @@ def main() -> None:
         return
     state, completed = restore_checkpoint(resume_root, state, shardings, contract=contract)
     assert completed == 1, f"expected checkpoint step 1, got {completed}"
+    _assert_optimizer_counts(state, completed)
     state, metrics = step(state, prepared.batches, prepared.loss_denominator)
     expected, expected_step = restore_checkpoint(expected_root, state, shardings, contract=contract)
     assert completed + 1 == expected_step == 2
+    _assert_optimizer_counts(state, expected_step)
+    _assert_optimizer_counts(expected, expected_step)
     maximum_error = _compare(state, expected)
     loss = metrics[TRAIN_LOSS_KEY].to_mpmd_local_array
     if loss is not None:
         expected_loss = json.loads(loss_path.read_text())
         loss_error = abs(float(loss) - expected_loss) / max(abs(expected_loss), np.finfo(float).tiny)
-        assert loss_error <= 0.002, (float(loss), expected_loss, loss_error)
+        assert loss_error <= _RELATIVE_L2_TOLERANCE, (float(loss), expected_loss, loss_error)
     print(f"CHECKPOINT_SMOKE_PASSED schedule={args.schedule} max_relative_l2={maximum_error}", flush=True)
 
 

--- a/experiments/grug/moe_pipeline/train.py
+++ b/experiments/grug/moe_pipeline/train.py
@@ -321,11 +321,13 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
     )
 
     profiler_callback = None
-    if config.profile_steps > 0:
+    profile_start_step = max(config.profile_start_step, start_step)
+    profile_end_step = min(config.profile_start_step + config.profile_steps, config.steps)
+    if config.profile_steps > 0 and profile_start_step < profile_end_step:
         profiler_callback = ProfilerConfig(
             enabled=True,
-            start_step=config.profile_start_step,
-            num_steps=config.profile_steps,
+            start_step=profile_start_step,
+            num_steps=profile_end_step - profile_start_step,
             perfetto_link=False,
             profile_options=ProfileOptionsConfig(
                 host_tracer_level=1,
@@ -336,7 +338,7 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
             "/tmp/grug-moe-pipeline-profiler",
             run_id=config.profile_run_id,
         )
-        profiler_callback(SimpleNamespace(step=-1))
+        profiler_callback(SimpleNamespace(step=start_step - 1))
 
     step_times = []
     loss = None

--- a/experiments/grug/moe_pipeline/train.py
+++ b/experiments/grug/moe_pipeline/train.py
@@ -198,7 +198,8 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
         expert_axis_size=config.expert_axis_size,
         replica_axis_size=replica_axis_size,
     )
-    optimizer = optax.adamw(learning_rate=1e-4, b1=0.9, b2=0.95, weight_decay=0.1)
+    optimizer_config = dict(learning_rate=1e-4, b1=0.9, b2=0.95, weight_decay=0.1)
+    optimizer = optax.adamw(**optimizer_config)
     peak_flops_per_device = device_flops("h100")
     if peak_flops_per_device is None:
         raise ValueError("Fray does not define H100 BF16 peak FLOP/s")
@@ -302,7 +303,7 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
     checkpoint_contract = {
         "model": asdict(model_config),
         "mp_policy": config.mp_policy_string,
-        "optimizer": "adamw-lr1e-4-b1-0.9-b2-0.95-wd0.1",
+        "optimizer": {"type": optax.adamw.__name__, **optimizer_config},
     }
     start_step = 0
     if config.checkpoint_root:

--- a/experiments/grug/moe_pipeline/train.py
+++ b/experiments/grug/moe_pipeline/train.py
@@ -301,11 +301,7 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
     loss_denominator = prepared.loss_denominator
     checkpoint_contract = {
         "model": asdict(model_config),
-        "pipeline": asdict(pipeline_config),
-        "schedule": config.schedule,
-        "layer_counts": config.layer_counts,
         "mp_policy": config.mp_policy_string,
-        "batch_size": config.batch_size,
         "optimizer": "adamw-lr1e-4-b1-0.9-b2-0.95-wd0.1",
     }
     start_step = 0

--- a/experiments/grug/moe_pipeline/train.py
+++ b/experiments/grug/moe_pipeline/train.py
@@ -9,7 +9,7 @@ import json
 import os
 import statistics
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import StrEnum
 from types import SimpleNamespace
 from typing import cast
@@ -30,6 +30,7 @@ from levanter.pipeline import reshape_batch_into_microbatches
 from levanter.utils.flop_utils import lm_flops_per_token
 
 from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe_pipeline.checkpoint import restore_checkpoint, save_checkpoint
 from experiments.grug.moe_pipeline.model import BATCH_AXES, GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     TRAIN_LOSS_KEY,
@@ -89,8 +90,14 @@ class GrugPipelineTrainConfig:
     attention_implementation: str
     moe_implementation: str
     schedule: PipelineSchedule
+    checkpoint_root: str | None
+    checkpoint_every_steps: int
 
     def __post_init__(self) -> None:
+        if self.checkpoint_every_steps < 0:
+            raise ValueError("checkpoint_every_steps must be nonnegative")
+        if self.checkpoint_every_steps and not self.checkpoint_root:
+            raise ValueError("checkpoint_root is required for checkpoint saves")
         if not isinstance(self.schedule, PipelineSchedule):
             raise ValueError(f"unknown pipeline schedule: {self.schedule!r}")
         if self.schedule == PipelineSchedule.ZERO_BUBBLE and self.stages != self.physical_stages:
@@ -292,6 +299,21 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
     state = prepared.state
     batches = prepared.batches
     loss_denominator = prepared.loss_denominator
+    checkpoint_contract = {
+        "model": asdict(model_config),
+        "pipeline": asdict(pipeline_config),
+        "schedule": config.schedule,
+        "layer_counts": config.layer_counts,
+        "mp_policy": config.mp_policy_string,
+        "batch_size": config.batch_size,
+        "optimizer": "adamw-lr1e-4-b1-0.9-b2-0.95-wd0.1",
+    }
+    start_step = 0
+    if config.checkpoint_root:
+        state, start_step = restore_checkpoint(
+            config.checkpoint_root, state, step.in_shardings[0][0], contract=checkpoint_contract
+        )
+        _log("PIPELINE_RESTORE", step=start_step, checkpoint_root=config.checkpoint_root)
     _log(
         "PIPELINE_LOWER",
         process_index=jax.process_index(),
@@ -318,7 +340,7 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
 
     step_times = []
     loss = None
-    for step_index in range(config.steps):
+    for step_index in range(start_step, config.steps):
         started = time.monotonic()
         state, metrics = step(state, batches, loss_denominator)
         jax.block_until_ready((state, metrics))
@@ -327,6 +349,13 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
         metric_loss = metrics[TRAIN_LOSS_KEY]
         if profiler_callback is not None:
             profiler_callback(SimpleNamespace(step=step_index))
+        completed_steps = step_index + 1
+        if config.checkpoint_root and config.checkpoint_every_steps:
+            if completed_steps % config.checkpoint_every_steps == 0 or completed_steps == config.steps:
+                checkpoint_path = save_checkpoint(
+                    config.checkpoint_root, state, step=completed_steps, contract=checkpoint_contract
+                )
+                _log("PIPELINE_CHECKPOINT", step=completed_steps, path=checkpoint_path)
         if isinstance(metric_loss, MpmdArray):
             if not metric_loss.is_partially_addressable:
                 continue
@@ -344,6 +373,9 @@ def _run_grug_local(config: GrugPipelineTrainConfig) -> None:
             loss=loss,
         )
 
+    if not step_times:
+        _log("PIPELINE_COMPLETE", step=start_step)
+        return
     measured = step_times[config.warmup_steps :]
     if not measured:
         measured = step_times

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -35,7 +35,7 @@ from jaxtyping import PyTree
 
 from rigging import telemetry
 from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.storage_path import StoragePath
+from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
@@ -901,7 +901,7 @@ def _save_metadata(checkpoint_path, step, is_temporary, extra_metadata=None):
         "is_temporary": is_temporary,
     }
     if jax.process_index() == 0:
-        with atomic_rename(os.path.join(checkpoint_path, "metadata.json")) as temporary_path:
+        with atomic_rename(prefix_join(checkpoint_path, "metadata.json")) as temporary_path:
             StoragePath(temporary_path).write_text(json.dumps(metadata))
 
 

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -34,10 +34,12 @@ from jax.experimental.array_serialization.serialization import GlobalAsyncCheckp
 from jaxtyping import PyTree
 
 from rigging import telemetry
+from rigging.filesystem.atomic import atomic_rename
 from rigging.filesystem.storage_path import StoragePath
 
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
+    TensorStoreReadConfig,
     TensorStoreWriteConfig,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
@@ -788,6 +790,7 @@ def save_checkpoint(
     is_temporary: bool = True,
     debug: CheckpointDebugConfig | None = None,
     write_config: TensorStoreWriteConfig | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ):
     """
     Save a checkpoint to a given path using TensorStore with OCDBT.
@@ -804,8 +807,11 @@ def save_checkpoint(
         manager: the GlobalAsyncCheckpointManager to use for saving the checkpoint
         commit_callback: a callback to call after the checkpoint has been saved
         is_temporary: whether the checkpoint is temporary
+        metadata: Additional application metadata committed with the completion marker.
         write_config: how the save divides work across the processes holding the state
     """
+    if metadata is not None and {"step", "timestamp", "is_temporary"}.intersection(metadata):
+        raise ValueError("Checkpoint metadata must not override step, timestamp, or is_temporary")
     step = int(step)
     checkpoint_path = str(checkpoint_path)
     checkpoint_debug = debug or CheckpointDebugConfig()
@@ -836,7 +842,7 @@ def save_checkpoint(
             progress_logger.set_phase("metadata_write")
         status = "completed"
         try:
-            _save_metadata(checkpoint_path, fs, step, is_temporary)
+            _save_metadata(checkpoint_path, step, is_temporary, metadata)
             logger.info(f"Saved checkpoint to {checkpoint_path} for step {step}")
 
             if commit_callback is not None:
@@ -887,11 +893,16 @@ def save_checkpoint(
     return checkpoint_path
 
 
-def _save_metadata(checkpoint_path, fs, step, is_temporary):
-    metadata = {"step": step, "timestamp": datetime.datetime.now().isoformat(), "is_temporary": is_temporary}
+def _save_metadata(checkpoint_path, step, is_temporary, extra_metadata=None):
+    metadata = {
+        **(extra_metadata or {}),
+        "step": step,
+        "timestamp": datetime.datetime.now().isoformat(),
+        "is_temporary": is_temporary,
+    }
     if jax.process_index() == 0:
-        with fs.open(os.path.join(checkpoint_path, "metadata.json"), "w") as json_out:
-            json.dump(metadata, json_out)
+        with atomic_rename(os.path.join(checkpoint_path, "metadata.json")) as temporary_path:
+            StoragePath(temporary_path).write_text(json.dumps(metadata))
 
 
 def load_checkpoint(
@@ -902,6 +913,7 @@ def load_checkpoint(
     axis_mapping: Optional[haliax.partitioning.ResourceMapping] = None,
     mesh: Optional[jax.sharding.Mesh] = None,
     allow_partial: bool = False,
+    read_config: TensorStoreReadConfig | None = None,
 ) -> M:
     """
     Load a checkpoint from a given path using TensorStore.
@@ -919,6 +931,7 @@ def load_checkpoint(
         subpath: the subpath to load from the checkpoint
         axis_mapping: the axis mapping to use for loading the checkpoint
         mesh: the mesh to use for loading the checkpoint
+        read_config: Controls replica-local reads and restore collectives.
         allow_partial: if True, allow partial loading of the checkpoint. If False, all parameters must be present in the checkpoint.
     Returns:
         the loaded checkpoint, with the same structure as the exemplar tree
@@ -939,7 +952,12 @@ def load_checkpoint(
 
     ser, non_ser = equinox.partition(tree, is_jax_array_like)
     tree = tree_deserialize_leaves_tensorstore(
-        checkpoint_path, ser, axis_mapping=axis_mapping, mesh=mesh, allow_missing=allow_partial
+        checkpoint_path,
+        ser,
+        axis_mapping=axis_mapping,
+        mesh=mesh,
+        allow_missing=allow_partial,
+        read_config=read_config,
     )
     tree = equinox.combine(tree, non_ser)
     return tree

--- a/lib/levanter/src/levanter/mpmd_checkpoint.py
+++ b/lib/levanter/src/levanter/mpmd_checkpoint.py
@@ -6,7 +6,9 @@
 from typing import TypeVar
 
 import jax
-from jax.sharding import NamedSharding
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jaxtyping import PyTree
 from levanter.checkpoint import load_checkpoint
 from levanter.tensorstore_serialization import (
     ReplicaRestoreMode,
@@ -42,13 +44,15 @@ def checkpoint_arrays(state: State) -> State:
     return jax.tree.map(unwrap, state)
 
 
-def restore_checkpoint(state: State, checkpoint_path: str, shardings) -> State:
+def restore_checkpoint(state: State, checkpoint_path: str, shardings: PyTree) -> State:
     """Load a normal Levanter checkpoint into the destination's MPMD placement.
 
     The exemplar state supplies global array shapes and destination shardings.
     The checkpoint's source mesh and partitioning may differ. Nonowning
     processes keep empty array descriptors, and each replica reads its own
-    shards without collectives across pipeline stages.
+    shards without collectives across pipeline stages. Scalar leaves are read
+    on every device before wrapping the destination MPMD placement; ordinary
+    JAX scalar leaves retain that replication for subsequent stage splitting.
 
     Args:
         state: Destination array tree, including MPMD arrays or abstract arrays.
@@ -59,6 +63,15 @@ def restore_checkpoint(state: State, checkpoint_path: str, shardings) -> State:
         Restored state with the destination's sharding and MPMD array types.
     """
     arrays = checkpoint_arrays(state)
+    # Canonical scalars may be shared by several destination stages. Read them
+    # on every device so each stage can reuse its local copy after repartitioning.
+    scalar_sharding = NamedSharding(Mesh(np.array(jax.devices()), ("checkpoint",)), PartitionSpec())
+    arrays = jax.tree.map(
+        lambda value: (
+            jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=scalar_sharding) if value.shape == () else value
+        ),
+        arrays,
+    )
     # Levanter's reader expects at least one addressable shard per input array.
     # Other stages remain empty descriptors and never enter the read plan.
     local_arrays = jax.tree.map(
@@ -85,7 +98,7 @@ def restore_checkpoint(state: State, checkpoint_path: str, shardings) -> State:
     return wrap_checkpoint_arrays(restored, shardings)
 
 
-def wrap_checkpoint_arrays(state: State, shardings) -> State:
+def wrap_checkpoint_arrays(state: State, shardings: PyTree) -> State:
     """Wrap restored device buffers in the destination MPMD array types.
 
     Arrays must already reside on the target devices; this does not reshard or

--- a/lib/levanter/src/levanter/mpmd_checkpoint.py
+++ b/lib/levanter/src/levanter/mpmd_checkpoint.py
@@ -1,0 +1,169 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shard-local checkpoints for JaxPP MPMD array trees."""
+
+import json
+import uuid
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import jax
+import numpy as np
+from jax.experimental import multihost_utils
+from jax.sharding import NamedSharding
+from levanter.checkpoint import discover_latest_checkpoint, load_checkpoint
+from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
+from levanter.tensorstore_serialization import (
+    ReplicaRestoreMode,
+    TensorStoreReadConfig,
+)
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.storage_path import StoragePath, prefix_join
+
+try:
+    import jaxpp.api as jaxpp  # pyrefly: ignore[missing-import]  # Optional pipeline extra.
+except ModuleNotFoundError as error:
+    if error.name != "jaxpp":
+        raise
+    jaxpp = None
+
+State = TypeVar("State")
+
+_FORMAT_VERSION = 1
+_METADATA_FILE = "metadata.json"
+_LATEST_FILE = "latest.json"
+
+
+def checkpoint_arrays(state: State) -> State:
+    """Expose an array tree's device buffers without moving any shards."""
+
+    def unwrap(value):
+        if jaxpp is None or not isinstance(value, jaxpp.MpmdArray):
+            return value
+        local = value.to_mpmd_local_array
+        arrays = [] if local is None else local if isinstance(local, list) else [local]
+        buffers = {shard.device: shard.data for array in arrays for shard in array.addressable_shards}
+        return jax.make_array_from_single_device_arrays(
+            value.shape,
+            value.sharding,
+            [buffers[device] for device in value.sharding.mesh.devices.flat if device in buffers],
+            dtype=value.dtype,
+        )
+
+    return jax.tree.map(unwrap, state)
+
+
+def _array_layout(state) -> list[dict]:
+    return [
+        {
+            "path": jax.tree_util.keystr(path),
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "spec": list(value.sharding.spec),
+            "mesh": dict(value.sharding.mesh.shape),
+            "processes": [device.process_index for device in value.sharding.mesh.devices.flat],
+        }
+        for path, value in jax.tree_util.tree_flatten_with_path(state)[0]
+    ]
+
+
+def save_checkpoint(root: str, state: State, *, step: int, metadata: dict) -> str:
+    """Commit a completed training step after every process finishes its shard writes."""
+    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
+    path = prefix_join(root, f"step-{step:012d}-{bytes(identifier).hex()}")
+    arrays = checkpoint_arrays(state)
+    checkpoint_metadata = {
+        "mpmd_version": _FORMAT_VERSION,
+        "user_metadata": metadata,
+        "arrays": _array_layout(arrays),
+    }
+
+    def commit():
+        with atomic_rename(prefix_join(root, _LATEST_FILE)) as temporary_path:
+            StoragePath(temporary_path).write_text(json.dumps({"checkpoint": StoragePath(path).name, "step": step}))
+
+    save_levanter_checkpoint(
+        arrays, step, path, commit_callback=commit, is_temporary=False, metadata=checkpoint_metadata
+    )
+    return path
+
+
+def restore_checkpoint(
+    root: str,
+    state: State,
+    shardings,
+    *,
+    validate_metadata: Callable[[dict[str, Any]], None],
+) -> tuple[State, int]:
+    """Restore the newest committed step, or return fresh state for an empty root.
+
+    The compiled step supplies the exact MPMD placement. Array layouts and
+    process topology must match. The caller validates its application metadata
+    before any array data is read.
+    """
+    latest_path = StoragePath(prefix_join(root, _LATEST_FILE))
+    latest = None
+    if latest_path.exists():
+        latest = json.loads(latest_path.read_text())
+        metadata_path = StoragePath(root) / latest["checkpoint"] / _METADATA_FILE
+    else:
+        # Recover a fully written first checkpoint if publication of latest.json
+        # was interrupted. Normal resumes need no checkpoint-directory listing.
+        checkpoint_path = discover_latest_checkpoint(root)
+        if checkpoint_path is None:
+            return state, 0
+        metadata_path = StoragePath(checkpoint_path) / _METADATA_FILE
+    metadata = json.loads(metadata_path.read_text())
+    if latest is not None and latest["step"] != metadata["step"]:
+        raise ValueError(f"Checkpoint step disagrees with latest.json: {metadata_path}")
+    arrays = checkpoint_arrays(state)
+    expected_layout = json.loads(json.dumps(_array_layout(arrays)))
+    if metadata["mpmd_version"] != _FORMAT_VERSION or metadata["arrays"] != expected_layout:
+        raise ValueError(f"Checkpoint array layout or topology does not match: {metadata_path}")
+    validate_metadata(metadata["user_metadata"])
+    path = str(metadata_path.parent)
+    # Levanter's reader expects at least one addressable shard per input array.
+    # Other stages remain empty descriptors and never enter the read plan.
+    local_arrays = jax.tree.map(
+        lambda value: (
+            jax.ShapeDtypeStruct(value.shape, value.dtype, sharding=value.sharding)
+            if value.sharding.addressable_devices
+            else None
+        ),
+        arrays,
+    )
+    restored = load_checkpoint(
+        local_arrays,
+        path,
+        # Avoid restore collectives across processes that do not own this stage.
+        read_config=TensorStoreReadConfig(replica_mode=ReplicaRestoreMode.EVERY_REPLICA),
+    )
+    restored = jax.tree.map(
+        lambda original, loaded: original if loaded is None else loaded,
+        arrays,
+        restored,
+        is_leaf=lambda value: value is None,
+    )
+
+    def wrap(value, target):
+        if isinstance(target, NamedSharding):
+            return value
+        if jaxpp is None:
+            raise ImportError("MPMD restore requires jaxpp")
+        buffers = {shard.device: shard.data for shard in value.addressable_shards}
+        local_arrays = []
+        for mesh_id in sorted(target.mesh_ids):
+            sharding = NamedSharding(target.mpmd_mesh.unstack[mesh_id], target.spec)
+            if sharding.addressable_devices:
+                local_arrays.append(
+                    jax.make_array_from_single_device_arrays(
+                        value.shape,
+                        sharding,
+                        [buffers[device] for device in sharding.mesh.devices.flat if device in buffers],
+                        dtype=value.dtype,
+                    )
+                )
+        return jaxpp.MpmdArray(local_arrays, target, shape=value.shape, dtype=value.dtype)
+
+    return jax.tree.map(wrap, restored, shardings), int(metadata["step"])

--- a/lib/levanter/src/levanter/mpmd_checkpoint.py
+++ b/lib/levanter/src/levanter/mpmd_checkpoint.py
@@ -3,23 +3,15 @@
 
 """Shard-local checkpoints for JaxPP MPMD array trees."""
 
-import json
-import uuid
-from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import jax
-import numpy as np
-from jax.experimental import multihost_utils
 from jax.sharding import NamedSharding
-from levanter.checkpoint import discover_latest_checkpoint, load_checkpoint
-from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
+from levanter.checkpoint import load_checkpoint
 from levanter.tensorstore_serialization import (
     ReplicaRestoreMode,
     TensorStoreReadConfig,
 )
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 try:
     import jaxpp.api as jaxpp  # pyrefly: ignore[missing-import]  # Optional pipeline extra.
@@ -29,10 +21,6 @@ except ModuleNotFoundError as error:
     jaxpp = None
 
 State = TypeVar("State")
-
-_FORMAT_VERSION = 1
-_METADATA_FILE = "metadata.json"
-_LATEST_FILE = "latest.json"
 
 
 def checkpoint_arrays(state: State) -> State:
@@ -54,75 +42,23 @@ def checkpoint_arrays(state: State) -> State:
     return jax.tree.map(unwrap, state)
 
 
-def _array_layout(state) -> list[dict]:
-    return [
-        {
-            "path": jax.tree_util.keystr(path),
-            "shape": list(value.shape),
-            "dtype": str(value.dtype),
-            "spec": list(value.sharding.spec),
-            "mesh": dict(value.sharding.mesh.shape),
-            "processes": [device.process_index for device in value.sharding.mesh.devices.flat],
-        }
-        for path, value in jax.tree_util.tree_flatten_with_path(state)[0]
-    ]
+def restore_checkpoint(state: State, checkpoint_path: str, shardings) -> State:
+    """Load a normal Levanter checkpoint into the destination's MPMD placement.
 
+    The exemplar state supplies global array shapes and destination shardings.
+    The checkpoint's source mesh and partitioning may differ. Nonowning
+    processes keep empty array descriptors, and each replica reads its own
+    shards without collectives across pipeline stages.
 
-def save_checkpoint(root: str, state: State, *, step: int, metadata: dict) -> str:
-    """Commit a completed training step after every process finishes its shard writes."""
-    identifier = multihost_utils.broadcast_one_to_all(np.frombuffer(uuid.uuid4().bytes, dtype=np.uint8))
-    path = prefix_join(root, f"step-{step:012d}-{bytes(identifier).hex()}")
-    arrays = checkpoint_arrays(state)
-    checkpoint_metadata = {
-        "mpmd_version": _FORMAT_VERSION,
-        "user_metadata": metadata,
-        "arrays": _array_layout(arrays),
-    }
+    Args:
+        state: Destination array tree, including MPMD arrays or abstract arrays.
+        checkpoint_path: Concrete checkpoint directory from Levanter discovery.
+        shardings: Destination sharding tree, including JaxPP MPMD shardings.
 
-    def commit():
-        with atomic_rename(prefix_join(root, _LATEST_FILE)) as temporary_path:
-            StoragePath(temporary_path).write_text(json.dumps({"checkpoint": StoragePath(path).name, "step": step}))
-
-    save_levanter_checkpoint(
-        arrays, step, path, commit_callback=commit, is_temporary=False, metadata=checkpoint_metadata
-    )
-    return path
-
-
-def restore_checkpoint(
-    root: str,
-    state: State,
-    shardings,
-    *,
-    validate_metadata: Callable[[dict[str, Any]], None],
-) -> tuple[State, int]:
-    """Restore the newest committed step, or return fresh state for an empty root.
-
-    The compiled step supplies the exact MPMD placement. Array layouts and
-    process topology must match. The caller validates its application metadata
-    before any array data is read.
+    Returns:
+        Restored state with the destination's sharding and MPMD array types.
     """
-    latest_path = StoragePath(prefix_join(root, _LATEST_FILE))
-    latest = None
-    if latest_path.exists():
-        latest = json.loads(latest_path.read_text())
-        metadata_path = StoragePath(root) / latest["checkpoint"] / _METADATA_FILE
-    else:
-        # Recover a fully written first checkpoint if publication of latest.json
-        # was interrupted. Normal resumes need no checkpoint-directory listing.
-        checkpoint_path = discover_latest_checkpoint(root)
-        if checkpoint_path is None:
-            return state, 0
-        metadata_path = StoragePath(checkpoint_path) / _METADATA_FILE
-    metadata = json.loads(metadata_path.read_text())
-    if latest is not None and latest["step"] != metadata["step"]:
-        raise ValueError(f"Checkpoint step disagrees with latest.json: {metadata_path}")
     arrays = checkpoint_arrays(state)
-    expected_layout = json.loads(json.dumps(_array_layout(arrays)))
-    if metadata["mpmd_version"] != _FORMAT_VERSION or metadata["arrays"] != expected_layout:
-        raise ValueError(f"Checkpoint array layout or topology does not match: {metadata_path}")
-    validate_metadata(metadata["user_metadata"])
-    path = str(metadata_path.parent)
     # Levanter's reader expects at least one addressable shard per input array.
     # Other stages remain empty descriptors and never enter the read plan.
     local_arrays = jax.tree.map(
@@ -135,7 +71,7 @@ def restore_checkpoint(
     )
     restored = load_checkpoint(
         local_arrays,
-        path,
+        checkpoint_path,
         # Avoid restore collectives across processes that do not own this stage.
         read_config=TensorStoreReadConfig(replica_mode=ReplicaRestoreMode.EVERY_REPLICA),
     )
@@ -146,12 +82,26 @@ def restore_checkpoint(
         is_leaf=lambda value: value is None,
     )
 
+    return wrap_checkpoint_arrays(restored, shardings)
+
+
+def wrap_checkpoint_arrays(state: State, shardings) -> State:
+    """Wrap restored device buffers in the destination MPMD array types.
+
+    Arrays must already reside on the target devices; this does not reshard or
+    copy them. Ordinary JAX shardings leave arrays unchanged.
+    """
+
     def wrap(value, target):
-        if isinstance(target, NamedSharding):
+        if isinstance(target, jax.sharding.Sharding):
             return value
         if jaxpp is None:
             raise ImportError("MPMD restore requires jaxpp")
-        buffers = {shard.device: shard.data for shard in value.addressable_shards}
+        buffers = (
+            {shard.device: shard.data for shard in value.addressable_shards}
+            if value.sharding.addressable_devices
+            else {}
+        )
         local_arrays = []
         for mesh_id in sorted(target.mesh_ids):
             sharding = NamedSharding(target.mpmd_mesh.unstack[mesh_id], target.spec)
@@ -166,4 +116,4 @@ def restore_checkpoint(
                 )
         return jaxpp.MpmdArray(local_arrays, target, shape=value.shape, dtype=value.dtype)
 
-    return jax.tree.map(wrap, restored, shardings), int(metadata["step"])
+    return jax.tree.map(wrap, state, shardings)

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -16,6 +16,7 @@ import jax
 import jax.experimental.array_serialization.serialization as array_ser
 import jax.tree_util as jtu
 import levanter.checkpoint as checkpoint_module
+import levanter.mpmd_checkpoint as mpmd_checkpoint
 import levanter.tensorstore_serialization as tensorstore_serialization
 import numpy as np
 import optax
@@ -1113,3 +1114,35 @@ def test_backward_compatibility_with_ocdbt():
         )
         assert all(np.isclose(restored_state.training_key, initial_state.training_key))
         assert restored_state.step == initial_state.step
+
+
+def test_mpmd_checkpoint_uses_standard_discovery_and_load(tmp_path):
+    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ("data",))
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+    state = {"weights": jax.device_put(jnp.arange(8, dtype=jnp.float32), sharding), "unused": None}
+    path = mpmd_checkpoint.save_checkpoint(str(tmp_path), state, step=7, metadata={"schedule": "test"})
+    assert discover_latest_checkpoint(tmp_path) == path
+    templates = jax.tree.map(lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=x.sharding), state)
+    loaded = load_checkpoint(templates, path)
+    np.testing.assert_array_equal(loaded["weights"], state["weights"])
+    assert loaded["unused"] is None
+    # Recovery after interrupted pointer publication uses standard discovery.
+    (tmp_path / "latest.json").unlink()
+    (tmp_path / "step-000000000008-incomplete").mkdir()
+    empty = jax.tree.map(jnp.zeros_like, state)
+    shardings = jax.tree.map(lambda x: x.sharding, state)
+
+    def validate_metadata(metadata):
+        assert metadata == {"schedule": "test"}
+
+    restored, step = mpmd_checkpoint.restore_checkpoint(
+        str(tmp_path), empty, shardings, validate_metadata=validate_metadata
+    )
+    assert step == 7
+    np.testing.assert_array_equal(restored["weights"], state["weights"])
+
+
+def test_checkpoint_application_metadata_cannot_replace_completion_fields(tmp_path):
+    with pytest.raises(ValueError, match="must not override"):
+        save_checkpoint({"weights": jnp.ones(2)}, 7, tmp_path, metadata={"step": 8})
+    assert discover_latest_checkpoint(tmp_path) is None

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -1123,18 +1123,30 @@ def test_mpmd_checkpoint_uses_standard_format_across_destination_shardings(tmp_p
     target_mesh = jax.sharding.Mesh(devices[:1], ("stage",))
     target_sharding = jax.sharding.NamedSharding(target_mesh, jax.sharding.PartitionSpec())
     weights = np.arange(8 * len(devices), dtype=np.float32)
-    state = {"weights": jax.device_put(weights, source_sharding), "unused": None}
+    state = {
+        "weights": jax.device_put(weights, source_sharding),
+        "progress": {"step": jax.device_put(np.array(7, dtype=np.int32), target_sharding)},
+        "unused": None,
+    }
     path = str(tmp_path / "step-7")
     save_checkpoint(mpmd_checkpoint.checkpoint_arrays(state), 7, path)
     assert discover_latest_checkpoint(tmp_path) == path
 
     templates = {
         "weights": jax.ShapeDtypeStruct(weights.shape, weights.dtype, sharding=target_sharding),
+        "progress": {"step": jax.ShapeDtypeStruct((), np.int32, sharding=target_sharding)},
         "unused": None,
     }
-    restored = mpmd_checkpoint.restore_checkpoint(templates, path, {"weights": target_sharding, "unused": None})
+    restored = mpmd_checkpoint.restore_checkpoint(
+        templates, path, jax.tree.map(lambda value: value.sharding, templates)
+    )
     np.testing.assert_array_equal(restored["weights"], weights)
     assert restored["weights"].sharding == target_sharding
+    # A canonical scalar can feed every destination stage, even when its
+    # exemplar initially resides on only one stage's devices.
+    assert restored["progress"]["step"].sharding.device_set == set(jax.devices())
+    for shard in restored["progress"]["step"].addressable_shards:
+        np.testing.assert_array_equal(shard.data, 7)
     assert restored["unused"] is None
 
     # Save the stage-local result and read it with the ordinary loader on the
@@ -1145,10 +1157,5 @@ def test_mpmd_checkpoint_uses_standard_format_across_destination_shardings(tmp_p
     loaded = load_checkpoint(source_templates, reverse_path)
     np.testing.assert_array_equal(loaded["weights"], weights)
     assert loaded["weights"].sharding == source_sharding
+    np.testing.assert_array_equal(loaded["progress"]["step"], 7)
     assert loaded["unused"] is None
-
-
-def test_checkpoint_application_metadata_cannot_replace_completion_fields(tmp_path):
-    with pytest.raises(ValueError, match="must not override"):
-        save_checkpoint({"weights": jnp.ones(2)}, 7, tmp_path, metadata={"step": 8})
-    assert discover_latest_checkpoint(tmp_path) is None

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -1116,30 +1116,36 @@ def test_backward_compatibility_with_ocdbt():
         assert restored_state.step == initial_state.step
 
 
-def test_mpmd_checkpoint_uses_standard_discovery_and_load(tmp_path):
-    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ("data",))
-    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
-    state = {"weights": jax.device_put(jnp.arange(8, dtype=jnp.float32), sharding), "unused": None}
-    path = mpmd_checkpoint.save_checkpoint(str(tmp_path), state, step=7, metadata={"schedule": "test"})
+def test_mpmd_checkpoint_uses_standard_format_across_destination_shardings(tmp_path):
+    devices = np.array(jax.devices())
+    mesh = jax.sharding.Mesh(devices, ("data",))
+    source_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("data"))
+    target_mesh = jax.sharding.Mesh(devices[:1], ("stage",))
+    target_sharding = jax.sharding.NamedSharding(target_mesh, jax.sharding.PartitionSpec())
+    weights = np.arange(8 * len(devices), dtype=np.float32)
+    state = {"weights": jax.device_put(weights, source_sharding), "unused": None}
+    path = str(tmp_path / "step-7")
+    save_checkpoint(mpmd_checkpoint.checkpoint_arrays(state), 7, path)
     assert discover_latest_checkpoint(tmp_path) == path
-    templates = jax.tree.map(lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=x.sharding), state)
-    loaded = load_checkpoint(templates, path)
-    np.testing.assert_array_equal(loaded["weights"], state["weights"])
+
+    templates = {
+        "weights": jax.ShapeDtypeStruct(weights.shape, weights.dtype, sharding=target_sharding),
+        "unused": None,
+    }
+    restored = mpmd_checkpoint.restore_checkpoint(templates, path, {"weights": target_sharding, "unused": None})
+    np.testing.assert_array_equal(restored["weights"], weights)
+    assert restored["weights"].sharding == target_sharding
+    assert restored["unused"] is None
+
+    # Save the stage-local result and read it with the ordinary loader on the
+    # original data mesh: the checkpoint format carries no source-topology gate.
+    reverse_path = str(tmp_path / "step-8")
+    save_checkpoint(mpmd_checkpoint.checkpoint_arrays(restored), 8, reverse_path)
+    source_templates = jax.tree.map(lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype, sharding=x.sharding), state)
+    loaded = load_checkpoint(source_templates, reverse_path)
+    np.testing.assert_array_equal(loaded["weights"], weights)
+    assert loaded["weights"].sharding == source_sharding
     assert loaded["unused"] is None
-    # Recovery after interrupted pointer publication uses standard discovery.
-    (tmp_path / "latest.json").unlink()
-    (tmp_path / "step-000000000008-incomplete").mkdir()
-    empty = jax.tree.map(jnp.zeros_like, state)
-    shardings = jax.tree.map(lambda x: x.sharding, state)
-
-    def validate_metadata(metadata):
-        assert metadata == {"schedule": "test"}
-
-    restored, step = mpmd_checkpoint.restore_checkpoint(
-        str(tmp_path), empty, shardings, validate_metadata=validate_metadata
-    )
-    assert step == 7
-    np.testing.assert_array_equal(restored["weights"], state["weights"])
 
 
 def test_checkpoint_application_metadata_cannot_replace_completion_fields(tmp_path):

--- a/tests/grug/test_grug_moe_pipeline.py
+++ b/tests/grug/test_grug_moe_pipeline.py
@@ -1,7 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from dataclasses import replace
 
 import jax
@@ -10,10 +9,12 @@ import numpy as np
 import optax
 import pytest
 from jax.sharding import AxisType, Mesh
+from levanter.checkpoint import load_checkpoint
+from levanter.checkpoint import save_checkpoint as save_levanter_checkpoint
 from levanter.data.text.examples import GrugLmExample
 
 from experiments.grug.moe_pipeline.benchmark import _resolve_benchmark_config
-from experiments.grug.moe_pipeline.checkpoint import restore_checkpoint, save_checkpoint
+from experiments.grug.moe_pipeline.checkpoint import checkpoint_state, restore_checkpoint, save_checkpoint
 from experiments.grug.moe_pipeline.model import GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     AutomaticPipelineSchedule,
@@ -186,14 +187,14 @@ def test_dualpipe_v_train_config_rejects_too_few_microbatches():
 
 
 def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
-    mesh, model = _tiny_model()
+    mesh, model = _tiny_model(num_layers=4)
     params, _ = split_automatic_stages(model, num_stages=2)
     optimizer = optax.adamw(1e-4)
     with jax.set_mesh(mesh):
         state = GrugMoeAutomaticPipelineState(
             params,
             tuple(optimizer.init(stage) for stage in params),
-            (jnp.array([[2.0, -1.0]]), jnp.array([[-3.0, 1.0]])),
+            (jnp.array([[2.0, -1.0], [1.0, 3.0]]), jnp.array([[-3.0, 1.0], [4.0, 2.0]])),
         )
         # Populate Adam moments and counts; a fresh optimizer must differ.
         gradients = jax.tree.map(jnp.ones_like, params)
@@ -210,10 +211,6 @@ def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
         )
         root = str(tmp_path)
         checkpoint = save_checkpoint(root, state, step=1, contract={"schedule": "zero_bubble"})
-        assert json.loads((tmp_path / "latest.json").read_text()) == {
-            "checkpoint": checkpoint.rsplit("/", 1)[-1],
-            "step": 1,
-        }
         # An interrupted newer save must not hide the committed checkpoint.
         (tmp_path / "step-000000000002-incomplete").mkdir()
         empty = jax.tree.map(jnp.zeros_like, state)
@@ -224,14 +221,28 @@ def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
             np.testing.assert_array_equal(actual, expected)
         for stage_optimizer in restored.opt_state:
             np.testing.assert_array_equal(stage_optimizer[0].count, step)
-        latest = json.loads((tmp_path / "latest.json").read_text())
-        (tmp_path / "latest.json").write_text(json.dumps({**latest, "step": 2}))
-        with pytest.raises(ValueError, match="step disagrees"):
-            restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
-        # Recover committed data even if the first latest-pointer write failed.
-        (tmp_path / "latest.json").unlink()
-        recovered, recovered_step = restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
-        assert recovered_step == step
-        _assert_trees_close(recovered, state)
+        # A plain Levanter reader sees a whole model and optimizer, not stages.
+        canonical = checkpoint_state(state)
+        loaded = load_checkpoint(jax.tree.map(jnp.zeros_like, canonical), checkpoint)
+        _assert_trees_close(loaded, canonical)
+        # Save with the ordinary FSDP API and restore into the pipeline.
+        fsdp_path = str(tmp_path / "fsdp")
+        save_levanter_checkpoint(loaded, 1, fsdp_path)
+        restored_fsdp, completed = restore_checkpoint(fsdp_path, empty, shardings, contract={})
+        assert completed == 1
+        _assert_trees_close(restored_fsdp, state)
         with pytest.raises(ValueError, match="training configuration"):
-            restore_checkpoint(root, empty, shardings, contract={"schedule": "dualpipe_v"})
+            restore_checkpoint(checkpoint, empty, shardings, contract={"schedule": "dualpipe_v"})
+
+        # The same FSDP checkpoint can populate a different logical layer split.
+        four_params, _ = split_automatic_stages(model, num_stages=4)
+        four_state = GrugMoeAutomaticPipelineState(
+            four_params,
+            tuple(optimizer.init(stage) for stage in four_params),
+            tuple(jnp.zeros((1, 2)) for _ in four_params),
+        )
+        four_restored, completed = restore_checkpoint(
+            fsdp_path, four_state, jax.tree.map(lambda value: value.sharding, four_state), contract={}
+        )
+        assert completed == 1
+        _assert_trees_close(checkpoint_state(four_restored), loaded)

--- a/tests/grug/test_grug_moe_pipeline.py
+++ b/tests/grug/test_grug_moe_pipeline.py
@@ -233,5 +233,5 @@ def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
         recovered, recovered_step = restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
         assert recovered_step == step
         _assert_trees_close(recovered, state)
-        with pytest.raises(ValueError, match="configuration or topology"):
+        with pytest.raises(ValueError, match="training configuration"):
             restore_checkpoint(root, empty, shardings, contract={"schedule": "dualpipe_v"})

--- a/tests/grug/test_grug_moe_pipeline.py
+++ b/tests/grug/test_grug_moe_pipeline.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from dataclasses import replace
 
 import jax
@@ -208,14 +209,29 @@ def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
             opt_state=tuple(item[1] for item in updated),
         )
         root = str(tmp_path)
-        save_checkpoint(root, state, step=7, contract={"schedule": "zero_bubble"})
+        checkpoint = save_checkpoint(root, state, step=1, contract={"schedule": "zero_bubble"})
+        assert json.loads((tmp_path / "latest.json").read_text()) == {
+            "checkpoint": checkpoint.rsplit("/", 1)[-1],
+            "step": 1,
+        }
         # An interrupted newer save must not hide the committed checkpoint.
-        (tmp_path / "step-000000000008-incomplete").mkdir()
+        (tmp_path / "step-000000000002-incomplete").mkdir()
         empty = jax.tree.map(jnp.zeros_like, state)
         shardings = jax.tree.map(lambda value: value.sharding, empty)
         restored, step = restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
-        assert step == 7
+        assert step == 1
         for actual, expected in zip(jax.tree.leaves(restored), jax.tree.leaves(state), strict=True):
             np.testing.assert_array_equal(actual, expected)
+        for stage_optimizer in restored.opt_state:
+            np.testing.assert_array_equal(stage_optimizer[0].count, step)
+        latest = json.loads((tmp_path / "latest.json").read_text())
+        (tmp_path / "latest.json").write_text(json.dumps({**latest, "step": 2}))
+        with pytest.raises(ValueError, match="step disagrees"):
+            restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
+        # Recover committed data even if the first latest-pointer write failed.
+        (tmp_path / "latest.json").unlink()
+        recovered, recovered_step = restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
+        assert recovered_step == step
+        _assert_trees_close(recovered, state)
         with pytest.raises(ValueError, match="configuration or topology"):
             restore_checkpoint(root, empty, shardings, contract={"schedule": "dualpipe_v"})

--- a/tests/grug/test_grug_moe_pipeline.py
+++ b/tests/grug/test_grug_moe_pipeline.py
@@ -6,14 +6,17 @@ from dataclasses import replace
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 import pytest
 from jax.sharding import AxisType, Mesh
 from levanter.data.text.examples import GrugLmExample
 
 from experiments.grug.moe_pipeline.benchmark import _resolve_benchmark_config
+from experiments.grug.moe_pipeline.checkpoint import restore_checkpoint, save_checkpoint
 from experiments.grug.moe_pipeline.model import GrugModelConfig, Transformer
 from experiments.grug.moe_pipeline.pipeline import (
     AutomaticPipelineSchedule,
+    GrugMoeAutomaticPipelineState,
     GrugMoePipelineConfig,
     _apply_qb_betas,
     automatic_stage_to_mpmd_indices,
@@ -179,3 +182,40 @@ def test_dualpipe_v_train_config_rejects_too_few_microbatches():
             microbatches=3,
             schedule=PipelineSchedule.DUALPIPE_V,
         )
+
+
+def test_checkpoint_restores_optimizer_and_pending_router_updates(tmp_path):
+    mesh, model = _tiny_model()
+    params, _ = split_automatic_stages(model, num_stages=2)
+    optimizer = optax.adamw(1e-4)
+    with jax.set_mesh(mesh):
+        state = GrugMoeAutomaticPipelineState(
+            params,
+            tuple(optimizer.init(stage) for stage in params),
+            (jnp.array([[2.0, -1.0]]), jnp.array([[-3.0, 1.0]])),
+        )
+        # Populate Adam moments and counts; a fresh optimizer must differ.
+        gradients = jax.tree.map(jnp.ones_like, params)
+        updated = [
+            optimizer.update(grad, opt, param)
+            for grad, opt, param in zip(gradients, state.opt_state, params, strict=True)
+        ]
+        state = replace(
+            state,
+            trainable_params=tuple(
+                optax.apply_updates(param, item[0]) for param, item in zip(params, updated, strict=True)
+            ),
+            opt_state=tuple(item[1] for item in updated),
+        )
+        root = str(tmp_path)
+        save_checkpoint(root, state, step=7, contract={"schedule": "zero_bubble"})
+        # An interrupted newer save must not hide the committed checkpoint.
+        (tmp_path / "step-000000000008-incomplete").mkdir()
+        empty = jax.tree.map(jnp.zeros_like, state)
+        shardings = jax.tree.map(lambda value: value.sharding, empty)
+        restored, step = restore_checkpoint(root, empty, shardings, contract={"schedule": "zero_bubble"})
+        assert step == 7
+        for actual, expected in zip(jax.tree.leaves(restored), jax.tree.leaves(state), strict=True):
+            np.testing.assert_array_equal(actual, expected)
+        with pytest.raises(ValueError, match="configuration or topology"):
+            restore_checkpoint(root, empty, shardings, contract={"schedule": "dualpipe_v"})


### PR DESCRIPTION
Save pipeline MoE checkpoints as one unsplit model and optimizer tree using ordinary Levanter checkpoint APIs. FSDP and PP can load the same state with different device meshes, pipeline schedules, and layer splits. The completed step and pending router updates survive the transition. The step limit counts total updates across restarts; an explicit checkpoint root and save cadence control persistence.

Grug maps stage-local state to global layer paths at the checkpoint boundary. Levanter adapts JaxPP device buffers and reconstructs the destination MPMD placement without gathering model or optimizer tensors. Shared optimizer counters are read on each destination stage. Standard completion metadata and discovery replace the separate latest pointer and source-topology checks. The model and optimizer structures must agree; checkpoints written by the pipeline trainer also record model configuration, optimizer settings, and precision for validation. Changing token grouping can change MoE routing and subsequent optimizer updates.

Fixes #8972
