### PR TITLE
[snowball] Expose June model stages for pipeline execution

### DIFF
--- a/docs/references/snowball-pipeline.md
+++ b/docs/references/snowball-pipeline.md
@@ -1,0 +1,53 @@
+# Snowball model and pipeline stages
+
+`experiments.june_tpu_67b_a2b.moe.rl_model.JuneSnowballConfig` exposes the June
+training transformer through Levanter's `LmHeadModel` interface. It uses the
+published Snowball HF configuration and tensor layout, with explicit causal
+segment masks and optional per-example position IDs. `capacity_factor` controls
+capacity in the backend selected by `moe_implementation` and must be finite and
+positive. For `ragged_all_to_all`, capacity is based on local token count ×
+experts selected per token, multiplied by this factor, then divided and rounded
+across local expert chunks. Padding consumes capacity. Other backends retain
+their existing capacity rules.
+
+The adapter accepts Levanter's structured causal `AttentionMask` with segment
+IDs; explicit dense masks are rejected. Tokens can attend only to earlier or
+current positions within the same segment, subject to each layer's window.
+Position IDs have the same named batch/position axes as tokens. The adapter
+preserves supplied positions, including packed-sequence resets; it does not
+infer resets from segment IDs. Stage methods take raw `[batch, sequence]`
+segment and position arrays.
+
+`split_june_pipeline_model(model, num_stages)` partitions contiguous blocks
+without copying their arrays. The first stage owns the embedding modules; the
+last owns the final normalization and output projection. Layer offsets preserve
+the original short/long attention schedule, including the final long layer.
+The stage interface provides `embed`, `run_blocks`, `finish`, and `get_lm_head`;
+an execution scheduler must place and transport these stage computations.
+This module does not provide a scheduler, optimizer, or checkpoint lifecycle.
+
+Each stage exports and loads only its owned HF keys, using global layer indices.
+The union of stage exports equals the full model export. Loading an owned tensor
+subset into an abstract stage template avoids constructing the full model.
+`trainable_filter` excludes the fixed per-expert QB biases used in top-k routing.
+Partition the model with this filter, cast only the trainable partition, and
+combine it with the unchanged FP32 frozen partition. Filtering gradients alone
+does not prevent an indiscriminate model-wide cast from rounding these biases.
+
+`run_blocks_with_stats` returns hidden states and routing counts. Each token-to-selected-expert pair is one assignment, including padded tokens.
+Backend counters count assignments clipped before transport (`sender`) or after
+transport (`receiver`); ragged transport reports its chunk clipping as sender
+drops. Stage counters sum backend totals across that stage's layers, without
+combining other pipeline stages. Counters also report the maximum drops
+in any layer, and the last global layer index with drops (`-1` when none).
+The caller decides whether drops are acceptable. With expert parallelism,
+telemetry rejects microbatches above 2²⁴ total assignments across all model layers
+so downstream floating-point auxiliary transport can represent counts exactly.
+
+The June model retains optimization barriers after RMS variance, embedding
+gather, and router sigmoid. These prevent demonstrated forward/AD rounding
+changes caused by fusion. The model-only tests cover HF mappings, masks and
+positions, forward/gradient agreement, stage ownership, and uneven partitions.
+The wider GRPO migration additionally required a scorer-only compute-weight
+cast boundary; its end-to-end numerical result should not be attributed to
+these model changes alone. See the [numerical investigation](https://marina.oa.dev/echo/wiki/363).

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -8,6 +8,7 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 """
 
 import dataclasses
+import math
 from dataclasses import dataclass
 from typing import Literal
 
@@ -119,6 +120,7 @@ class GrugModelConfig:
     disable_long_rope: bool = False
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR
     ce_implementation: str | None = None
     """Fused cross-entropy backend selection (levanter fused_cross_entropy_loss). None keeps the
     backend default (GPU: full-logits ``xla`` path). Set ``"batched_xla"`` to use the blocked-vocab
@@ -150,6 +152,8 @@ class GrugModelConfig:
 
     def __post_init__(self) -> None:
         _ = self.inferred_head_dim
+        if not math.isfinite(self.capacity_factor) or self.capacity_factor <= 0:
+            raise ValueError("capacity_factor must be finite and positive")
         if self.num_heads % self.num_kv_heads != 0:
             raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
         if self.vocab_size <= 0:
@@ -180,6 +184,8 @@ class GrugModelConfig:
 def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
     """Non-parametric RMS norm over the last dimension."""
     variance = jnp.mean(jnp.square(x.astype(jnp.float32)), axis=-1, keepdims=True)
+    # AD retains different intermediates; pin the reduction to preserve forward rounding.
+    variance = jax.lax.optimization_barrier(variance)
     return (x * jax.lax.rsqrt(variance + eps)).astype(x.dtype)
 
 
@@ -195,6 +201,7 @@ def _apply_half_rope(
     seq_len: int,
     head_dim: int,
     rope: RotaryConfig,
+    position_ids: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """RoPE applied to the first ``head_dim`` channels of q/k.
 
@@ -204,10 +211,12 @@ def _apply_half_rope(
     """
     half_dim = head_dim // 2
     inv_freq = _rope_inv_freq(half_dim, rope.theta)
-    positions = jnp.arange(seq_len, dtype=jnp.float32)
-    angles = positions[:, None] * inv_freq[None, :]
-    cos = jnp.cos(angles)[None, :, None, :]
-    sin = jnp.sin(angles)[None, :, None, :]
+    positions = (
+        jnp.arange(seq_len, dtype=jnp.float32)[None, :] if position_ids is None else position_ids.astype(jnp.float32)
+    )
+    angles = positions[..., None] * inv_freq
+    cos = jnp.cos(angles)[:, :, None, :]
+    sin = jnp.sin(angles)[:, :, None, :]
 
     def _apply(x: jax.Array) -> jax.Array:
         dtype = x.dtype
@@ -248,6 +257,7 @@ class CausalSelfAttention(eqx.Module):
         use_pko: bool = False,
         disable_rope: bool = False,
         qk_mult_scale: float = 1.0,
+        position_ids: jax.Array | None = None,
     ) -> Float[Array, "B S D"]:
         head_dim = self.cfg.inferred_head_dim
         seq_len = x.shape[1]
@@ -309,6 +319,7 @@ class CausalSelfAttention(eqx.Module):
                 seq_len=seq_len,
                 head_dim=half,
                 rope=cfg.rope,
+                position_ids=position_ids,
             )
             q = jnp.concatenate([q_rot, q[..., half:]], axis=-1)
             k = jnp.concatenate([k_rot, k[..., half:]], axis=-1)
@@ -351,6 +362,8 @@ class RMSNorm(eqx.Module):
         dtype = x.dtype
         x = x.astype(jnp.float32)
         variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+        # AD retains different intermediates; pin the reduction to preserve forward rounding.
+        variance = jax.lax.optimization_barrier(variance)
         normed = x * jax.lax.rsqrt(variance + self.eps)
         return (normed * weight).astype(dtype)
 
@@ -533,7 +546,7 @@ class MoEMLP(eqx.Module):
                 key=k_expert,
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
-                capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
+                capacity_factor=cfg.capacity_factor,
             ),
             cfg=cfg,
         )
@@ -547,7 +560,7 @@ class MoEMLP(eqx.Module):
         x_flat = rearrange(x, "b s d -> (b s) d")
         # Keep the router path in fp32 before top-k, softmax, and QB statistics.
         router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
-        biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
+        biased_logits = router_logits + jax.lax.stop_gradient(unshard(self.router_bias))
         router_probs = jax.nn.softmax(router_logits, axis=-1)
         # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
         _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
@@ -556,6 +569,8 @@ class MoEMLP(eqx.Module):
         # Sigmoid combine weights on unbiased logits for selected experts.
         unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
         combine_weights_f = jax.nn.sigmoid(unbiased_topk)
+        # Keep sigmoid rounding consistent when AD fuses expert-weight renormalization.
+        combine_weights_f = jax.lax.optimization_barrier(combine_weights_f)
         # Renormalize K combine weights to sum to ``_ROUTING_RENORM_SUM`` (baked in).
         denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
         combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
@@ -596,6 +611,9 @@ class MoEMLP(eqx.Module):
             report_capacity_overflow=True,
         )
         router_stats["capacity_overflow"] = capacity_overflow.total.astype(jnp.float32)
+        router_stats["routing_assignments"] = jnp.asarray(b * s * self.cfg.num_experts_per_token, dtype=jnp.int32)
+        router_stats["routing_sender_drops"] = capacity_overflow.sender
+        router_stats["routing_receiver_drops"] = capacity_overflow.receiver
 
         routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
         routed = reshard(routed, _batch_spec())
@@ -638,6 +656,7 @@ class Block(eqx.Module):
         use_long_mask: Bool[Array, ""] | bool,
         use_pko: bool = False,
         disable_long_rope: bool = False,
+        position_ids: jax.Array | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
         # lax.cond so the body has a uniform shape across scan iterations:
@@ -651,8 +670,11 @@ class Block(eqx.Module):
                 use_pko=use_pko,
                 disable_rope=disable_long_rope,
                 qk_mult_scale=self.attn.cfg.qk_mult_long_scale,
+                position_ids=position_ids,
             ),
-            lambda _: self.attn(attn_in, short_mask, use_pko=False, disable_rope=False, qk_mult_scale=1.0),
+            lambda _: self.attn(
+                attn_in, short_mask, use_pko=False, disable_rope=False, qk_mult_scale=1.0, position_ids=position_ids
+            ),
             operand=None,
         )
         x = x + attn_out
@@ -727,6 +749,8 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
+        *,
+        position_ids: jax.Array | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         if mask is None:
             mask = AttentionMask.causal()
@@ -734,6 +758,8 @@ class Transformer(eqx.Module):
         batch_spec = _batch_spec()
         cfg = self.config
         hidden = self.token_embed.at[token_ids].get(out_sharding=batch_spec)
+        # Keep gather fusion from changing normalization rounding between scoring and AD.
+        hidden = jax.lax.optimization_barrier(hidden)
         hidden = self.embed_norm(hidden)
         hidden = self.embed_gated_norm(hidden)
 
@@ -755,7 +781,7 @@ class Transformer(eqx.Module):
                 is_long = i % 4 == 3 or is_last
                 use_pko = is_long and not cfg.disable_pko
                 hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
-                    hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope
+                    hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope, position_ids
                 )
                 moe_router_stats.append(router_stats)
             router_metrics = {
@@ -776,7 +802,7 @@ class Transformer(eqx.Module):
             ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
                 layer, layer_use_long_mask = scan_inputs
                 return eqx.filter_checkpoint(layer, policy=remat_policy)(
-                    carry_hidden, short_mask, long_mask, layer_use_long_mask, False, cfg.disable_long_rope
+                    carry_hidden, short_mask, long_mask, layer_use_long_mask, False, cfg.disable_long_rope, position_ids
                 )
 
             hidden, stacked_router_stats = jax.lax.scan(

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -80,6 +80,9 @@ def _layer_attention_masks(mask: AttentionMask, *, sliding_window: int) -> tuple
     return mask.with_sliding_window(sliding_window // 2), mask.with_sliding_window(sliding_window)
 
 
+LONG_ATTENTION_INTERVAL = 4
+
+
 @dataclass(frozen=True)
 class GrugModelConfig:
     """Hyperparameters for the grug MoE transformer.
@@ -689,7 +692,7 @@ class Block(eqx.Module):
 def _long_layer_schedule(num_layers: int) -> jax.Array:
     """Bool[num_layers] = True for every 4th layer and the last layer."""
     idx = jnp.arange(num_layers)
-    return ((idx % 4) == 3) | (idx == num_layers - 1)
+    return ((idx % LONG_ATTENTION_INTERVAL) == LONG_ATTENTION_INTERVAL - 1) | (idx == num_layers - 1)
 
 
 class Transformer(eqx.Module):
@@ -778,7 +781,7 @@ class Transformer(eqx.Module):
             moe_router_stats: list[dict[str, jax.Array]] = []
             for i, block in enumerate(self.blocks):
                 is_last = i == num_blocks - 1
-                is_long = i % 4 == 3 or is_last
+                is_long = i % LONG_ATTENTION_INTERVAL == LONG_ATTENTION_INTERVAL - 1 or is_last
                 use_pko = is_long and not cfg.disable_pko
                 hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
                     hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope, position_ids

--- a/experiments/june_tpu_67b_a2b/moe/rl_model.py
+++ b/experiments/june_tpu_67b_a2b/moe/rl_model.py
@@ -33,7 +33,14 @@ from levanter.models.snowball import (
 )
 from levanter.pipeline import evenly_partition_layers
 
-from experiments.june_tpu_67b_a2b.moe.model import Block, GatedNorm, GrugModelConfig, RMSNorm, Transformer
+from experiments.june_tpu_67b_a2b.moe.model import (
+    LONG_ATTENTION_INTERVAL,
+    Block,
+    GatedNorm,
+    GrugModelConfig,
+    RMSNorm,
+    Transformer,
+)
 
 
 @LmConfig.register_subclass("june_snowball")
@@ -176,7 +183,9 @@ class JunePipelineStage(eqx.Module):
         short_mask = GrugAttentionMask(is_causal=True, sliding_window=self.config.sliding_window, segment_ids=segments)
         long_mask = GrugAttentionMask(is_causal=True, segment_ids=segments)
         for index, block in enumerate(self.blocks, start=self.layer_offset):
-            is_long = index % 4 == 3 or index == self.config.num_layers - 1
+            is_long = (
+                index % LONG_ATTENTION_INTERVAL == LONG_ATTENTION_INTERVAL - 1 or index == self.config.num_layers - 1
+            )
             hidden, layer_stats = eqx.filter_checkpoint(block)(
                 hidden,
                 short_mask,

--- a/experiments/june_tpu_67b_a2b/moe/rl_model.py
+++ b/experiments/june_tpu_67b_a2b/moe/rl_model.py
@@ -1,0 +1,268 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Levanter learner boundary over the June Snowball training transformer."""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import cast
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
+from jax.sharding import PartitionSpec as P
+from jax.sharding import get_abstract_mesh
+from levanter.grug.attention import AttentionMask as GrugAttentionMask
+from levanter.grug.grug_moe import _DEFAULT_EP_CAPACITY_FACTOR
+from levanter.layers.attention import AttentionMask
+from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.snowball import (
+    SnowballBlock,
+    SnowballConfig,
+    SnowballTransformer,
+    snowball_block_from_state_dict,
+    snowball_block_to_state_dict,
+    snowball_embeddings_from_state_dict,
+    snowball_embeddings_to_state_dict,
+    snowball_final_from_state_dict,
+    snowball_final_to_state_dict,
+    snowball_from_state_dict,
+    snowball_to_state_dict,
+)
+from levanter.pipeline import evenly_partition_layers
+
+from experiments.june_tpu_67b_a2b.moe.model import Block, GatedNorm, GrugModelConfig, RMSNorm, Transformer
+
+
+@LmConfig.register_subclass("june_snowball")
+@dataclass(frozen=True)
+class JuneSnowballConfig(SnowballConfig):
+    """Published Snowball architecture using June's training kernels."""
+
+    capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR
+
+    @property
+    def model_type(self):  # pyrefly: ignore[bad-override]  # Same HF recipe, different transformer implementation.
+        return JuneSnowballLMHeadModel
+
+    def training_config(self) -> GrugModelConfig:
+        fields = {
+            field.name: getattr(self, field.name)
+            for field in dataclasses.fields(SnowballConfig)
+            if field.name not in ("reference_checkpoint", "tokenizer")
+        }
+        return GrugModelConfig(**fields, disable_pko=True, disable_long_rope=True, capacity_factor=self.capacity_factor)
+
+
+class JuneSnowballLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[JuneSnowballConfig]):
+    transformer: Transformer
+    _config: JuneSnowballConfig = eqx.field(static=True)
+
+    @property
+    def config(self) -> JuneSnowballConfig:
+        return self._config
+
+    @property
+    def Vocab(self) -> hax.Axis:
+        return hax.Axis("vocab", self.config.vocab_size)
+
+    @classmethod
+    def init(cls, Vocab: hax.Axis, config: JuneSnowballConfig, *, key):
+        config = dataclasses.replace(config, vocab_size=Vocab.size)
+        return cls(Transformer.init(config.training_config(), key=key), config)
+
+    def activations(self, input_ids, attn_mask=None, *, key=None, pos_ids=None):
+        Position = input_ids.resolve_axis(self.Pos.name)
+        leading = tuple(axis for axis in input_ids.axes if axis != Position)
+        tokens = input_ids.rearrange((*leading, Position)).array.reshape(-1, Position.size)
+        if attn_mask is None:
+            attn_mask = AttentionMask.causal()
+        if not isinstance(attn_mask, AttentionMask):
+            raise ValueError("June Snowball requires a structured causal attention mask")
+        if (
+            not attn_mask.is_causal
+            or attn_mask.explicit_mask is not None
+            or attn_mask.causal_offset is not None
+            or attn_mask.sliding_window is not None
+            or attn_mask.bidirectional_window is not None
+        ):
+            raise ValueError("June Snowball supports causal segment masks with its fixed layer window schedule")
+        segments = None
+        if attn_mask.segment_ids is not None:
+            segments = tuple(
+                segment.broadcast_axis(leading).rearrange((*leading, ...)).array.reshape(tokens.shape)
+                for segment in attn_mask.segment_ids
+            )
+        positions = None if pos_ids is None else pos_ids.rearrange((*leading, Position)).array.reshape(tokens.shape)
+        hidden, _router_metrics = self.transformer(
+            tokens,
+            mask=GrugAttentionMask(is_causal=True, segment_ids=segments),
+            position_ids=positions,
+        )
+        return hax.named(
+            hidden.reshape(*(axis.size for axis in leading), Position.size, self.Embed.size),
+            (*leading, Position, self.Embed),
+        )
+
+    def get_lm_head(self):
+        return hax.auto_sharded(hax.named(self.transformer.output_proj, (self.Embed, self.Vocab)))
+
+    def resize_vocab(self, new_size, key=None):
+        if new_size != self.Vocab.size:
+            raise ValueError("June Snowball preserves the published checkpoint vocabulary")
+        return self
+
+    def to_state_dict(self, prefix=None) -> StateDict:
+        # Tuple-block June and Snowball have the same canonical HF tensor layout.
+        return snowball_to_state_dict(cast(SnowballTransformer, self.transformer), prefix=prefix)
+
+    def from_state_dict(self, state_dict: StateDict, prefix=None):
+        transformer = snowball_from_state_dict(cast(SnowballTransformer, self.transformer), state_dict, prefix=prefix)
+        return eqx.tree_at(lambda model: model.transformer, self, cast(Transformer, transformer))
+
+
+def june_trainable_filter(model: JuneSnowballLMHeadModel):
+    """Exclude fixed QB routing biases from gradients and optimizer weight decay."""
+    mask = jax.tree.map(lambda _: True, model)
+    assert model.transformer.blocks is not None
+    return eqx.tree_at(
+        lambda tree: tuple(block.mlp.router_bias for block in tree.transformer.blocks),
+        mask,
+        tuple(False for _ in model.transformer.blocks),
+    )
+
+
+class JunePipelineStage(eqx.Module):
+    """One contiguous set of June blocks with only its owned boundary weights."""
+
+    blocks: tuple[Block, ...]
+    token_embed: jax.Array | None
+    embed_norm: RMSNorm | None
+    embed_gated_norm: GatedNorm | None
+    final_norm: RMSNorm | None
+    final_gated_norm: GatedNorm | None
+    output_proj: jax.Array | None
+    config: GrugModelConfig = eqx.field(static=True)
+    layer_offset: int = eqx.field(static=True)
+
+    def embed(self, token_ids):
+        assert self.token_embed is not None and self.embed_norm is not None and self.embed_gated_norm is not None
+        hidden = self.token_embed.at[token_ids].get(out_sharding=P(("replica_dcn", "data", "expert")))
+        # Keep gather fusion from changing normalization rounding between scoring and AD.
+        hidden = jax.lax.optimization_barrier(hidden)
+        return self.embed_gated_norm(self.embed_norm(hidden))
+
+    def run_blocks(self, hidden, segment_ids, position_ids):
+        return self.run_blocks_with_stats(hidden, segment_ids, position_ids)[0]
+
+    def run_blocks_with_stats(self, hidden, segment_ids, position_ids):
+        """Return hidden states and total routing counts, including padding assignments."""
+        # Pipeline AD transports these counters through floating auxiliary values.
+        # Bound the complete microbatch so every count remains exactly representable.
+        assignment_bound = segment_ids.size * self.config.num_experts_per_token * self.config.num_layers
+        if get_abstract_mesh().shape["expert"] > 1 and assignment_bound > 2**24:
+            raise ValueError(
+                "EP routing telemetry requires at most 2**24 assignments per microbatch; use more microbatches"
+            )
+        stats = {
+            name: jnp.asarray(0, dtype=jnp.int32)
+            for name in ("routing_assignments", "routing_sender_drops", "routing_receiver_drops")
+        }
+        max_layer_drops = jnp.asarray(0, dtype=jnp.int32)
+        drop_layer = jnp.asarray(-1, dtype=jnp.int32)
+        segments = (segment_ids, segment_ids)
+        short_mask = GrugAttentionMask(is_causal=True, sliding_window=self.config.sliding_window, segment_ids=segments)
+        long_mask = GrugAttentionMask(is_causal=True, segment_ids=segments)
+        for index, block in enumerate(self.blocks, start=self.layer_offset):
+            is_long = index % 4 == 3 or index == self.config.num_layers - 1
+            hidden, layer_stats = eqx.filter_checkpoint(block)(
+                hidden,
+                short_mask,
+                long_mask,
+                is_long,
+                False,
+                True,
+                position_ids,
+            )
+            stats = {name: count + layer_stats[name] for name, count in stats.items()}
+            layer_drops = layer_stats["routing_sender_drops"] + layer_stats["routing_receiver_drops"]
+            max_layer_drops = jnp.maximum(max_layer_drops, layer_drops)
+            drop_layer = jnp.where(layer_drops > 0, index, drop_layer)
+        return hidden, {**stats, "routing_max_layer_drops": max_layer_drops, "routing_drop_layer": drop_layer}
+
+    def finish(self, hidden):
+        assert self.final_norm is not None and self.final_gated_norm is not None
+        return self.final_gated_norm(self.final_norm(hidden))
+
+    def get_lm_head(self):
+        assert self.output_proj is not None
+        return self.output_proj
+
+    def to_state_dict(self, prefix=None) -> StateDict:
+        """Export only this stage's tensors using global HF layer indices."""
+        tensors = {}
+        if self.token_embed is not None:
+            tensors.update(snowball_embeddings_to_state_dict(cast(SnowballTransformer, self), prefix))
+        if self.output_proj is not None:
+            tensors.update(snowball_final_to_state_dict(cast(SnowballTransformer, self), prefix))
+        for index, block in enumerate(self.blocks, start=self.layer_offset):
+            tensors.update(snowball_block_to_state_dict(cast(SnowballBlock, block), index, prefix))
+        return tensors
+
+    def from_state_dict(self, state_dict: StateDict, prefix=None):
+        """Load an owned-stage tensor subset without constructing the full model."""
+        stage = self
+        if self.token_embed is not None:
+            stage = cast(
+                JunePipelineStage,
+                snowball_embeddings_from_state_dict(
+                    cast(SnowballTransformer, stage),
+                    state_dict,
+                    prefix,
+                ),
+            )
+        if self.output_proj is not None:
+            stage = cast(
+                JunePipelineStage,
+                snowball_final_from_state_dict(
+                    cast(SnowballTransformer, stage),
+                    state_dict,
+                    prefix,
+                ),
+            )
+        blocks = tuple(
+            cast(Block, snowball_block_from_state_dict(cast(SnowballBlock, block), state_dict, index, prefix))
+            for index, block in enumerate(stage.blocks, start=stage.layer_offset)
+        )
+        return eqx.tree_at(lambda stage: stage.blocks, stage, blocks)
+
+    def trainable_filter(self):
+        mask = jax.tree.map(lambda _: True, self)
+        return eqx.tree_at(
+            lambda stage: tuple(block.mlp.router_bias for block in stage.blocks), mask, tuple(False for _ in self.blocks)
+        )
+
+
+def split_june_pipeline_model(model: JuneSnowballLMHeadModel, num_stages: int) -> tuple[JunePipelineStage, ...]:
+    """Partition tuple blocks and boundary weights without copying model arrays."""
+    transformer = model.transformer
+    assert transformer.blocks is not None
+    stages = []
+    for stage_index, (start, end) in enumerate(evenly_partition_layers(len(transformer.blocks), num_stages)):
+        first, last = stage_index == 0, stage_index == num_stages - 1
+        stages.append(
+            JunePipelineStage(
+                blocks=transformer.blocks[start:end],
+                token_embed=transformer.token_embed if first else None,
+                embed_norm=transformer.embed_norm if first else None,
+                embed_gated_norm=transformer.embed_gated_norm if first else None,
+                final_norm=transformer.final_norm if last else None,
+                final_gated_norm=transformer.final_gated_norm if last else None,
+                output_proj=transformer.output_proj if last else None,
+                config=transformer.config,
+                layer_offset=start,
+            )
+        )
+    return tuple(stages)

--- a/lib/levanter/src/levanter/models/snowball.py
+++ b/lib/levanter/src/levanter/models/snowball.py
@@ -769,42 +769,52 @@ def _T(value: jax.Array) -> jax.Array:
     return jnp.swapaxes(value, -1, -2)
 
 
-def snowball_to_state_dict(model: SnowballTransformer, prefix: Optional[str] = None) -> StateDict:
-    tensors: dict[str, jax.Array] = {
+def snowball_embeddings_to_state_dict(model: SnowballTransformer, prefix: Optional[str] = None) -> StateDict:
+    """Export the embeddings boundary using canonical HF keys."""
+    tensors = {
         "model.embed_tokens.weight": model.token_embed,
         "model.embed_norm.weight": model.embed_norm.weight,
         "model.embed_gated_norm.down_proj.weight": _T(model.embed_gated_norm.w_down),
         "model.embed_gated_norm.up_proj.weight": _T(model.embed_gated_norm.w_up),
+    }
+    return {_with_prefix(prefix, name): value for name, value in tensors.items()}
+
+
+def snowball_final_to_state_dict(model: SnowballTransformer, prefix: Optional[str] = None) -> StateDict:
+    """Export the final boundary using canonical HF keys."""
+    tensors = {
         "model.norm.weight": model.final_norm.weight,
         "model.final_gated_norm.down_proj.weight": _T(model.final_gated_norm.w_down),
         "model.final_gated_norm.up_proj.weight": _T(model.final_gated_norm.w_up),
         "lm_head.weight": _T(model.output_proj),
     }
-    for i, block in enumerate(model.blocks):
-        p = f"model.layers.{i}"
-        tensors.update(
-            {
-                f"{p}.input_layernorm.weight": block.rms_attn.weight,
-                f"{p}.attn_gated_norm.down_proj.weight": _T(block.attn_gated_norm.w_down),
-                f"{p}.attn_gated_norm.up_proj.weight": _T(block.attn_gated_norm.w_up),
-                f"{p}.self_attn.q_proj.weight": _T(block.attn.w_q),
-                f"{p}.self_attn.k_proj.weight": _T(block.attn.w_k),
-                f"{p}.self_attn.v_proj.weight": _T(block.attn.w_v),
-                f"{p}.self_attn.o_proj.weight": _T(block.attn.w_o),
-                f"{p}.self_attn.attn_gate.weight": _T(block.attn.attn_gate),
-                f"{p}.post_attention_layernorm.weight": block.rms_mlp.weight,
-                f"{p}.mlp_gated_norm.down_proj.weight": _T(block.mlp_gated_norm.w_down),
-                f"{p}.mlp_gated_norm.up_proj.weight": _T(block.mlp_gated_norm.w_up),
-                f"{p}.mlp.router.weight": _T(block.mlp.router),
-                f"{p}.mlp.router.bias": block.mlp.router_bias,
-                f"{p}.mlp.experts.gate_proj.weight": _T(block.mlp.expert_mlp.w_gate),
-                f"{p}.mlp.experts.up_proj.weight": _T(block.mlp.expert_mlp.w_up),
-                f"{p}.mlp.experts.down_proj.weight": _T(block.mlp.expert_mlp.w_down),
-                f"{p}.shared_expert.gate_proj.weight": _T(block.shared.w_gate),
-                f"{p}.shared_expert.up_proj.weight": _T(block.shared.w_up),
-                f"{p}.shared_expert.down_proj.weight": _T(block.shared.w_down),
-            }
-        )
+    return {_with_prefix(prefix, name): value for name, value in tensors.items()}
+
+
+def snowball_block_to_state_dict(block: SnowballBlock, layer_index: int, prefix: Optional[str] = None) -> StateDict:
+    """Export one layer under its global HF layer index."""
+    p = f"model.layers.{layer_index}"
+    tensors = {
+        f"{p}.input_layernorm.weight": block.rms_attn.weight,
+        f"{p}.attn_gated_norm.down_proj.weight": _T(block.attn_gated_norm.w_down),
+        f"{p}.attn_gated_norm.up_proj.weight": _T(block.attn_gated_norm.w_up),
+        f"{p}.self_attn.q_proj.weight": _T(block.attn.w_q),
+        f"{p}.self_attn.k_proj.weight": _T(block.attn.w_k),
+        f"{p}.self_attn.v_proj.weight": _T(block.attn.w_v),
+        f"{p}.self_attn.o_proj.weight": _T(block.attn.w_o),
+        f"{p}.self_attn.attn_gate.weight": _T(block.attn.attn_gate),
+        f"{p}.post_attention_layernorm.weight": block.rms_mlp.weight,
+        f"{p}.mlp_gated_norm.down_proj.weight": _T(block.mlp_gated_norm.w_down),
+        f"{p}.mlp_gated_norm.up_proj.weight": _T(block.mlp_gated_norm.w_up),
+        f"{p}.mlp.router.weight": _T(block.mlp.router),
+        f"{p}.mlp.router.bias": block.mlp.router_bias,
+        f"{p}.mlp.experts.gate_proj.weight": _T(block.mlp.expert_mlp.w_gate),
+        f"{p}.mlp.experts.up_proj.weight": _T(block.mlp.expert_mlp.w_up),
+        f"{p}.mlp.experts.down_proj.weight": _T(block.mlp.expert_mlp.w_down),
+        f"{p}.shared_expert.gate_proj.weight": _T(block.shared.w_gate),
+        f"{p}.shared_expert.up_proj.weight": _T(block.shared.w_up),
+        f"{p}.shared_expert.down_proj.weight": _T(block.shared.w_down),
+    }
     return {_with_prefix(prefix, name): value for name, value in tensors.items()}
 
 
@@ -812,17 +822,11 @@ def _get(state_dict: StateDict, prefix: Optional[str], name: str) -> jax.Array:
     return jnp.asarray(state_dict[_with_prefix(prefix, name)])
 
 
-def snowball_from_state_dict(
+def snowball_embeddings_from_state_dict(
     template: SnowballTransformer, state_dict: StateDict, prefix: Optional[str] = None
 ) -> SnowballTransformer:
-    """Populate the template's leaves from canonical HF keys, resharding each to its Grug spec.
-
-    Each leaf must be resharded to its Grug partition spec on load: the generic loader only shards
-    NamedArray-keyed axes, so Snowball's raw-array leaves would otherwise load replicated (and the
-    67B would not fit).
-    """
+    """Load canonical HF embeddings weights into the current mesh."""
     g = lambda name: _get(state_dict, prefix, name)  # noqa: E731
-
     m = template
     m = eqx.tree_at(lambda t: t.token_embed, m, _reshard_for_init(g("model.embed_tokens.weight"), Pembed_vocab))
     m = eqx.tree_at(lambda t: t.embed_norm.weight, m, g("model.embed_norm.weight"))
@@ -832,6 +836,15 @@ def snowball_from_state_dict(
     m = eqx.tree_at(
         lambda t: t.embed_gated_norm.w_up, m, _reshard_replicated(_T(g("model.embed_gated_norm.up_proj.weight")))
     )
+    return m
+
+
+def snowball_final_from_state_dict(
+    template: SnowballTransformer, state_dict: StateDict, prefix: Optional[str] = None
+) -> SnowballTransformer:
+    """Load canonical HF final weights into the current mesh."""
+    g = lambda name: _get(state_dict, prefix, name)  # noqa: E731
+    m = template
     m = eqx.tree_at(lambda t: t.final_norm.weight, m, g("model.norm.weight"))
     m = eqx.tree_at(
         lambda t: t.final_gated_norm.w_down, m, _reshard_replicated(_T(g("model.final_gated_norm.down_proj.weight")))
@@ -841,78 +854,96 @@ def snowball_from_state_dict(
     )
     m = eqx.tree_at(lambda t: t.output_proj, m, _reshard_for_init(_T(g("lm_head.weight")), Plm_head))
 
-    for i in range(len(m.blocks)):
-        p = f"model.layers.{i}"
-        m = eqx.tree_at(lambda t, i=i: t.blocks[i].rms_attn.weight, m, g(f"{p}.input_layernorm.weight"))
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn_gated_norm.w_down,
-            m,
-            _reshard_replicated(_T(g(f"{p}.attn_gated_norm.down_proj.weight"))),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn_gated_norm.w_up,
-            m,
-            _reshard_replicated(_T(g(f"{p}.attn_gated_norm.up_proj.weight"))),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn.w_q, m, _reshard(_T(g(f"{p}.self_attn.q_proj.weight")), P("data", "model"))
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn.w_k, m, _reshard(_T(g(f"{p}.self_attn.k_proj.weight")), P("data", "model"))
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn.w_v, m, _reshard(_T(g(f"{p}.self_attn.v_proj.weight")), P("data", "model"))
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn.w_o, m, _reshard(_T(g(f"{p}.self_attn.o_proj.weight")), P("model", "data"))
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].attn.attn_gate, m, _reshard_replicated(_T(g(f"{p}.self_attn.attn_gate.weight")))
-        )
-        m = eqx.tree_at(lambda t, i=i: t.blocks[i].rms_mlp.weight, m, g(f"{p}.post_attention_layernorm.weight"))
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].mlp_gated_norm.w_down,
-            m,
-            _reshard_replicated(_T(g(f"{p}.mlp_gated_norm.down_proj.weight"))),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].mlp_gated_norm.w_up,
-            m,
-            _reshard_replicated(_T(g(f"{p}.mlp_gated_norm.up_proj.weight"))),
-        )
-        m = eqx.tree_at(lambda t, i=i: t.blocks[i].mlp.router, m, _reshard_replicated(_T(g(f"{p}.mlp.router.weight"))))
-        m = eqx.tree_at(lambda t, i=i: t.blocks[i].mlp.router_bias, m, g(f"{p}.mlp.router.bias"))
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].mlp.expert_mlp.w_gate,
-            m,
-            _reshard(_T(g(f"{p}.mlp.experts.gate_proj.weight")), _EXPERT_GATE_UP_SPEC),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].mlp.expert_mlp.w_up,
-            m,
-            _reshard(_T(g(f"{p}.mlp.experts.up_proj.weight")), _EXPERT_GATE_UP_SPEC),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].mlp.expert_mlp.w_down,
-            m,
-            _reshard(_T(g(f"{p}.mlp.experts.down_proj.weight")), _EXPERT_DOWN_SPEC),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].shared.w_gate,
-            m,
-            _reshard(_T(g(f"{p}.shared_expert.gate_proj.weight")), P("data", "model")),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].shared.w_up,
-            m,
-            _reshard(_T(g(f"{p}.shared_expert.up_proj.weight")), P("data", "model")),
-        )
-        m = eqx.tree_at(
-            lambda t, i=i: t.blocks[i].shared.w_down,
-            m,
-            _reshard(_T(g(f"{p}.shared_expert.down_proj.weight")), P("model", "data")),
-        )
     return m
+
+
+def snowball_block_from_state_dict(
+    template: SnowballBlock, state_dict: StateDict, layer_index: int, prefix: Optional[str] = None
+) -> SnowballBlock:
+    """Load canonical HF block weights into the current mesh."""
+    g = lambda name: _get(state_dict, prefix, name)  # noqa: E731
+    m = template
+    p = f"model.layers.{layer_index}"
+    m = eqx.tree_at(lambda t: t.rms_attn.weight, m, g(f"{p}.input_layernorm.weight"))
+    m = eqx.tree_at(
+        lambda t: t.attn_gated_norm.w_down,
+        m,
+        _reshard_replicated(_T(g(f"{p}.attn_gated_norm.down_proj.weight"))),
+    )
+    m = eqx.tree_at(
+        lambda t: t.attn_gated_norm.w_up,
+        m,
+        _reshard_replicated(_T(g(f"{p}.attn_gated_norm.up_proj.weight"))),
+    )
+    m = eqx.tree_at(lambda t: t.attn.w_q, m, _reshard(_T(g(f"{p}.self_attn.q_proj.weight")), P("data", "model")))
+    m = eqx.tree_at(lambda t: t.attn.w_k, m, _reshard(_T(g(f"{p}.self_attn.k_proj.weight")), P("data", "model")))
+    m = eqx.tree_at(lambda t: t.attn.w_v, m, _reshard(_T(g(f"{p}.self_attn.v_proj.weight")), P("data", "model")))
+    m = eqx.tree_at(lambda t: t.attn.w_o, m, _reshard(_T(g(f"{p}.self_attn.o_proj.weight")), P("model", "data")))
+    m = eqx.tree_at(lambda t: t.attn.attn_gate, m, _reshard_replicated(_T(g(f"{p}.self_attn.attn_gate.weight"))))
+    m = eqx.tree_at(lambda t: t.rms_mlp.weight, m, g(f"{p}.post_attention_layernorm.weight"))
+    m = eqx.tree_at(
+        lambda t: t.mlp_gated_norm.w_down,
+        m,
+        _reshard_replicated(_T(g(f"{p}.mlp_gated_norm.down_proj.weight"))),
+    )
+    m = eqx.tree_at(
+        lambda t: t.mlp_gated_norm.w_up,
+        m,
+        _reshard_replicated(_T(g(f"{p}.mlp_gated_norm.up_proj.weight"))),
+    )
+    m = eqx.tree_at(lambda t: t.mlp.router, m, _reshard_replicated(_T(g(f"{p}.mlp.router.weight"))))
+    m = eqx.tree_at(lambda t: t.mlp.router_bias, m, g(f"{p}.mlp.router.bias"))
+    m = eqx.tree_at(
+        lambda t: t.mlp.expert_mlp.w_gate,
+        m,
+        _reshard(_T(g(f"{p}.mlp.experts.gate_proj.weight")), _EXPERT_GATE_UP_SPEC),
+    )
+    m = eqx.tree_at(
+        lambda t: t.mlp.expert_mlp.w_up,
+        m,
+        _reshard(_T(g(f"{p}.mlp.experts.up_proj.weight")), _EXPERT_GATE_UP_SPEC),
+    )
+    m = eqx.tree_at(
+        lambda t: t.mlp.expert_mlp.w_down,
+        m,
+        _reshard(_T(g(f"{p}.mlp.experts.down_proj.weight")), _EXPERT_DOWN_SPEC),
+    )
+    m = eqx.tree_at(
+        lambda t: t.shared.w_gate,
+        m,
+        _reshard(_T(g(f"{p}.shared_expert.gate_proj.weight")), P("data", "model")),
+    )
+    m = eqx.tree_at(
+        lambda t: t.shared.w_up,
+        m,
+        _reshard(_T(g(f"{p}.shared_expert.up_proj.weight")), P("data", "model")),
+    )
+    m = eqx.tree_at(
+        lambda t: t.shared.w_down,
+        m,
+        _reshard(_T(g(f"{p}.shared_expert.down_proj.weight")), P("model", "data")),
+    )
+    return m
+
+
+def snowball_to_state_dict(model: SnowballTransformer, prefix: Optional[str] = None) -> StateDict:
+    tensors = snowball_embeddings_to_state_dict(model, prefix)
+    tensors.update(snowball_final_to_state_dict(model, prefix))
+    for index, block in enumerate(model.blocks):
+        tensors.update(snowball_block_to_state_dict(block, index, prefix))
+    return tensors
+
+
+def snowball_from_state_dict(
+    template: SnowballTransformer, state_dict: StateDict, prefix: Optional[str] = None
+) -> SnowballTransformer:
+    """Load HF weights with their Grug partition specs rather than replicating raw leaves."""
+    model = snowball_embeddings_from_state_dict(template, state_dict, prefix)
+    model = snowball_final_from_state_dict(model, state_dict, prefix)
+    blocks = tuple(
+        snowball_block_from_state_dict(block, state_dict, index, prefix) for index, block in enumerate(model.blocks)
+    )
+    return eqx.tree_at(lambda model: model.blocks, model, blocks)
 
 
 _EXPERT_GATE_UP_SPEC = P("expert", "data", "model")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Specifying Hardware Resources: references/resource-config.md
       - Default Steps: references/default-steps.md
       - Training Configuration: references/train-config.md
+      - Snowball Pipeline Stages: references/snowball-pipeline.md
       - HBM Optimization: references/hbm-optimization.md
       - Perplexity Gap Analysis: references/perplexity-gap-analysis.md
       - Browsing Buckets with fsutil: references/fsutil.md

--- a/tests/test_june_snowball_model.py
+++ b/tests/test_june_snowball_model.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+from typing import NamedTuple
 
 import equinox as eqx
 import haliax as hax
@@ -58,12 +59,18 @@ def _config():
     )
 
 
-def _inputs():
+class ModelInputs(NamedTuple):
+    tokens: hax.NamedArray
+    segments: hax.NamedArray
+    positions: hax.NamedArray
+
+
+def _inputs() -> ModelInputs:
     Batch, Position = hax.Axis("batch", jax.device_count()), hax.Axis("position", 6)
     tokens = hax.named(jnp.broadcast_to(jnp.array([0, 0, 2, 3, 4, 5]), (Batch.size, 6)), (Batch, Position))
     segments = hax.named(jnp.broadcast_to(jnp.array([0, 0, 1, 1, 1, 1]), (Batch.size, 6)), (Batch, Position))
     positions = hax.named(jnp.broadcast_to(jnp.array([0, 0, 0, 2, 4, 6]), (Batch.size, 6)), (Batch, Position))
-    return tokens, segments, positions
+    return ModelInputs(tokens, segments, positions)
 
 
 def _arrays(tree):

--- a/tests/test_june_snowball_model.py
+++ b/tests/test_june_snowball_model.py
@@ -1,0 +1,200 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from levanter.grug.attention import AttentionMask as GrugAttentionMask
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.layers.attention import AttentionMask
+from levanter.models.snowball import SnowballConfig
+
+from experiments.june_tpu_67b_a2b.moe.model import RMSNorm
+from experiments.june_tpu_67b_a2b.moe.rl_model import JuneSnowballConfig, split_june_pipeline_model
+
+
+def test_bf16_rms_norm_scoring_matches_differentiated_forward():
+    # This size exercises reduction fusion that differs when AD retains intermediates.
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        inputs = jax.random.normal(jax.random.PRNGKey(10), (2, 2048, 2560)).astype(jnp.bfloat16)
+        weight = (jax.random.normal(jax.random.PRNGKey(11), (2560,)) * 0.3 + 1).astype(jnp.bfloat16)
+        norm = RMSNorm(weight, eps=1e-6)
+
+        def forward(module, values):
+            return module(values)
+
+        def objective(module, values):
+            output = forward(module, values)
+            return jnp.mean(jnp.sin(output.astype(jnp.float32))), output
+
+        scored = jax.jit(forward)(norm, inputs)
+        (_, trained), gradients = jax.jit(jax.value_and_grad(objective, argnums=(0, 1), has_aux=True))(norm, inputs)
+        jax.block_until_ready(gradients)
+        np.testing.assert_array_equal(scored, trained)
+
+
+def _config():
+    return JuneSnowballConfig(
+        vocab_size=24,
+        hidden_dim=12,
+        intermediate_dim=16,
+        shared_expert_intermediate_dim=12,
+        num_experts=4,
+        num_experts_per_token=2,
+        num_layers=2,
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=8,
+        max_seq_len=8,
+        sliding_window=4,
+        initializer_std=0.02,
+        attention_implementation="reference",
+        moe_implementation="ring",
+    )
+
+
+def _inputs():
+    Batch, Position = hax.Axis("batch", jax.device_count()), hax.Axis("position", 6)
+    tokens = hax.named(jnp.broadcast_to(jnp.array([0, 0, 2, 3, 4, 5]), (Batch.size, 6)), (Batch, Position))
+    segments = hax.named(jnp.broadcast_to(jnp.array([0, 0, 1, 1, 1, 1]), (Batch.size, 6)), (Batch, Position))
+    positions = hax.named(jnp.broadcast_to(jnp.array([0, 0, 0, 2, 4, 6]), (Batch.size, 6)), (Batch, Position))
+    return tokens, segments, positions
+
+
+def _arrays(tree):
+    return [np.asarray(x) for x in jax.tree.leaves(eqx.filter(tree, eqx.is_array))]
+
+
+@pytest.mark.timeout(180)
+def test_june_hf_mapping_roundtrip_preserves_weights_and_forward():
+    config = _config()
+    decoded = JuneSnowballConfig.from_hf_config(config.to_hf_config(config.vocab_size))
+    assert isinstance(decoded, JuneSnowballConfig)
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        model = config.build(hax.Axis("vocab", config.vocab_size), key=jax.random.PRNGKey(5))
+        tensors = model.to_state_dict()
+        # A non-square Q projection catches transpose errors independently of roundtrip symmetry.
+        np.testing.assert_array_equal(
+            tensors["model.layers.0.self_attn.q_proj.weight"], model.transformer.blocks[0].attn.w_q.T
+        )
+        loaded = config.build(model.Vocab, key=jax.random.PRNGKey(9)).from_state_dict(tensors)
+        for source, restored in zip(_arrays(model), _arrays(loaded), strict=True):
+            np.testing.assert_array_equal(source, restored)
+        serving_config = SnowballConfig.from_hf_config(config.to_hf_config(config.vocab_size))
+        serving = serving_config.build(model.Vocab, key=jax.random.PRNGKey(3)).from_state_dict(tensors)
+        tokens, _, _ = _inputs()
+        # Unpadded inputs exercise shared HF semantics without the serving snapshot's mask limitation.
+        tokens = tokens["position", hax.ds(2, 4)]
+        actual = hax.named_jit(lambda m, t: m.activations(t))(loaded, tokens)
+        reference = hax.named_jit(lambda m, t: m.activations(t))(serving, tokens)
+        np.testing.assert_allclose(actual.array, reference.array, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.timeout(180)
+def test_june_adapter_preserves_mask_positions_and_transformer_gradient():
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        model = _config().build(hax.Axis("vocab", 24), key=jax.random.PRNGKey(7))
+        tokens, segments, positions = _inputs()
+        mask = AttentionMask.causal().with_segment_ids(segments)
+
+        def wrapped(m):
+            return m.activations(tokens, mask, pos_ids=positions).array[:, 2:].sum()
+
+        def direct(m):
+            hidden, _ = m.transformer(
+                tokens.array, GrugAttentionMask.causal().with_segment_ids(segments.array), position_ids=positions.array
+            )
+            return hidden[:, 2:].sum()
+
+        value, gradient = eqx.filter_jit(eqx.filter_value_and_grad(wrapped))(model)
+        expected, expected_gradient = eqx.filter_jit(eqx.filter_value_and_grad(direct))(model)
+        np.testing.assert_array_equal(value, expected)
+        for actual, reference in zip(_arrays(gradient), _arrays(expected_gradient), strict=True):
+            np.testing.assert_array_equal(actual, reference)
+        padded = hax.named_jit(lambda m, t, a, p: m.activations(t, a, pos_ids=p))(model, tokens, mask, positions)
+        unpadded_tokens = tokens["position", hax.ds(2, 4)]
+        unpadded_positions = positions["position", hax.ds(2, 4)]
+        unpadded = hax.named_jit(lambda m, t, p: m.activations(t, pos_ids=p))(model, unpadded_tokens, unpadded_positions)
+        np.testing.assert_allclose(padded.array[:, 2:], unpadded.array, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("num_layers", [2, 5])
+def test_june_pipeline_stage_split_preserves_masked_forward(num_layers):
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        model = dataclasses.replace(_config(), num_layers=num_layers).build(
+            hax.Axis("vocab", 24), key=jax.random.PRNGKey(21)
+        )
+        tokens, segments, positions = _inputs()
+        stages = split_june_pipeline_model(model, 2)
+
+        def pipeline(parts):
+            hidden = parts[0].embed(tokens.array)
+            counts = []
+            for stage in parts:
+                hidden, stats = stage.run_blocks_with_stats(hidden, segments.array, positions.array)
+                counts.append(stats)
+            hidden = parts[-1].finish(hidden)
+            return hidden @ parts[-1].get_lm_head(), counts
+
+        actual, counts = eqx.filter_jit(pipeline)(stages)
+        for stage, stats in zip(stages, counts, strict=True):
+            # Padding is routed too and consumes capacity; count the complete input width.
+            assert int(stats["routing_assignments"]) == tokens.array.size * 2 * len(stage.blocks)
+            assert int(stats["routing_sender_drops"]) == 0
+            assert int(stats["routing_receiver_drops"]) == 0
+            assert int(stats["routing_max_layer_drops"]) == 0
+            assert int(stats["routing_drop_layer"]) == -1
+        expected = hax.named_jit(
+            lambda m: m.activations(
+                tokens,
+                AttentionMask.causal().with_segment_ids(segments),
+                pos_ids=positions,
+            ).array
+            @ m.get_lm_head().array
+        )(model)
+        np.testing.assert_array_equal(actual, expected)
+        # Every parameter is owned by exactly one stage, including both boundary modules.
+        assert sum(array.size for array in _arrays(stages)) == sum(array.size for array in _arrays(model))
+
+
+@pytest.mark.timeout(180)
+def test_june_adapter_mask_axis_order_does_not_change_attention():
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        model = _config().build(hax.Axis("vocab", 24), key=jax.random.PRNGKey(23))
+        tokens, segments, positions = _inputs()
+        Batch = hax.Axis("batch", 2 * jax.device_count())
+        tokens, segments, positions = (hax.concatenate(Batch, [value, value]) for value in (tokens, segments, positions))
+        canonical = AttentionMask.causal().with_segment_ids(segments)
+        transposed = AttentionMask.causal().with_segment_ids(segments.rearrange(("position", "batch")))
+        score = hax.named_jit(lambda mask: model.activations(tokens, mask, pos_ids=positions))
+        expected = score(canonical)
+        actual = score(transposed)
+        np.testing.assert_array_equal(actual.array, expected.array)
+
+
+@pytest.mark.parametrize("num_stages", [1, 2, 3])
+def test_june_stage_hf_mapping_loads_only_owned_tensors(num_stages):
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        model = dataclasses.replace(_config(), num_layers=5).build(hax.Axis("vocab", 24), key=jax.random.PRNGKey(31))
+        full = model.to_state_dict(prefix="policy")
+        stage_tensors = {}
+        for stage in split_june_pipeline_model(model, num_stages):
+            owned = stage.to_state_dict(prefix="policy")
+            template = eqx.filter_eval_shape(lambda stage: stage, stage)
+            expected_shapes = eqx.filter_eval_shape(lambda stage: stage.to_state_dict(prefix="policy"), template)
+            assert owned.keys() == expected_shapes.keys()
+            assert not (stage_tensors.keys() & owned.keys())
+            stage_tensors.update(owned)
+            # The loader only receives this stage's key subset and abstract shape leaves.
+            restored = template.from_state_dict(owned, prefix="policy")
+            for expected, actual in zip(_arrays(stage), _arrays(restored), strict=True):
+                np.testing.assert_array_equal(expected, actual)
+        assert stage_tensors.keys() == full.keys()
+        for key, value in full.items():
+            np.testing.assert_array_equal(stage_tensors[key], value)


### PR DESCRIPTION
Expose the June Snowball transformer through Levanter and split it into contiguous pipeline stages that retain the original attention schedule. Each stage owns and loads only its HF tensor subset, including the embedding or output boundary when appropriate. Explicit position IDs, causal segment masks, configurable expert capacity, and routing-drop counters support packed expert-parallel execution.

Keep the demonstrated RMS, embedding-gather, and router-sigmoid rounding boundaries. Model tests cover HF loading, masked values and gradients, uneven stage partitions, and exact parameter ownership. These model changes are independent of the GRPO objective, pipeline scheduler, and checkpoint lifecycle; the full migration also needs its scorer-only compute-cast correction. Numerical evidence and its scope are recorded in https://marina.oa.dev/echo/wiki/363.
