### PR TITLE
[eval] Load GSM8K from openai/gsm8k

### DIFF
--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -96,6 +96,25 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+_TASK_DATASET_PATH_OVERRIDES = {
+    "gsm8k": "openai/gsm8k",
+    "gsm8k_cot": "openai/gsm8k",
+}
+
+
+def _task_spec_with_dataset_path_override(task: TaskConfig | str) -> dict[str, object] | str:
+    if isinstance(task, str):
+        dataset_path = _TASK_DATASET_PATH_OVERRIDES.get(task)
+        if dataset_path is None:
+            return task
+        return TaskConfig(task=task, dataset_path=dataset_path).to_dict()
+
+    if task.dataset_path is None:
+        dataset_path = _TASK_DATASET_PATH_OVERRIDES.get(task.task)
+        if dataset_path is not None:
+            task = dataclasses.replace(task, dataset_path=dataset_path)
+    return task.to_dict()
+
 
 def _call_with_retry(
     fn: Callable[[], T],
@@ -1047,7 +1066,7 @@ class LmEvalHarnessConfig:
         Returns:
             List of task specifications, with TaskConfig objects converted to dictionaries
         """
-        return [task.to_dict() if isinstance(task, TaskConfig) else task for task in self.task_spec]
+        return [_task_spec_with_dataset_path_override(task) for task in self.task_spec]
 
     def to_task_dict(self) -> dict:
         """

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -102,13 +102,7 @@ _TASK_DATASET_PATH_OVERRIDES = {
 }
 
 
-def _task_spec_with_dataset_path_override(task: TaskConfig | str) -> dict[str, object] | str:
-    if isinstance(task, str):
-        dataset_path = _TASK_DATASET_PATH_OVERRIDES.get(task)
-        if dataset_path is None:
-            return task
-        return TaskConfig(task=task, dataset_path=dataset_path).to_dict()
-
+def _task_config_with_dataset_path_override(task: TaskConfig) -> dict[str, object]:
     if task.dataset_path is None:
         dataset_path = _TASK_DATASET_PATH_OVERRIDES.get(task.task)
         if dataset_path is not None:
@@ -1066,7 +1060,15 @@ class LmEvalHarnessConfig:
         Returns:
             List of task specifications, with TaskConfig objects converted to dictionaries
         """
-        return [_task_spec_with_dataset_path_override(task) for task in self.task_spec]
+        task_specs: list[str | dict] = []
+        for task in self.task_spec:
+            if isinstance(task, str):
+                if task not in _TASK_DATASET_PATH_OVERRIDES:
+                    task_specs.append(task)
+                    continue
+                task = TaskConfig(task=task)
+            task_specs.append(_task_config_with_dataset_path_override(task))
+        return task_specs
 
     def to_task_dict(self) -> dict:
         """

--- a/lib/levanter/tests/test_eval_harness.py
+++ b/lib/levanter/tests/test_eval_harness.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from datasets import Dataset, DatasetDict
 from levanter.testing.helpers import skip_if_module_missing
 from transformers import AutoTokenizer
 
@@ -186,43 +185,6 @@ def test_task_config():
     q = config.to_task_dict()
 
     assert len(q) == 3
-
-
-@pytest.mark.parametrize(
-    ("task_spec", "expected_task", "expected_dataset_path"),
-    [
-        ("gsm8k", "gsm8k", "openai/gsm8k"),
-        (TaskConfig(task="gsm8k_cot"), "gsm8k_cot", "openai/gsm8k"),
-        (
-            TaskConfig(task="gsm8k", dataset_path="example/gsm8k"),
-            "gsm8k",
-            "example/gsm8k",
-        ),
-    ],
-)
-@skip_if_module_missing("lm_eval")
-def test_gsm8k_task_uses_namespaced_dataset(task_spec, expected_task, expected_dataset_path, monkeypatch):
-    dataset = DatasetDict(
-        {
-            "train": Dataset.from_dict({"question": ["What is 1 + 1?"], "answer": ["The answer is 2. #### 2"]}),
-            "test": Dataset.from_dict({"question": ["What is 2 + 2?"], "answer": ["The answer is 4. #### 4"]}),
-        }
-    )
-    loaded_dataset_paths = []
-
-    def load_dataset(path, *args, **kwargs):
-        loaded_dataset_paths.append(path)
-        if path != expected_dataset_path:
-            raise ValueError(f"Unexpected dataset path: {path}")
-        return dataset
-
-    monkeypatch.setattr("datasets.load_dataset", load_dataset)
-    monkeypatch.setattr("levanter.eval_harness.time.sleep", lambda _: None)
-
-    task_dict = LmEvalHarnessConfig(task_spec=[task_spec]).to_task_dict()
-
-    assert list(task_dict) == [expected_task]
-    assert loaded_dataset_paths == [expected_dataset_path]
 
 
 def test_call_with_retry_does_not_sleep_after_the_last_attempt(monkeypatch):

--- a/lib/levanter/tests/test_eval_harness.py
+++ b/lib/levanter/tests/test_eval_harness.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from datasets import Dataset, DatasetDict
 from levanter.testing.helpers import skip_if_module_missing
 from transformers import AutoTokenizer
 
@@ -185,6 +186,43 @@ def test_task_config():
     q = config.to_task_dict()
 
     assert len(q) == 3
+
+
+@pytest.mark.parametrize(
+    ("task_spec", "expected_task", "expected_dataset_path"),
+    [
+        ("gsm8k", "gsm8k", "openai/gsm8k"),
+        (TaskConfig(task="gsm8k_cot"), "gsm8k_cot", "openai/gsm8k"),
+        (
+            TaskConfig(task="gsm8k", dataset_path="example/gsm8k"),
+            "gsm8k",
+            "example/gsm8k",
+        ),
+    ],
+)
+@skip_if_module_missing("lm_eval")
+def test_gsm8k_task_uses_namespaced_dataset(task_spec, expected_task, expected_dataset_path, monkeypatch):
+    dataset = DatasetDict(
+        {
+            "train": Dataset.from_dict({"question": ["What is 1 + 1?"], "answer": ["The answer is 2. #### 2"]}),
+            "test": Dataset.from_dict({"question": ["What is 2 + 2?"], "answer": ["The answer is 4. #### 4"]}),
+        }
+    )
+    loaded_dataset_paths = []
+
+    def load_dataset(path, *args, **kwargs):
+        loaded_dataset_paths.append(path)
+        if path != expected_dataset_path:
+            raise ValueError(f"Unexpected dataset path: {path}")
+        return dataset
+
+    monkeypatch.setattr("datasets.load_dataset", load_dataset)
+    monkeypatch.setattr("levanter.eval_harness.time.sleep", lambda _: None)
+
+    task_dict = LmEvalHarnessConfig(task_spec=[task_spec]).to_task_dict()
+
+    assert list(task_dict) == [expected_task]
+    assert loaded_dataset_paths == [expected_dataset_path]
 
 
 def test_call_with_retry_does_not_sleep_after_the_last_attempt(monkeypatch):


### PR DESCRIPTION
Use `openai/gsm8k` as the default `dataset_path` for Levanter's built-in `gsm8k` and `gsm8k_cot` task specs. Caller-supplied `dataset_path` values still pass through unchanged.

When `dataset_path` is unset, Levanter's pinned lm-eval task definitions default to the bare `gsm8k` identifier. With `datasets==4.8.5` and `huggingface-hub==1.21.0`, dataset loading rejects that identifier before evaluation begins.

Fixes #7004
