### PR TITLE
Add GRPO replay and packed pipeline learning

### DIFF
--- a/docs/references/grpo-replay.md
+++ b/docs/references/grpo-replay.md
@@ -1,0 +1,115 @@
+# GRPO replay and offline learning
+
+`levanter.grpo` implements the regular PPO surrogate used by the pinned
+MarinSkyRL GRPO recipe. `marin.rl.grpo_replay` checks captured loss values and
+logprob gradients. `marin.rl.train_grpo` trains a model on an ordered list of
+completed captures; rollout generation and online policy publication are outside
+this entrypoint.
+
+## Objective and captures
+
+Compute group advantages and objective weights over the complete admitted batch
+before dividing it into execution microbatches. Advantages use group sample
+standard deviation. Policy weights preserve the original objective partitions'
+masked token means; KL weights preserve their sequence means. A partition is
+an original oracle execution microbatch on one data-parallel rank. Partition
+means receive equal weight; within each KL partition, sequences receive equal
+weight. Empty responses count as sequences but contribute zero KL. Old-policy scores,
+reference scores, advantages, and weights are detached. `KlGradient` explicitly
+selects detached or differentiated reference KL; the pinned oracle uses detached
+KL, with gradients through current-policy scores disabled. Reference scores are
+always detached; `KlGradient.DIFFERENTIABLE` enables only the current-policy
+contribution. `accumulation_steps` cancels Levanter's averaging over execution microbatches.
+
+`marin.rl.grpo_artifact.GoldenRollout` stores complete token sequences, attention
+masks, response-aligned objectives, group IDs, original objective-partition IDs,
+and distinct raw-policy and sampling-policy scores. Its NPZ format embeds a JSON
+manifest and loads with pickle disabled. `write_golden_rollout` and
+`read_golden_rollout` validate the array shapes and masks.
+
+Replay requires the recorded MarinSkyRL oracle revision
+`8e33e01707b7225ecde1d6b8ad172a3dd4dc8661`, its configuration/provenance manifest,
+and captured independent Torch logprob gradients:
+
+```bash
+uv run python -m marin.rl.grpo_replay /data/golden.npz \
+  --output-uri /data/replay-result.json --atol 1e-5 --rtol 1e-5
+```
+
+The command rejects unsupported algorithm recipes and reports maximum/mean
+absolute errors for advantages, loss, gradients, and PPO diagnostics. Gradient
+comparisons divide by each positive policy weight before applying tolerances,
+so a large batch cannot hide an error through a small reduction weight. This
+checks the loss boundary; full-model optimizer parity requires separate evidence.
+
+The supported surrogate takes the minimum of the unclipped ratio advantage and
+the clipped-ratio advantage, with independently configured lower/upper clip
+widths. Reference KL uses the clipped k3 estimator. Singleton reward groups
+retain their reward; groups with equal rewards produce zero centered advantages.
+Normalization adds epsilon `1e-6` to the sample standard deviation.
+
+## Offline learner
+
+Run `uv run python -m marin.rl.train_grpo --config_path CONFIG.yaml` with an
+`OfflineGrpoConfig`. Required fields are `captures` (ordered NPZ paths),
+`initial_model`, `tokenizer`, and `hf_save_path`. Set
+`trainer.num_train_steps` to the number of captures and `trainer.train_batch_size`
+to each capture's trajectory count. Each complete batch must divide evenly by
+`trainer.microbatch_size` when configured. The model configuration defaults to
+Qwen3 and can be selected through Levanter's registered model configs.
+
+Each capture receives one update. Before that update, captured raw old-policy
+scores are replaced by current-learner scores; captured tokens, rewards, groups,
+partitions, and reference scores remain fixed. Sampling-policy scores are
+retained for provenance and do not enter importance correction. This is offline
+replay, not an off-policy-corrected training algorithm. Scoring and training use
+the same trajectory count and padded sequence width within each capture. Every
+capture must match the configured full batch count; a different sequence width
+can trigger recompilation. It disables dropout and masks padding as a separate
+attention segment. Every update saves through the existing Levanter checkpointer.
+To interrupt deliberately, set `stop_after` to an absolute step; resume with the
+same checkpointer path, run ID, ordered captures, and recipe, removing `stop_after`.
+The saved contract hashes capture contents and rejects changed inputs or recipes.
+At the final step the learner exports HF weights to `hf_save_path`.
+This uses the existing single-learner checkpoint lifecycle; stage-local pipeline
+checkpoint integration is separate.
+
+## Pipeline execution
+
+`levanter.grpo_pipeline` provides model-independent stage execution. A model
+implements `PipelineStage` for embeddings, blocks, final normalization, output
+weights, trainable selection, and routing counters. Install the root `pipeline`
+extra for JaxPP execution. The schedule is standard 1F1B; multihost execution
+requires one process to own all devices of each stage. Expert and replica axes
+must divide the device count evenly.
+
+`packed_pipeline_batch` uses Levanter packing to place complete trajectories in
+fixed-length rows. It preserves source position IDs, segment boundaries, and
+precomputed objective weights; it rejects trajectories longer than the row.
+Cross-segment targets and padding have zero objective weight. Choose row length
+and microbatch dimensions explicitly; packing does not split trajectories.
+
+The pipeline scorer applies `jax.lax.optimization_barrier` after casting
+trainable weights inside each stage. This blocks the cast fusion that caused the
+observed June scorer/training discrepancy; other models and shapes still require
+validation. Frozen tensors retain their dtype. The training path keeps
+FP32 master parameters and exposes FP32 or BF16 temporal gradient accumulation;
+global gradient clipping precedes the stage-local optimizer updates.
+Routing drops are rejected by default. `RoutingDropPolicy.REPORT` explicitly
+allows capacity experiments and reports assignment counts, including padding.
+
+`log_ratio_abs_max` measures the largest absolute difference between current and
+old logprobs where `policy_weights > 0`. PPO clipping-pressure metrics count
+ratios outside the configured clip interval with policy weights. `policy_kl`
+is the reference-KL estimator and is zero when its coefficient is zero; that
+zero alone does not demonstrate scorer agreement.
+
+The complete June integration, including separate model/kernel fixes, measured
+`log_ratio_abs_max == 0` before parameter changes in each of three packed 67B
+updates on 32 H100s with PP4/EP8 and capacity 16. This compares recomputed
+old-policy scores with training-forward scores where `policy_weights > 0`.
+Those results validate the combined integration; they are not an isolated
+validation of these learner modules.
+See the [numerical investigation](https://marina.oa.dev/echo/wiki/363) for the
+configuration, artifacts, and validation limits. The June entrypoint and online
+rollout lifecycle are separate integration work.

--- a/lib/levanter/src/levanter/grpo.py
+++ b/lib/levanter/src/levanter/grpo.py
@@ -1,0 +1,169 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Synchronous GRPO math with explicit objective partitions.
+
+Matches MarinSkyRL's regular PPO surrogate, sample-standard-deviation GRPO,
+masked token mean policy loss, and sequence mean k3 KL. Objective partitions
+are the reference learner's microbatches (including data-parallel ranks).
+Compute weights and advantages over the complete accepted batch before slicing
+execution microbatches; changing execution partitions then preserves the loss.
+Reference equations: marin-community/MarinSkyRL at
+8e33e01707b7225ecde1d6b8ad172a3dd4dc8661 (utils/{advantage_estimators,policy_losses,policy_math}.py).
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+import haliax as hax
+import jax
+import jax.numpy as jnp
+from haliax import Axis, NamedArray
+
+from levanter.metrics import Metric, ReductionType
+
+
+LOG_PROB_DELTA_CLIP = 20.0
+GRPO_EPSILON = 1e-6
+
+
+class KlGradient(StrEnum):
+    DETACHED = "detached"
+    DIFFERENTIABLE = "differentiable"
+
+
+@dataclass(frozen=True)
+class GrpoConfig:
+    eps_clip_low: float
+    eps_clip_high: float
+    kl_loss_coef: float
+    kl_gradient: KlGradient
+
+
+def grpo_advantages(
+    token_rewards: NamedArray,
+    response_mask: NamedArray,
+    group_ids: NamedArray,
+    *,
+    Batch: Axis,
+    Position: Axis,
+    num_groups: int,
+    normalize_by_std: bool,
+) -> NamedArray:
+    """Compute detached token advantages from complete admitted groups.
+
+    Group IDs must be dense integers in [0, num_groups). Rewards are summed
+    without masking, matching the oracle's outcome-reward contract. Singleton
+    groups retain their score (divided by 1 + epsilon when normalizing).
+    """
+    scores = token_rewards.sum(Position).rearrange((Batch,)).array.astype(jnp.float32)
+    ids = group_ids.rearrange((Batch,)).array
+    counts = jax.ops.segment_sum(jnp.ones_like(scores), ids, num_groups)
+    means = jax.ops.segment_sum(scores, ids, num_groups) / jnp.maximum(counts, 1)
+    centered = scores - means[ids]
+    variances = jax.ops.segment_sum(centered**2, ids, num_groups) / jnp.maximum(counts - 1, 1)
+    group_mean = jnp.where(counts[ids] > 1, means[ids], 0)
+    std = jnp.where(counts[ids] > 1, jnp.sqrt(variances[ids]), 1)
+    advantages = scores - group_mean
+    if normalize_by_std:
+        advantages = advantages / (std + GRPO_EPSILON)
+    result = hax.named(jax.lax.stop_gradient(advantages), Batch) * response_mask
+    return result.rearrange((Batch, Position))
+
+
+def grpo_objective_weights(
+    response_mask: NamedArray,
+    objective_partition_ids: NamedArray,
+    *,
+    Batch: Axis,
+    Position: Axis,
+    num_partitions: int,
+) -> tuple[NamedArray, NamedArray]:
+    """Return policy and KL weights preserving reference partition reductions.
+
+    Partition IDs must densely enumerate all reference microbatches across DP
+    ranks in [0, num_partitions). Each reference partition has equal objective
+    weight. An empty response contributes zero but still counts as a sequence
+    in the KL mean. The response mask must be binary.
+    """
+    mask = response_mask.rearrange((Batch, Position)).array.astype(jnp.float32)
+    ids = objective_partition_ids.rearrange((Batch,)).array
+    lengths = mask.sum(axis=1)
+    tokens = jax.ops.segment_sum(lengths, ids, num_partitions)
+    sequences = jax.ops.segment_sum(jnp.ones_like(lengths), ids, num_partitions)
+    policy = mask / (jnp.maximum(tokens[ids], 1)[:, None] * num_partitions)
+    kl = mask / (jnp.maximum(lengths, 1)[:, None] * jnp.maximum(sequences[ids], 1)[:, None] * num_partitions)
+    return hax.named(policy, (Batch, Position)), hax.named(kl, (Batch, Position))
+
+
+def _clamp(value: NamedArray, low: float, high: float) -> NamedArray:
+    # Torch clamp passes the full gradient at either boundary; JAX clip halves it.
+    return hax.where(value < low, low, hax.where(value > high, high, value))
+
+
+def grpo_loss(
+    log_probs: NamedArray,
+    old_log_probs: NamedArray,
+    reference_log_probs: NamedArray | None,
+    advantages: NamedArray,
+    policy_weights: NamedArray,
+    kl_weights: NamedArray,
+    *,
+    config: GrpoConfig,
+    accumulation_steps: int,
+) -> tuple[jax.Array, dict[str, Metric]]:
+    """Return loss and additive metrics for Levanter gradient accumulation.
+
+    Pass the number of execution microbatches as accumulation_steps to cancel
+    Levanter's gradient averaging. All other inputs are sliced from the full
+    batch; old/reference logprobs, advantages and weights are detached. The
+    captured MarinSkyRL oracle uses detached KL, which affects reported loss
+    but contributes no gradient. Choose that behavior explicitly in config.
+    """
+    if accumulation_steps < 1:
+        raise ValueError("accumulation_steps must be positive")
+    old_log_probs = jax.tree_util.tree_map(jax.lax.stop_gradient, old_log_probs)
+    advantages = jax.tree_util.tree_map(jax.lax.stop_gradient, advantages)
+    policy_weights = jax.tree_util.tree_map(jax.lax.stop_gradient, policy_weights)
+    kl_weights = jax.tree_util.tree_map(jax.lax.stop_gradient, kl_weights)
+    ratio = hax.exp(
+        _clamp((log_probs - old_log_probs).astype(jnp.float32), -LOG_PROB_DELTA_CLIP, LOG_PROB_DELTA_CLIP)
+    ).astype(log_probs.dtype)
+    surrogate = ratio * advantages
+    clipped = _clamp(ratio, 1 - config.eps_clip_low, 1 + config.eps_clip_high) * advantages
+    policy_loss = -(hax.minimum(surrogate, clipped) * policy_weights).sum().scalar()
+    kl_loss = jnp.zeros((), dtype=log_probs.dtype)
+    if config.kl_loss_coef != 0:
+        if reference_log_probs is None:
+            raise ValueError("reference_log_probs are required for nonzero KL coefficient")
+        reference_log_probs = jax.tree_util.tree_map(jax.lax.stop_gradient, reference_log_probs)
+        delta = _clamp(reference_log_probs - log_probs, -LOG_PROB_DELTA_CLIP, LOG_PROB_DELTA_CLIP)
+        kl = _clamp(hax.exp(delta) - delta - 1, -10.0, 10.0)
+        if config.kl_gradient == KlGradient.DETACHED:
+            kl = jax.tree_util.tree_map(jax.lax.stop_gradient, kl)
+        kl_loss = (kl * kl_weights).sum().scalar()
+    loss = policy_loss + config.kl_loss_coef * kl_loss
+    metrics = {
+        "loss": Metric.from_value(loss, ReductionType.SUM),
+        "policy_loss": Metric.from_value(policy_loss, ReductionType.SUM),
+        "policy_kl": Metric.from_value(kl_loss, ReductionType.SUM),
+        "ppo_clip_ratio": Metric.from_value(
+            ((clipped < surrogate) * policy_weights).sum().scalar(), ReductionType.SUM
+        ),
+    }
+    selected = clipped < surrogate
+    low_pressure = ratio < 1 - config.eps_clip_low
+    high_pressure = ratio > 1 + config.eps_clip_high
+    for name, condition in (
+        ("ppo_clip_ratio_low", selected & low_pressure),
+        ("ppo_clip_ratio_high", selected & high_pressure),
+        ("ppo_clip_pressure_low", low_pressure),
+        ("ppo_clip_pressure_high", high_pressure),
+        ("ppo_ratio_exact_unit_fraction", ratio == 1),
+    ):
+        metrics[name] = Metric.from_value((condition * policy_weights).sum().scalar(), ReductionType.SUM)
+    metrics["log_ratio_abs_max"] = Metric.from_value(
+        hax.where(policy_weights > 0, hax.abs(log_probs - old_log_probs), 0).max().scalar(),
+        ReductionType.MAX,
+    )
+    return loss * accumulation_steps, metrics

--- a/lib/levanter/src/levanter/grpo_model.py
+++ b/lib/levanter/src/levanter/grpo_model.py
@@ -1,0 +1,102 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-facing scoring and loss for persisted synchronous GRPO examples."""
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+from haliax import NamedArray
+
+from levanter.grpo import GrpoConfig, grpo_loss
+from levanter.layers.attention import AttentionMask
+from levanter.metrics import Metric
+from levanter.models.lm_model import LmHeadModel, split_activations
+from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
+from levanter.utils.tree_utils import inference_mode
+
+
+class GrpoExample(eqx.Module):
+    """A learner batch with complete sequences and aligned response objectives.
+
+    Full sequences use axes (batch, position); objective arrays use
+    (batch, response). The final response.size sequence positions are the
+    response, including any masked trailing padding. Position IDs count real
+    tokens from zero, independently of left padding. Objective weights and
+    advantages must be computed before slicing execution microbatches.
+    """
+
+    tokens: NamedArray
+    attention_mask: NamedArray
+    position_ids: NamedArray
+    response_mask: NamedArray
+    advantages: NamedArray
+    policy_weights: NamedArray
+    kl_weights: NamedArray
+    old_logprobs: NamedArray
+    reference_logprobs: NamedArray | None
+
+
+def response_logprobs(
+    model: LmHeadModel,
+    batch: GrpoExample,
+    *,
+    key: jax.Array | None = None,
+    block_size: int = 1024,
+) -> NamedArray:
+    """Score raw-policy response tokens without materializing full-vocab logits.
+
+    Both scoring and training disable dropout. Padding forms a separate
+    attention segment, so valid queries cannot attend to padded keys. Returned
+    values include masked response positions; their objective weights are zero.
+    """
+    Position = batch.tokens.resolve_axis("position")
+    Response = batch.response_mask.resolve_axis("response")
+    if Response.size >= Position.size:
+        raise ValueError("Every response needs at least one preceding prompt token")
+    if block_size < 1:
+        raise ValueError("block_size must be positive")
+    model = inference_mode(model, True)
+    mask = AttentionMask.causal().with_segment_ids(batch.attention_mask.astype(jnp.int32))
+    activations, _ = split_activations(model.activations(batch.tokens, mask, pos_ids=batch.position_ids, key=key))
+    # A token at i is scored by the activation at i-1. Slice before the
+    # vocabulary projection so prompt positions do not incur that cost.
+    start = Position.size - Response.size
+    predictions = activations[Position, hax.ds(start - 1, Response.size)].rename({Position.name: Response.name})
+    targets = batch.tokens[Position, hax.ds(start, Response.size)].rename({Position.name: Response.name})
+    loss = fused_cross_entropy_loss_and_logsumexp_penalty(
+        predictions.astype(jnp.float32),
+        model.get_lm_head().astype(jnp.float32),
+        Contract=model.Embed,
+        Label=model.Vocab,
+        target_y=targets,
+        reduction=None,
+        logsumexp_weight=0.0,
+        block_size=block_size,
+        dtype=jnp.float32,
+    )
+    return -loss.rearrange(("batch", "response"))
+
+
+def grpo_model_loss(
+    model: LmHeadModel,
+    batch: GrpoExample,
+    *,
+    key: jax.Array | None,
+    config: GrpoConfig,
+    accumulation_steps: int,
+    block_size: int,
+) -> tuple[jax.Array, dict[str, Metric]]:
+    """Compute the same inference-mode raw-policy scores and GRPO objective."""
+    current = response_logprobs(model, batch, key=key, block_size=block_size)
+    return grpo_loss(
+        current,
+        batch.old_logprobs,
+        batch.reference_logprobs,
+        batch.advantages,
+        batch.policy_weights,
+        batch.kl_weights,
+        config=config,
+        accumulation_steps=accumulation_steps,
+    )

--- a/lib/levanter/src/levanter/grpo_pipeline.py
+++ b/lib/levanter/src/levanter/grpo_pipeline.py
@@ -3,7 +3,7 @@
 
 """Stage-owned GRPO execution using JaxPP's standard 1F1B schedule.
 
-MPMD placement and initialization follow Marin PR 8739, commit f32a83bc.
+Each stage owns its model weights and optimizer moments.
 Model-specific stage wrappers implement the protocol below; this module owns
 only scoring, objective reduction, global clipping, and optimizer execution.
 """
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import partial
-from typing import Any, Protocol
+from typing import Any, NamedTuple, Protocol
 
 import equinox as eqx
 import haliax as hax
@@ -536,6 +536,12 @@ def _place_existing(tree, targets, mpmd_mesh):
     return jax.tree.map(place, tree, targets)
 
 
+class PreparedPipelineTrain(NamedTuple):
+    update: Callable
+    state: PipelineState
+    batches: PipelineBatch
+
+
 def prepare_pipeline_train(step, state, batches, mpmd_mesh):
     """Compile, place scalar state, and consume input batches into stage-owned arrays."""
     api = _require_jaxpp()
@@ -557,7 +563,7 @@ def prepare_pipeline_train(step, state, batches, mpmd_mesh):
     state = _place_existing(state, state_specs, mpmd_mesh)
     batches = api.spmd_to_mpmd_reshard(mpmd_mesh, batches, batch_specs, threshold=0)
     batches = _place_existing(batches, batch_specs, mpmd_mesh)
-    return partial(_run_pipeline_update, compiled), state, batches
+    return PreparedPipelineTrain(partial(_run_pipeline_update, compiled), state, batches)
 
 
 def _run_pipeline_update(compiled, state, batches):

--- a/lib/levanter/src/levanter/grpo_pipeline.py
+++ b/lib/levanter/src/levanter/grpo_pipeline.py
@@ -1,0 +1,699 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stage-owned GRPO execution using JaxPP's standard 1F1B schedule.
+
+MPMD placement and initialization follow Marin PR 8739, commit f32a83bc.
+Model-specific stage wrappers implement the protocol below; this module owns
+only scoring, objective reduction, global clipping, and optimizer execution.
+"""
+
+import dataclasses
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import partial
+from typing import Any, Protocol
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from jax.sharding import AxisType, Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from levanter.data.packing import SequencePacker, pack_documents
+from levanter.grpo import GrpoConfig, grpo_loss
+from levanter.grpo_model import GrpoExample
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.pipeline import reshape_batch_into_microbatches
+from levanter.utils.jax_utils import barrier_sync, multihost_broadcast_sync
+
+try:
+    import jaxpp.api as pp  # pyrefly: ignore[missing-import]  # Optional pipeline extra.
+except ModuleNotFoundError as error:
+    if error.name != "jaxpp":
+        raise
+    pp = None
+
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_SCHEDULE = "std_1f1b"
+_SCORING_WINDOW_SIZE = 8
+BATCH_AXES = ("replica_dcn", "data", "expert")
+ROUTING_METRIC_NAMES = (
+    "routing_assignments",
+    "routing_sender_drops",
+    "routing_receiver_drops",
+    "routing_max_layer_drops",
+    "routing_drop_layer",
+)
+ROUTING_MAX_METRICS = ("routing_max_layer_drops", "routing_drop_layer")
+METRIC_NAMES = (
+    "loss",
+    "policy_loss",
+    "policy_kl",
+    "ppo_clip_ratio",
+    "ppo_clip_ratio_low",
+    "ppo_clip_ratio_high",
+    "ppo_clip_pressure_low",
+    "ppo_clip_pressure_high",
+    "ppo_ratio_exact_unit_fraction",
+    "log_ratio_abs_max",
+)
+
+
+class PipelineStage(Protocol):
+    """An Equinox stage owning a contiguous layer range and its boundary weights."""
+
+    def embed(self, token_ids: jax.Array) -> jax.Array: ...
+    def run_blocks(self, hidden: jax.Array, segment_ids: jax.Array, position_ids: jax.Array) -> jax.Array: ...
+    def run_blocks_with_stats(self, hidden: jax.Array, segment_ids: jax.Array, position_ids: jax.Array): ...
+    def finish(self, hidden: jax.Array) -> jax.Array: ...
+    def get_lm_head(self) -> jax.Array: ...
+    def trainable_filter(self) -> Any: ...
+
+
+@dataclass(frozen=True)
+class GrpoPipelineConfig:
+    stages: int
+    microbatches: int
+    max_grad_norm: float
+    gradient_accum_dtype: str = "float32"
+    expert_axis_size: int = 1
+
+    def __post_init__(self):
+        if self.stages < 2 or self.microbatches < self.stages:
+            raise ValueError("Pipeline GRPO requires at least two stages and at least one microbatch per stage")
+        if self.gradient_accum_dtype not in ("float32", "bfloat16"):
+            raise ValueError("gradient_accum_dtype must be float32 or bfloat16")
+        if self.expert_axis_size < 1:
+            raise ValueError("expert_axis_size must be positive")
+        if self.max_grad_norm <= 0:
+            raise ValueError("max_grad_norm must be positive")
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class PipelineBatch:
+    tokens: jax.Array
+    attention_mask: jax.Array
+    segment_ids: jax.Array
+    position_ids: jax.Array
+    advantages: jax.Array
+    policy_weights: jax.Array
+    kl_weights: jax.Array
+    old_logprobs: jax.Array
+    reference_logprobs: jax.Array
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class PipelineState:
+    trainable: tuple[Any, ...]
+    frozen: tuple[Any, ...]
+    opt_state: tuple[optax.OptState, ...]
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class _OptimizerState:
+    trainable: tuple[Any, ...]
+    opt_state: tuple[optax.OptState, ...]
+
+
+def pipeline_batch(example: GrpoExample, *, microbatches: int) -> PipelineBatch:
+    """Convert named examples once, then add an explicit temporal batch axis."""
+
+    def sequence(value):
+        return value.rearrange(("batch", "position")).array
+
+    def response(value):
+        return value.rearrange(("batch", "response")).array
+
+    batch = PipelineBatch(
+        sequence(example.tokens),
+        sequence(example.attention_mask),
+        sequence(example.attention_mask),
+        sequence(example.position_ids),
+        response(example.advantages),
+        response(example.policy_weights),
+        response(example.kl_weights),
+        response(example.old_logprobs),
+        (
+            jnp.zeros_like(response(example.old_logprobs))
+            if example.reference_logprobs is None
+            else response(example.reference_logprobs)
+        ),
+    )
+    return reshape_batch_into_microbatches(batch, microbatches)
+
+
+def packed_pipeline_batch(
+    example: GrpoExample,
+    *,
+    sequence_length: int,
+    rows_per_microbatch: int,
+    pad_token_id: int,
+    minimum_microbatches: int = 1,
+) -> PipelineBatch:
+    """Pack complete trajectories while preserving their precomputed objectives.
+
+    Only masked input padding is removed. Response fields move to the predictor
+    of their original target token; prompt, segment-boundary, and padding targets
+    receive zero objective weight. Source position IDs are preserved verbatim.
+    """
+    if sequence_length < 2 or rows_per_microbatch < 1 or minimum_microbatches < 1:
+        raise ValueError("Packing requires sequence_length >= 2 and positive batch dimensions")
+    source = jax.tree.map(lambda value: np.asarray(value[0]), pipeline_batch(example, microbatches=1))
+    response_mask = np.asarray(example.response_mask.rearrange(("batch", "response")).array)
+    if np.any((source.attention_mask != 0) & (source.attention_mask != 1)):
+        raise ValueError("Packing requires a binary input attention mask")
+    valid = source.attention_mask.astype(bool)
+    lengths = valid.sum(axis=1)
+    packs = pack_documents(lengths, sequence_length, slice_strategy="raise")
+    microbatches = max(minimum_microbatches, (len(packs) + rows_per_microbatch - 1) // rows_per_microbatch)
+    rows = microbatches * rows_per_microbatch
+    tokens = np.full((rows, sequence_length), pad_token_id, dtype=np.int32)
+    segments = np.full((rows, sequence_length), -1, dtype=np.int32)
+    positions = np.zeros((rows, sequence_length), dtype=np.int32)
+    response_names = ("advantages", "policy_weights", "kl_weights", "old_logprobs", "reference_logprobs")
+    objective = {
+        name: np.zeros((rows, sequence_length - 1), dtype=getattr(source, name).dtype) for name in response_names
+    }
+    response_start = source.tokens.shape[1] - source.old_logprobs.shape[1]
+    if response_start < 1:
+        raise ValueError("Each response needs a preceding prompt token")
+    if np.any(response_mask > valid[:, response_start:]) or np.any(response_mask > valid[:, response_start - 1 : -1]):
+        raise ValueError("Each response target and its predecessor must be attended")
+    if np.any((response_mask == 0) & ((source.policy_weights != 0) | (source.kl_weights != 0))):
+        raise ValueError("Objective weights must be zero outside the response mask")
+    for row, documents in enumerate(packs):
+        packer = SequencePacker(hax.Axis("position", sequence_length), max(len(documents), 1), pad_token_id)
+        offset = 0
+        for document in documents:
+            indices = np.flatnonzero(valid[document])
+            count = len(indices)
+            packer.add_example(source.tokens[document, indices].tolist(), np.zeros(count), segment_id=document)
+            positions[row, offset : offset + count] = source.position_ids[document, indices]
+            for compact_target, target in enumerate(indices):
+                if target < response_start or compact_target == 0 or not valid[document, target - 1]:
+                    continue
+                response_index = target - response_start
+                predictor = offset + compact_target - 1
+                for name in response_names:
+                    objective[name][row, predictor] = getattr(source, name)[document, response_index]
+            offset += count
+        packed = packer.pack()
+        tokens[row] = np.asarray(packed.tokens.array)
+        segments[row] = np.asarray(packed.attn_mask.segment_ids[0].array)
+    batch = PipelineBatch(
+        tokens, (segments >= 0).astype(np.int32), segments, positions, *(objective[name] for name in response_names)
+    )
+    return reshape_batch_into_microbatches(jax.tree.map(jnp.asarray, batch), microbatches)
+
+
+def _require_jaxpp():
+    if pp is None:
+        raise ModuleNotFoundError("GRPO pipeline execution requires the root `pipeline` extra")
+    return pp
+
+
+def make_pipeline_mesh(config: GrpoPipelineConfig, *, replica_axis_size: int = 1):
+    """Create explicit stage/data/expert meshes without duplicating model state."""
+    expert_axis_size = config.expert_axis_size
+    if jax.process_count() > 1 and jax.process_count() != config.stages:
+        raise ValueError("Multihost GRPO requires one JAX process per pipeline stage")
+    api = _require_jaxpp()
+    fixed = config.stages * replica_axis_size * expert_axis_size
+    if jax.device_count() % fixed:
+        raise ValueError("Device count must divide evenly into pipeline, replica, and expert axes")
+    shape = (config.stages, replica_axis_size, jax.device_count() // fixed, expert_axis_size, 1)
+    ordered_devices = sorted(jax.devices(), key=lambda device: (device.process_index, device.local_hardware_id))
+    devices = np.asarray(ordered_devices, dtype=object).reshape(shape)
+    mesh = Mesh(devices, ("pipeline", *BATCH_AXES, "model"), axis_types=(AxisType.Explicit,) * len(shape))
+    if mesh.is_multi_process:
+        for stage_index in range(config.stages):
+            if {device.process_index for device in devices[stage_index].flat} != {stage_index}:
+                raise ValueError("Every process must own all devices of exactly one pipeline stage")
+    return mesh, api.MpmdMesh(mesh, "pipeline")
+
+
+def _is_array(value):
+    return isinstance(value, (jax.Array, jax.ShapeDtypeStruct)) or (pp is not None and isinstance(value, pp.MpmdArray))
+
+
+def _partition_specs(tree):
+    def spec(value):
+        if not _is_array(value):
+            return None
+        return (
+            value.sharding.spec
+            if isinstance(value.sharding, (NamedSharding, pp.MpmdSharding))
+            else P(*([None] * value.ndim))
+        )
+
+    return jax.tree.map(spec, tree)
+
+
+def _stage_shardings(mpmd_mesh, stage_index, tree):
+    api = _require_jaxpp()
+
+    def sharding(value):
+        if not _is_array(value):
+            return None
+        spec = value.sharding.spec if isinstance(value.sharding, NamedSharding) else P(*([None] * value.ndim))
+        return api.MpmdSharding(mpmd_mesh, mesh_ids={stage_index}, spec=spec)
+
+    return jax.tree.map(sharding, tree)
+
+
+def _owns(sharding):
+    return any(device.process_index == jax.process_index() for device in sharding.mesh.devices.flat)
+
+
+def initialize_pipeline_state(stages: tuple[PipelineStage, ...], optimizer, mpmd_mesh) -> PipelineState:
+    """Consume source stages, place owned weights, then allocate stage-local moments."""
+    api = _require_jaxpp()
+    trainable, frozen = zip(*(eqx.partition(stage, stage.trainable_filter()) for stage in stages), strict=True)
+    trainable = api.spmd_to_mpmd_reshard(
+        mpmd_mesh,
+        trainable,
+        tuple(_stage_shardings(mpmd_mesh, i, stage) for i, stage in enumerate(trainable)),
+        threshold=0,
+    )
+    frozen = api.spmd_to_mpmd_reshard(
+        mpmd_mesh,
+        frozen,
+        tuple(_stage_shardings(mpmd_mesh, i, stage) for i, stage in enumerate(frozen)),
+        threshold=0,
+    )
+    opt_state = []
+    for i, stage in enumerate(trainable):
+        sharding = NamedSharding(mpmd_mesh.unstack[i], P())
+
+        def localize(value):
+            if _is_array(value) and value.shape == ():
+                if _owns(sharding):
+                    return jax.device_put(np.asarray(value), sharding)
+                return jax.make_array_from_single_device_arrays((), sharding, [], dtype=value.dtype)
+            return value
+
+        opt_state.append(jax.tree.map(localize, optimizer.init(stage)))
+    return PipelineState(tuple(trainable), tuple(frozen), tuple(opt_state))
+
+
+def _score_stages(
+    trainable,
+    frozen,
+    batch: PipelineBatch,
+    mp_policy,
+    mark: Callable,
+    *,
+    report_routing=False,
+    compute_weight_boundary: Callable = lambda value: value,
+):
+    hidden = None
+    last = None
+    routing = {
+        # Integer auxiliary outputs generate float0 cotangents that JaxPP cannot
+        # transfer. Cast exact per-microbatch counts back to int32 after AD.
+        name: jnp.asarray(
+            -1 if name == "routing_drop_layer" else 0,
+            dtype=jnp.float32,
+        )
+        for name in ROUTING_METRIC_NAMES
+    }
+    for index, (params, fixed) in enumerate(zip(trainable, frozen, strict=True)):
+        # Fixed routing bias remains FP32; only trainable weights enter compute precision.
+        stage = eqx.combine(compute_weight_boundary(mp_policy.cast_to_compute(params)), fixed)
+        if index == 0:
+            hidden = stage.embed(batch.tokens)
+        if report_routing:
+            hidden, stage_routing = stage.run_blocks_with_stats(hidden, batch.segment_ids, batch.position_ids)
+            routing = {
+                name: (
+                    jnp.maximum(routing[name], stage_routing[name].astype(jnp.float32))
+                    if name in ROUTING_MAX_METRICS
+                    else routing[name] + stage_routing[name].astype(jnp.float32)
+                )
+                for name in ROUTING_METRIC_NAMES
+            }
+        else:
+            hidden = stage.run_blocks(hidden, batch.segment_ids, batch.position_ids)
+        if index < len(trainable) - 1:
+            if report_routing:
+                hidden, routing = mark((hidden, routing))
+            else:
+                hidden = mark(hidden)
+        last = stage
+    hidden = last.finish(hidden)
+    response_width = batch.old_logprobs.shape[-1]
+    start = batch.tokens.shape[-1] - response_width
+    if start < 1:
+        raise ValueError("Response span needs a preceding prompt token")
+    logprobs = -fused_linear_softmax_cross_entropy_loss(
+        hidden[:, start - 1 : -1].astype(jnp.float32),
+        last.get_lm_head().astype(jnp.float32),
+        batch.tokens[:, start:],
+        reduction="none",
+        logsumexp_weight=0.0,
+    )
+    return (logprobs, routing) if report_routing else logprobs
+
+
+def pipeline_loss(
+    trainable, frozen, batch: PipelineBatch, *, config: GrpoConfig, mp_policy, mark=lambda x: x, report_routing=False
+):
+    """Compute one microbatch contribution; objective weights already span the batch."""
+    scored = _score_stages(trainable, frozen, batch, mp_policy, mark, report_routing=report_routing)
+    logprobs, routing = scored if report_routing else (scored, {})
+    axes = (hax.Axis("batch", logprobs.shape[0]), hax.Axis("response", logprobs.shape[1]))
+    named = tuple(
+        hax.named(value, axes)
+        for value in (
+            logprobs,
+            batch.old_logprobs,
+            batch.reference_logprobs,
+            batch.advantages,
+            batch.policy_weights,
+            batch.kl_weights,
+        )
+    )
+    loss, metrics = grpo_loss(*named, config=config, accumulation_steps=1)
+    return mark((loss, {**{name: metric.value() for name, metric in metrics.items()}, **routing}))
+
+
+def _pipeline_value_and_grad(
+    compute_params, frozen, batch, *, config, mp_policy, mark, gradient_accum_dtype="float32", report_routing=False
+):
+    def loss(params):
+        return pipeline_loss(
+            params, frozen, batch, config=config, mp_policy=mp_policy, mark=mark, report_routing=report_routing
+        )
+
+    result, gradients = jax.value_and_grad(loss, has_aux=True)(compute_params)
+    if report_routing:
+        value, metrics = result
+        metrics = {
+            name: (
+                metric.astype(jnp.int32)
+                if name in ROUTING_METRIC_NAMES and name not in ROUTING_MAX_METRICS
+                else metric
+            )
+            for name, metric in metrics.items()
+        }
+        result = value, metrics
+    # The default reproduces the master-to-compute cast pullback per microbatch.
+    # BF16 instead rounds the temporal accumulator after every addition. Data
+    # parallel reductions inside this derivative retain their existing order.
+    return result, jax.tree.map(lambda gradient: gradient.astype(gradient_accum_dtype), gradients)
+
+
+def make_pipeline_train_step(
+    optimizer, mp_policy, sample_state, sample_batches, *, config: GrpoPipelineConfig, grpo: GrpoConfig, mpmd_mesh
+):
+    """Compile 1F1B gradients and global clipping; each update consumes its state."""
+    api = _require_jaxpp()
+    metric_names = (*METRIC_NAMES, *ROUTING_METRIC_NAMES) if config.expert_axis_size > 1 else METRIC_NAMES
+    metric_ops = {
+        name: api.Max if name in ("log_ratio_abs_max", *ROUTING_MAX_METRICS) else api.Add for name in metric_names
+    }
+
+    def step(state, frozen, batches):
+        # Share compute weights across all in-flight microbatches. Casting inside
+        # the differentiated loss retains another BF16 copy in every residual.
+        compute_params = mp_policy.cast_to_compute(state.trainable)
+        (value, metrics), grads = api.treduce(
+            lambda batch: _pipeline_value_and_grad(
+                compute_params,
+                frozen,
+                batch,
+                config=grpo,
+                mp_policy=mp_policy,
+                mark=api.mark_stage_end,
+                gradient_accum_dtype=config.gradient_accum_dtype,
+                report_routing=config.expert_axis_size > 1,
+            ),
+            batches,
+            schedule=api.Std1F1B(num_stages=config.stages),
+            operation=((api.Add, metric_ops), api.Add),
+        )
+        grads = mp_policy.cast_to_param(grads)
+        norms = tuple(sum(jnp.sum(g.astype(jnp.float32) ** 2) for g in jax.tree.leaves(stage)) for stage in grads)
+        norm = jnp.sqrt(api.cross_mpmd_all_reduce(*norms))
+        scale = jnp.minimum(1.0, config.max_grad_norm / jnp.maximum(norm, config.max_grad_norm))
+        next_params, next_opt = [], []
+        for params, state_opt, gradient in zip(state.trainable, state.opt_state, grads, strict=True):
+            gradient = jax.tree.map(lambda g: g * scale, gradient)
+            updates, state_opt = optimizer.update(gradient, state_opt, params)
+            next_params.append(eqx.apply_updates(params, updates))
+            next_opt.append(state_opt)
+        metrics = {**metrics, "grad_norm": norm}
+        return _OptimizerState(tuple(next_params), tuple(next_opt)), metrics
+
+    optimizer_specs = _partition_specs(_OptimizerState(sample_state.trainable, sample_state.opt_state))
+    function = api.mpmd_jit_with_loop(
+        step,
+        mpmd_mesh=mpmd_mesh,
+        in_specs=(optimizer_specs, _partition_specs(sample_state.frozen), _partition_specs(sample_batches)),
+        out_specs=(optimizer_specs, {name: P() for name in (*metric_names, "grad_norm")}),
+        donate_argnums=(0,),
+    )
+    return function
+
+
+def make_pipeline_scorer(mp_policy, sample_state, sample_microbatch, *, config: GrpoPipelineConfig, mpmd_mesh):
+    """Build a forward-only MPMD scorer using the training stage placement."""
+    api = _require_jaxpp()
+
+    def score(trainable, frozen, batch):
+        # AD materializes compute weights; preserve that rounding boundary in
+        # forward-only scoring too, without changing the training gradients.
+        return api.mark_stage_end(
+            _score_stages(
+                trainable,
+                frozen,
+                batch,
+                mp_policy,
+                api.mark_stage_end,
+                report_routing=config.expert_axis_size > 1,
+                compute_weight_boundary=partial(jax.tree.map, jax.lax.optimization_barrier),
+            )
+        )
+
+    return api.mpmd_jit_by_yield(
+        score,
+        mpmd_mesh=mpmd_mesh,
+        target_num_stages=config.stages,
+        in_shardings=(
+            _partition_specs(sample_state.trainable),
+            _partition_specs(sample_state.frozen),
+            _partition_specs(sample_microbatch),
+        ),
+        out_shardings=(
+            (P(BATCH_AXES, None), {name: P() for name in ROUTING_METRIC_NAMES})
+            if config.expert_axis_size > 1
+            else P(BATCH_AXES, None)
+        ),
+    )
+
+
+def _place_existing(tree, targets, mpmd_mesh):
+    """Keep tensor state stage-owned while placing shared scalar counters."""
+    api = _require_jaxpp()
+
+    def place(value, target):
+        if not _is_array(value) or not target.mesh_ids:
+            return value
+        source = value.first_mpmd_replica if isinstance(value, api.MpmdArray) else value
+        source_ids = set(mpmd_mesh.mpmd_indices_for_mesh(value.sharding.mesh))
+        if isinstance(value, api.MpmdArray) and source_ids == target.mesh_ids and value.sharding.spec == target.spec:
+            return value
+        if mpmd_mesh.jax_mesh.is_multi_process and not target.mesh_ids <= source_ids:
+            if value.shape:
+                raise ValueError(
+                    f"Compiled stage input requires new owners: {source_ids} -> {target.mesh_ids}, shape={value.shape}"
+                )
+            # CSE can share Adam's step counter across stage programs. Broadcast the
+            # actual scalar through the coordination service, avoiding GPU collectives.
+            is_source = jax.process_index() == min(source_ids)
+            scalar = np.asarray(source).item() if is_source else None
+            source = np.asarray(multihost_broadcast_sync(scalar, is_source=is_source), dtype=value.dtype)
+        arrays = []
+        for index in sorted(target.mesh_ids):
+            sharding = NamedSharding(mpmd_mesh.unstack[index], target.spec)
+            if _owns(sharding):
+                if source is None:
+                    raise ValueError("An owned stage input needs a local source replica")
+                arrays.append(jax.device_put(source, sharding))
+        return api.MpmdArray(arrays, target, shape=value.shape, dtype=value.dtype)
+
+    return jax.tree.map(place, tree, targets)
+
+
+def prepare_pipeline_train(step, state, batches, mpmd_mesh):
+    """Compile, place scalar state, and consume input batches into stage-owned arrays."""
+    api = _require_jaxpp()
+    # JaxPP establishes a stage-sized lowering mesh; an enclosing full mesh conflicts.
+    with jax.set_mesh(None):
+        compiled = step.compile(_OptimizerState(state.trainable, state.opt_state), state.frozen, batches)
+    (optimizer_specs, frozen_specs, batch_specs), kwargs = compiled.in_shardings
+    state_specs = PipelineState(optimizer_specs.trainable, frozen_specs, optimizer_specs.opt_state)
+    if kwargs:
+        raise ValueError("Pipeline step accepts positional state and batches")
+
+    for index, stage in enumerate(state_specs.trainable):
+        if any(target.mesh_ids != {index} for target in jax.tree.leaves(stage)):
+            raise ValueError("Pipeline compilation must preserve unique parameter ownership per stage")
+    for index, (stage_values, stage_targets) in enumerate(zip(state.opt_state, state_specs.opt_state, strict=True)):
+        for value, target in zip(jax.tree.leaves(stage_values), jax.tree.leaves(stage_targets), strict=True):
+            if value.shape and target.mesh_ids != {index}:
+                raise ValueError("Pipeline compilation must preserve unique optimizer-moment ownership per stage")
+    state = _place_existing(state, state_specs, mpmd_mesh)
+    batches = api.spmd_to_mpmd_reshard(mpmd_mesh, batches, batch_specs, threshold=0)
+    batches = _place_existing(batches, batch_specs, mpmd_mesh)
+    return partial(_run_pipeline_update, compiled), state, batches
+
+
+def _run_pipeline_update(compiled, state, batches):
+    # JaxPP's donation lifetime fences execute on individual stage meshes.
+    with jax.set_mesh(None):
+        optimizer, metrics = compiled(_OptimizerState(state.trainable, state.opt_state), state.frozen, batches)
+    return PipelineState(optimizer.trainable, state.frozen, optimizer.opt_state), metrics
+
+
+class RoutingDropPolicy(StrEnum):
+    REJECT = "reject"
+    REPORT = "report"
+
+
+def validate_routing_drops(metrics, *, context, policy: RoutingDropPolicy = RoutingDropPolicy.REJECT):
+    """Reject routing drops unless an experiment explicitly requests reporting."""
+    sender = int(metrics.get("routing_sender_drops", 0))
+    receiver = int(metrics.get("routing_receiver_drops", 0))
+    if not (sender or receiver):
+        return
+    message = f"{context}: expert capacity dropped assignments (padding included): {dict(metrics)}"
+    if policy == RoutingDropPolicy.REJECT:
+        raise FloatingPointError(message)
+    logger.warning(message)
+
+
+def _scorer_repeatability_details(first_logprobs, repeated_logprobs, policy_weights, first_routing, repeated_routing):
+    active = policy_weights > 0
+    difference = jnp.abs(first_logprobs.astype(jnp.float32) - repeated_logprobs.astype(jnp.float32))
+    changed = first_logprobs != repeated_logprobs
+    return {
+        "active_logprob_max_abs": float(jnp.max(jnp.where(active, difference, 0))),
+        "inactive_logprob_max_abs": float(jnp.max(jnp.where(active, 0, difference))),
+        "active_logprob_changed": int(jnp.sum(changed & active)),
+        "inactive_logprob_changed": int(jnp.sum(changed & ~active)),
+        "first_nonfinite_logprobs": int(jnp.sum(~jnp.isfinite(first_logprobs))),
+        "repeated_nonfinite_logprobs": int(jnp.sum(~jnp.isfinite(repeated_logprobs))),
+        "routing": {
+            name: {"first": int(first_routing[name]), "repeated": int(repeated_routing[name])}
+            for name in first_routing
+        },
+    }
+
+
+def score_pipeline_batch(
+    scorer,
+    state,
+    batches: PipelineBatch,
+    mpmd_mesh,
+    *,
+    routing_drop_policy: RoutingDropPolicy = RoutingDropPolicy.REJECT,
+) -> PipelineBatch:
+    """Freeze raw old scores and verify exact first-microbatch scorer repeatability."""
+    api = _require_jaxpp()
+    sample = jax.tree.map(lambda x: x[0], batches)
+    with jax.set_mesh(None):
+        compiled = scorer.compile(state.trainable, state.frozen, sample)
+    specs, kwargs = compiled.in_shardings
+    if kwargs:
+        raise ValueError("Pipeline scorer accepts positional parameters and batch")
+    scoring_trainable = _place_existing(state.trainable, specs[0], mpmd_mesh)
+    scoring_frozen = _place_existing(state.frozen, specs[1], mpmd_mesh)
+    sharding = NamedSharding(mpmd_mesh.jax_mesh, P(BATCH_AXES, None))
+    report_routing = mpmd_mesh.jax_mesh.shape["expert"] > 1
+    output_sharding = (
+        (sharding, {name: NamedSharding(mpmd_mesh.jax_mesh, P()) for name in ROUTING_METRIC_NAMES})
+        if report_routing
+        else sharding
+    )
+    routing_totals = {name: -1 if name == "routing_drop_layer" else 0 for name in ROUTING_METRIC_NAMES}
+
+    def checked_score(result, index):
+        if not report_routing:
+            return result
+        logprobs, routing = result
+        values = {name: int(value) for name, value in routing.items()}
+        validate_routing_drops(values, context=f"GRPO scorer microbatch {index}", policy=routing_drop_policy)
+        for name, value in values.items():
+            routing_totals[name] = (
+                max(routing_totals[name], value) if name in ROUTING_MAX_METRICS else routing_totals[name] + value
+            )
+        return logprobs
+
+    stacked_sharding = NamedSharding(mpmd_mesh.jax_mesh, P(None, BATCH_AXES, None))
+    # Preserve the original first-microbatch repeatability check before allowing
+    # independent microbatches to overlap across stages.
+    placed = api.spmd_to_mpmd_reshard(mpmd_mesh, sample, specs[2], threshold=0)
+    placed = _place_existing(placed, specs[2], mpmd_mesh)
+    with jax.set_mesh(None):
+        score = compiled(scoring_trainable, scoring_frozen, placed)
+        score = api.mpmd_to_spmd_reshard(mpmd_mesh, score, output_sharding, threshold=0)
+    jax.block_until_ready(score)
+    barrier_sync()
+    with jax.set_mesh(None):
+        repeated = compiled(scoring_trainable, scoring_frozen, placed)
+        repeated = api.mpmd_to_spmd_reshard(mpmd_mesh, repeated, output_sharding, threshold=0)
+    jax.block_until_ready(repeated)
+    barrier_sync()
+    if not all(
+        bool(jnp.array_equal(a, b)) for a, b in zip(jax.tree.leaves(score), jax.tree.leaves(repeated), strict=True)
+    ):
+        first_logprobs = score[0] if report_routing else score
+        repeated_logprobs = repeated[0] if report_routing else repeated
+        details = _scorer_repeatability_details(
+            first_logprobs,
+            repeated_logprobs,
+            sample.policy_weights,
+            score[1] if report_routing else {},
+            repeated[1] if report_routing else {},
+        )
+        raise FloatingPointError(f"Compiled GRPO scorer is not repeatable: {details}")
+    logger.info("Verified exact compiled scorer repeatability on the first microbatch")
+    score = checked_score(score, 0)
+    scores = [jax.lax.reshape(score, (1, *score.shape), out_sharding=stacked_sharding)]
+    for start in range(1, batches.tokens.shape[0], _SCORING_WINDOW_SIZE):
+        stop = min(start + _SCORING_WINDOW_SIZE, batches.tokens.shape[0])
+        window = tuple(jax.tree.map(lambda value, index=index: value[index], batches) for index in range(start, stop))
+        window_specs = (specs[2],) * len(window)
+        # An explicit positive threshold batches the tree into one resharding
+        # group. Zero would split every leaf; None queries memory across hosts.
+        input_bytes = sum(value.size * value.dtype.itemsize for value in jax.tree.leaves(window))
+        placed_window = api.spmd_to_mpmd_reshard(
+            mpmd_mesh, window, window_specs, threshold=input_bytes * mpmd_mesh.mpmd_dim
+        )
+        placed_window = _place_existing(placed_window, window_specs, mpmd_mesh)
+        with jax.set_mesh(None):
+            pending = tuple(compiled(scoring_trainable, scoring_frozen, microbatch) for microbatch in placed_window)
+            output_bytes = sum(
+                int(np.prod(value.shape)) * np.dtype(value.dtype).itemsize for value in jax.tree.leaves(pending)
+            )
+            completed = api.mpmd_to_spmd_reshard(
+                mpmd_mesh, pending, (output_sharding,) * len(pending), threshold=output_bytes * mpmd_mesh.mpmd_dim
+            )
+        for index, result in enumerate(completed, start=start):
+            value = checked_score(result, index)
+            scores.append(jax.lax.reshape(value, (1, *value.shape), out_sharding=stacked_sharding))
+    if report_routing:
+        logger.info("GRPO scorer routing totals (padding included): %s", routing_totals)
+    return dataclasses.replace(batches, old_logprobs=jnp.concatenate(scores, axis=0))

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -10,7 +10,7 @@ import sys
 import typing
 import warnings
 from dataclasses import dataclass
-from functools import cached_property
+from functools import cached_property, partial
 from pathlib import Path
 from typing import (
     Any,
@@ -779,7 +779,8 @@ class Trainer:
         Batch = _resolve_axis_in_tree((batch, batch_kwargs), self.config.batch_axis_name)
 
         # loss_fn always returns (loss, metrics), so has_aux=True
-        grad_fn = eqx.filter_value_and_grad(loss_fn, has_aux=True)
+        # Only batch inputs should be split; raw model dimensions can match the batch size.
+        grad_fn = partial(eqx.filter_value_and_grad(loss_fn, has_aux=True), model)
 
         mbs = self.config.microbatch_size
         if mbs is not None:
@@ -792,7 +793,7 @@ class Trainer:
             )
 
         with hax.axis_mapping(self.compute_axis_mapping):
-            (loss, metrics), grads = grad_fn(model, *batch, **batch_kwargs)
+            (loss, metrics), grads = grad_fn(*batch, **batch_kwargs)
 
         return loss, grads, metrics
 

--- a/lib/levanter/tests/test_grpo.py
+++ b/lib/levanter/tests/test_grpo.py
@@ -17,6 +17,19 @@ from levanter.grpo import GrpoConfig, KlGradient, grpo_advantages, grpo_loss, gr
 from levanter.testing.helpers import skip_if_no_torch, use_test_mesh
 
 
+@dataclasses.dataclass(frozen=True)
+class Rollout:
+    Batch: hax.Axis
+    Position: hax.Axis
+    old: np.ndarray
+    current: np.ndarray
+    reference: np.ndarray
+    mask: np.ndarray
+    groups: np.ndarray
+    rewards: np.ndarray
+    partitions: np.ndarray
+
+
 CONFIG = GrpoConfig(eps_clip_low=0.2, eps_clip_high=0.2, kl_loss_coef=0.001, kl_gradient=KlGradient.DETACHED)
 
 
@@ -34,7 +47,7 @@ def rollout():
     rewards = np.zeros_like(old)
     rewards[:, -1] = np.resize([1, -2, 3, 4, 1, 1, 2, 0], Batch.size)
     partitions = np.arange(Batch.size, dtype=np.int32) // 2
-    return Batch, Position, old, current, reference, mask, groups, rewards, partitions
+    return Rollout(Batch, Position, old, current, reference, mask, groups, rewards, partitions)
 
 
 def torch_advantages(rewards, mask, groups, normalize):
@@ -78,7 +91,11 @@ def torch_objective(current, old, reference, advantages, mask, partitions, confi
 @skip_if_no_torch
 @pytest.mark.parametrize("normalize", [False, True])
 def test_grpo_advantages_matches_torch_groups(rollout, normalize):
-    B, P, _, _, _, mask, groups, rewards, _ = rollout
+    B = rollout.Batch
+    P = rollout.Position
+    mask = rollout.mask
+    groups = rollout.groups
+    rewards = rollout.rewards
     actual = eqx.filter_jit(grpo_advantages)(
         hax.named(rewards, (B, P)),
         hax.named(mask, (B, P)),
@@ -101,7 +118,15 @@ def test_grpo_advantages_matches_torch_groups(rollout, normalize):
 def test_grpo_value_gradient_and_execution_partition_parity(rollout, kl_gradient, kl_coef, microbatch_size):
     import torch  # noqa: PLC0415  # optional dependency
 
-    B, P, old, current, reference, mask, groups, rewards, partitions = rollout
+    B = rollout.Batch
+    P = rollout.Position
+    old = rollout.old
+    current = rollout.current
+    reference = rollout.reference
+    mask = rollout.mask
+    groups = rollout.groups
+    rewards = rollout.rewards
+    partitions = rollout.partitions
     microbatch_size *= len(jax.devices())
     config = dataclasses.replace(CONFIG, kl_gradient=kl_gradient, kl_loss_coef=kl_coef)
     adv = torch_advantages(rewards, mask, groups, True)
@@ -192,7 +217,14 @@ def test_grpo_value_gradient_and_execution_partition_parity(rollout, kl_gradient
 def test_grpo_tiny_model_adamw_update_matches_torch(rollout):
     import torch  # noqa: PLC0415  # optional dependency
 
-    B, P, old, _, reference, mask, groups, rewards, partitions = rollout
+    B = rollout.Batch
+    P = rollout.Position
+    old = rollout.old
+    reference = rollout.reference
+    mask = rollout.mask
+    groups = rollout.groups
+    rewards = rollout.rewards
+    partitions = rollout.partitions
     rng = np.random.default_rng(5)
     features = rng.normal(size=(B.size, P.size, 3)).astype(np.float32) * 1000
     initial = rng.normal(size=(3, 7)).astype(np.float32) * 1e-4
@@ -247,7 +279,13 @@ def test_grpo_tiny_model_adamw_update_matches_torch(rollout):
 
 
 def test_grpo_zero_advantages_detached_kl_has_zero_surrogate_gradient(rollout):
-    B, P, old, current, reference, mask, _, _, partitions = rollout
+    B = rollout.Batch
+    P = rollout.Position
+    old = rollout.old
+    current = rollout.current
+    reference = rollout.reference
+    mask = rollout.mask
+    partitions = rollout.partitions
     pw, kw = grpo_objective_weights(
         hax.named(mask, (B, P)),
         hax.named(partitions, B),

--- a/lib/levanter/tests/test_grpo.py
+++ b/lib/levanter/tests/test_grpo.py
@@ -1,0 +1,309 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+from haliax.partitioning import ResourceAxis
+
+from levanter.grad_accum import microbatched
+from levanter.grpo import GrpoConfig, KlGradient, grpo_advantages, grpo_loss, grpo_objective_weights
+from levanter.testing.helpers import skip_if_no_torch, use_test_mesh
+
+
+CONFIG = GrpoConfig(eps_clip_low=0.2, eps_clip_high=0.2, kl_loss_coef=0.001, kl_gradient=KlGradient.DETACHED)
+
+
+@pytest.fixture
+def rollout():
+    Batch, Position = hax.Axis("batch", 8 * len(jax.devices())), hax.Axis("position", 5)
+    rng = np.random.default_rng(18)
+    old = rng.normal(-3, 0.3, (Batch.size, Position.size)).astype(np.float32)
+    current = old + rng.uniform(-0.6, 0.6, old.shape).astype(np.float32)
+    reference = old + rng.normal(0, 0.2, old.shape).astype(np.float32)
+    # Empty responses, unequal lengths, and interleaved groups are intentional.
+    lengths = np.resize([0, 1, 2, 5, 4, 1, 3, 5], Batch.size)
+    mask = (np.arange(Position.size)[None, :] < lengths[:, None]).astype(np.float32)
+    groups = np.resize([0, 1, 0, 1, 2, 2, 3, 4], Batch.size).astype(np.int32)
+    rewards = np.zeros_like(old)
+    rewards[:, -1] = np.resize([1, -2, 3, 4, 1, 1, 2, 0], Batch.size)
+    partitions = np.arange(Batch.size, dtype=np.int32) // 2
+    return Batch, Position, old, current, reference, mask, groups, rewards, partitions
+
+
+def torch_advantages(rewards, mask, groups, normalize):
+    import torch  # noqa: PLC0415  # optional dependency
+
+    scores = torch.tensor(rewards).sum(-1)
+    result = torch.zeros_like(scores)
+    for group in np.unique(groups):
+        rows = groups == group
+        selected = scores[rows]
+        mean = selected.mean() if len(selected) > 1 else 0
+        std = selected.std() if len(selected) > 1 else 1
+        result[rows] = (selected - mean) / (std + 1e-6) if normalize else selected - mean
+    return result[:, None] * torch.tensor(mask)
+
+
+def torch_objective(current, old, reference, advantages, mask, partitions, config):
+    """Independent Torch reduction over the reference's actual objective partitions.
+
+    Equations follow MarinSkyRL 8e33e017 policy_losses.py and policy_math.py; unlike the
+    JAX implementation this executes one locally normalized loss per partition.
+    """
+    import torch  # noqa: PLC0415  # optional dependency
+
+    objectives = []
+    for partition in np.unique(partitions):
+        rows = partitions == partition
+        lp, prev, ref, adv, m = (x[rows] for x in (current, old, reference, advantages, mask))
+        ratio = (lp - prev).float().clamp(-20, 20).exp().to(lp.dtype)
+        policy = -torch.minimum(ratio * adv, ratio.clamp(0.8, 1.2) * adv)
+        policy = (policy * m).sum() / m.sum().clamp(min=1)
+        delta = (ref - lp).clamp(-20, 20)
+        kl = (delta.exp() - delta - 1).clamp(-10, 10)
+        if config.kl_gradient == KlGradient.DETACHED:
+            kl = kl.detach()
+        kl = ((kl * m).sum(-1) / m.sum(-1).clamp(min=1)).mean()
+        objectives.append(policy + config.kl_loss_coef * kl)
+    return torch.stack(objectives).mean()
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize("normalize", [False, True])
+def test_grpo_advantages_matches_torch_groups(rollout, normalize):
+    B, P, _, _, _, mask, groups, rewards, _ = rollout
+    actual = eqx.filter_jit(grpo_advantages)(
+        hax.named(rewards, (B, P)),
+        hax.named(mask, (B, P)),
+        hax.named(groups, B),
+        Batch=B,
+        Position=P,
+        num_groups=5,
+        normalize_by_std=normalize,
+    )
+    expected = torch_advantages(rewards, mask, groups, normalize)
+    np.testing.assert_allclose(actual.array, expected.numpy(), atol=1e-5, rtol=1e-5)
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize(
+    "kl_gradient, kl_coef",
+    [(KlGradient.DETACHED, 0.0), (KlGradient.DETACHED, 0.001), (KlGradient.DIFFERENTIABLE, 0.001)],
+)
+@pytest.mark.parametrize("microbatch_size", [1, 2, 4])
+def test_grpo_value_gradient_and_execution_partition_parity(rollout, kl_gradient, kl_coef, microbatch_size):
+    import torch  # noqa: PLC0415  # optional dependency
+
+    B, P, old, current, reference, mask, groups, rewards, partitions = rollout
+    microbatch_size *= len(jax.devices())
+    config = dataclasses.replace(CONFIG, kl_gradient=kl_gradient, kl_loss_coef=kl_coef)
+    adv = torch_advantages(rewards, mask, groups, True)
+    lp = torch.tensor(current, requires_grad=True)
+    expected = torch_objective(
+        lp, torch.tensor(old), torch.tensor(reference), adv, torch.tensor(mask), partitions, config
+    )
+    expected.backward()
+    policy_weights, kl_weights = grpo_objective_weights(
+        hax.named(mask, (B, P)),
+        hax.named(partitions, B),
+        Batch=B,
+        Position=P,
+        num_partitions=int(partitions.max()) + 1,
+    )
+    inputs = tuple(hax.named(x, (B, P)) for x in (old, reference, adv.numpy()))
+
+    # A shared scalar perturbation permits real microbatched parameter gradients;
+    # per-token gradients are also checked below against Torch autograd.
+    def loss(offset, current, old, reference, advantages, pw, kw):
+        return grpo_loss(
+            current + offset,
+            old,
+            reference if kl_coef else None,
+            advantages,
+            pw,
+            kw,
+            config=config,
+            accumulation_steps=B.size // microbatch_size,
+        )
+
+    mapping = {B.name: ResourceAxis.DATA}
+    with use_test_mesh():
+        fn = microbatched(
+            eqx.filter_value_and_grad(loss, has_aux=True), B, microbatch_size, mapping, mapping, patch_in_rng_key=None
+        )
+        (value, metrics), grad = eqx.filter_jit(fn)(
+            jnp.array(0.0),
+            hax.named(current, (B, P)),
+            *inputs,
+            policy_weights,
+            kl_weights,
+        )
+    np.testing.assert_allclose(value, expected.detach().numpy(), atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(grad, lp.grad.numpy().sum(), atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(metrics["loss"].value(), value, atol=1e-5, rtol=1e-5)
+
+    # Compare the observable diagnostics against independently normalized Torch
+    # partitions, including partitions with unequal numbers of response tokens.
+    ratio = (lp.detach() - torch.tensor(old)).clamp(-20, 20).exp()
+    selected = ratio.clamp(0.8, 1.2) * adv < ratio * adv
+    for name, condition in (
+        ("ppo_clip_ratio", selected),
+        ("ppo_clip_ratio_low", selected & (ratio < 0.8)),
+        ("ppo_clip_ratio_high", selected & (ratio > 1.2)),
+        ("ppo_clip_pressure_low", ratio < 0.8),
+        ("ppo_clip_pressure_high", ratio > 1.2),
+        ("ppo_ratio_exact_unit_fraction", ratio == 1),
+    ):
+        fractions = []
+        for partition in np.unique(partitions):
+            rows = partitions == partition
+            m = torch.tensor(mask[rows])
+            fractions.append((condition[rows] * m).sum() / m.sum().clamp(min=1))
+        expected_metric = torch.stack(fractions).mean().numpy()
+        np.testing.assert_allclose(metrics[name].value(), expected_metric, atol=1e-5, rtol=1e-5)
+    delta = (torch.tensor(reference) - lp.detach()).clamp(-20, 20)
+    token_kl = (delta.exp() - delta - 1).clamp(-10, 10)
+    expected_kl = ((token_kl * torch.tensor(mask)).sum(-1) / torch.tensor(mask).sum(-1).clamp(min=1)).mean()
+    np.testing.assert_allclose(
+        metrics["policy_kl"].value(), expected_kl.numpy() if kl_coef else 0, atol=1e-5, rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        metrics["log_ratio_abs_max"].value(), np.abs(current - old)[mask > 0].max(), atol=1e-5, rtol=1e-5
+    )
+
+    def full_loss(values):
+        return grpo_loss(
+            hax.named(values, (B, P)), *inputs, policy_weights, kl_weights, config=config, accumulation_steps=1
+        )[0]
+
+    gradient = jax.jit(jax.grad(full_loss))(jnp.array(current))
+    np.testing.assert_allclose(gradient, lp.grad.numpy(), atol=1e-5, rtol=1e-5)
+    assert np.max(np.abs(np.asarray(gradient)[mask == 0])) == 0
+
+
+@skip_if_no_torch
+def test_grpo_tiny_model_adamw_update_matches_torch(rollout):
+    import torch  # noqa: PLC0415  # optional dependency
+
+    B, P, old, _, reference, mask, groups, rewards, partitions = rollout
+    rng = np.random.default_rng(5)
+    features = rng.normal(size=(B.size, P.size, 3)).astype(np.float32) * 1000
+    initial = rng.normal(size=(3, 7)).astype(np.float32) * 1e-4
+    labels = rng.integers(0, 7, size=(B.size, P.size))
+    advantages = torch_advantages(rewards, mask, groups, True)
+    param = torch.tensor(initial, requires_grad=True)
+    torch_optimizer = torch.optim.AdamW([param], lr=1e-6, betas=(0.9, 0.999), eps=1e-8, weight_decay=0.01)
+    log_probs = (
+        torch.log_softmax(torch.tensor(features) @ param, dim=-1)
+        .gather(-1, torch.tensor(labels)[..., None])
+        .squeeze(-1)
+    )
+    # Keep ratios around one so the update exercises unclipped token gradients.
+    old = log_probs.detach().numpy() + 0.05
+    loss = torch_objective(
+        log_probs, torch.tensor(old), torch.tensor(reference), advantages, torch.tensor(mask), partitions, CONFIG
+    )
+    loss.backward()
+    torch_grad_norm = torch.nn.utils.clip_grad_norm_([param], max_norm=1.0)
+    assert torch_grad_norm > 1.0
+    torch_optimizer.step()
+
+    pw, kw = grpo_objective_weights(
+        hax.named(mask, (B, P)),
+        hax.named(partitions, B),
+        Batch=B,
+        Position=P,
+        num_partitions=int(partitions.max()) + 1,
+    )
+    inputs = tuple(hax.named(x, (B, P)) for x in (old, reference, advantages.numpy()))
+
+    def jax_loss(weights):
+        logits = jnp.asarray(features) @ weights
+        lp = jnp.take_along_axis(jax.nn.log_softmax(logits), jnp.asarray(labels)[..., None], axis=-1)[..., 0]
+        return grpo_loss(hax.named(lp, (B, P)), *inputs, pw, kw, config=CONFIG, accumulation_steps=1)[0]
+
+    # Match Torch's clip_grad_norm_ epsilon explicitly rather than silently
+    # changing either optimizer's clipping convention.
+    optimizer = optax.adamw(1e-6, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.01)
+    gradient = jax.grad(jax_loss)(jnp.asarray(initial))
+    gradient *= jnp.minimum(1.0, 1.0 / (optax.global_norm(gradient) + 1e-6))
+    updates, state = optimizer.update(gradient, optimizer.init(jnp.asarray(initial)), jnp.asarray(initial))
+    actual = optax.apply_updates(jnp.asarray(initial), updates)
+    actual_delta = np.asarray(actual) - initial
+    expected_delta = param.detach().numpy() - initial
+    np.testing.assert_allclose(actual_delta, expected_delta, atol=1e-10, rtol=1e-5)
+    assert np.max(np.abs(actual_delta)) > 5e-7
+    # First-step Adam largely cancels uniform gradient scaling in the update.
+    # Moment parity therefore verifies that clipping actually happened.
+    np.testing.assert_allclose(state[0].mu, torch_optimizer.state[param]["exp_avg"].numpy(), atol=1e-8, rtol=1e-5)
+    np.testing.assert_allclose(state[0].nu, torch_optimizer.state[param]["exp_avg_sq"].numpy(), atol=1e-10, rtol=1e-5)
+
+
+def test_grpo_zero_advantages_detached_kl_has_zero_surrogate_gradient(rollout):
+    B, P, old, current, reference, mask, _, _, partitions = rollout
+    pw, kw = grpo_objective_weights(
+        hax.named(mask, (B, P)),
+        hax.named(partitions, B),
+        Batch=B,
+        Position=P,
+        num_partitions=int(partitions.max()) + 1,
+    )
+
+    def loss(values, config):
+        return grpo_loss(
+            hax.named(values, (B, P)),
+            hax.named(old, (B, P)),
+            hax.named(reference, (B, P)),
+            hax.zeros((B, P)),
+            pw,
+            kw,
+            config=config,
+            accumulation_steps=1,
+        )[0]
+
+    detached = jax.grad(lambda x: loss(x, CONFIG))(jnp.asarray(current))
+    differentiable = jax.grad(lambda x: loss(x, dataclasses.replace(CONFIG, kl_gradient=KlGradient.DIFFERENTIABLE)))(
+        jnp.asarray(current)
+    )
+    np.testing.assert_array_equal(detached, np.zeros_like(current))
+    assert np.max(np.abs(differentiable)) > 0
+
+
+def test_grpo_clamp_boundaries_preserve_pinned_torch_gradient():
+    B, P = hax.Axis("batch", 2), hax.Axis("position", 4)
+    # Torch 2.11.0 (MarinSkyRL 8e33e017's lock) passes the full clamp
+    # derivative at endpoints. Torch 2.14 changed it to zero. These recorded
+    # 2.11 gradients protect the migration contract independently of installed
+    # Torch. Zero-width PPO bounds force an exact surrogate tie at ratio=1.
+    current = np.array([[0, 0, 20, -20], [0, 0, 20, -20]], dtype=np.float32)
+    adv = np.array([[1, -1, -1, 1], [-1, 1, 1, -1]], dtype=np.float32)
+    expected = np.array(
+        [
+            [-0.125, 0.125, 60645648.0, -2.576442115e-10],
+            [0.125, -0.125, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    config = GrpoConfig(0.0, 0.0, 0.0, KlGradient.DETACHED)
+
+    def jax_loss(values):
+        return grpo_loss(
+            hax.named(values, (B, P)),
+            hax.zeros((B, P)),
+            None,
+            hax.named(adv, (B, P)),
+            hax.ones((B, P)) / 8,
+            hax.ones((B, P)) / 8,
+            config=config,
+            accumulation_steps=1,
+        )[0]
+
+    actual = jax.grad(jax_loss)(jnp.asarray(current))
+    np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)

--- a/lib/levanter/tests/test_grpo_model.py
+++ b/lib/levanter/tests/test_grpo_model.py
@@ -1,0 +1,116 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from levanter.grpo import GrpoConfig, KlGradient, grpo_loss
+from levanter.grpo_model import GrpoExample, grpo_model_loss, response_logprobs
+from levanter.layers.attention import AttentionBackend, AttentionMask
+from levanter.models.llama import LlamaConfig
+from levanter.models.qwen import QwenConfig
+from levanter.utils.tree_utils import inference_mode
+
+
+@pytest.fixture(params=[LlamaConfig, QwenConfig])
+def model_batch(request):
+    config = request.param(
+        max_seq_len=8,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_layers=1,
+        num_heads=2,
+        num_kv_heads=1,
+        attn_backend=AttentionBackend.VANILLA,
+    )
+    model = config.build(hax.Axis("vocab", 32), key=jax.random.PRNGKey(0))
+    B, S, T = hax.Axis("batch", 2 * len(jax.devices())), hax.Axis("position", 8), hax.Axis("response", 3)
+    tokens = np.tile([[3, 4, 5, 6, 7, 8, 9, 10], [0, 0, 3, 4, 5, 8, 9, 0]], (len(jax.devices()), 1))
+    mask = np.tile([[1, 1, 1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 1, 0]], (len(jax.devices()), 1))
+    response_mask = hax.named(mask[:, -3:].astype(np.float32), (B, T))
+    weights = response_mask / response_mask.sum(T) / B.size
+    batch = GrpoExample(
+        tokens=hax.named(tokens, (B, S)),
+        attention_mask=hax.named(mask, (B, S)),
+        position_ids=hax.named(np.maximum(mask.cumsum(-1) - 1, 0), (B, S)),
+        response_mask=response_mask,
+        advantages=response_mask,
+        policy_weights=weights,
+        kl_weights=weights,
+        old_logprobs=hax.full((B, T), -3.5),
+        reference_logprobs=None,
+    )
+    return model, batch
+
+
+def full_softmax_scores(model, batch):
+    model = inference_mode(model, True)
+    mask = AttentionMask.causal().with_segment_ids(batch.attention_mask.astype(jnp.int32))
+    logits = model(batch.tokens, mask, pos_ids=batch.position_ids).rearrange(("batch", "position", "vocab"))
+    tokens = batch.tokens.rearrange(("batch", "position"))
+    width = batch.response_mask.axis_size("response")
+    # Explicit shifted full-vocabulary reference, independent of fused CE slicing.
+    logprobs = jax.nn.log_softmax(logits.array.astype(jnp.float32)[:, :-1], axis=-1)
+    selected = jnp.take_along_axis(logprobs, tokens.array[:, 1:, None], axis=-1)[..., 0]
+    return hax.named(selected[:, -width:], batch.response_mask.axes)
+
+
+@pytest.mark.parametrize("block_size", [8, 64])
+def test_response_scores_match_full_softmax_and_unpadded_context(model_batch, block_size):
+    model, batch = model_batch
+    actual = eqx.filter_jit(response_logprobs)(model, batch, block_size=block_size)
+    np.testing.assert_allclose(actual.array, full_softmax_scores(model, batch).array, atol=1e-5, rtol=1e-5)
+    # Remove left padding from the second trajectory. Its response stays at
+    # the end and real tokens keep the same explicit rotary positions.
+    row = jax.tree_util.tree_map(
+        lambda x: x["batch", hax.ds(1, 1)] if isinstance(x, hax.NamedArray) else x,
+        batch,
+        is_leaf=lambda x: isinstance(x, hax.NamedArray),
+    )
+    unpadded = dataclasses.replace(
+        row,
+        tokens=row.tokens["position", hax.ds(2, 6)],
+        attention_mask=row.attention_mask["position", hax.ds(2, 6)],
+        position_ids=row.position_ids["position", hax.ds(2, 6)],
+    )
+    without_padding = eqx.filter_jit(response_logprobs)(model, unpadded, block_size=block_size)
+    np.testing.assert_allclose(actual.array[1, :2], without_padding.array[0, :2], atol=1e-5, rtol=1e-5)
+
+
+def test_grpo_model_value_and_gradients_match_full_softmax(model_batch):
+    model, batch = model_batch
+    old = response_logprobs(model, batch, block_size=8)
+    batch = dataclasses.replace(batch, old_logprobs=old)
+    config = GrpoConfig(0.2, 0.2, 0.0, KlGradient.DETACHED)
+
+    def fused_loss(model):
+        return grpo_model_loss(
+            model, batch, key=jax.random.PRNGKey(9), config=config, accumulation_steps=1, block_size=8
+        )[0]
+
+    def reference_loss(model):
+        return grpo_loss(
+            full_softmax_scores(model, batch),
+            batch.old_logprobs,
+            None,
+            batch.advantages,
+            batch.policy_weights,
+            batch.kl_weights,
+            config=config,
+            accumulation_steps=1,
+        )[0]
+
+    actual, gradient = eqx.filter_jit(eqx.filter_value_and_grad(fused_loss))(model)
+    expected, expected_gradient = eqx.filter_jit(eqx.filter_value_and_grad(reference_loss))(model)
+    np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
+    for observed, reference in zip(
+        jax.tree_util.tree_leaves(gradient), jax.tree_util.tree_leaves(expected_gradient), strict=True
+    ):
+        np.testing.assert_allclose(observed, reference, atol=1e-6, rtol=1e-5)
+    assert max(float(jnp.max(jnp.abs(g))) for g in jax.tree_util.tree_leaves(gradient)) > 1e-3

--- a/lib/levanter/tests/test_grpo_model.py
+++ b/lib/levanter/tests/test_grpo_model.py
@@ -46,7 +46,9 @@ def model_batch(request):
         old_logprobs=hax.full((B, T), -3.5),
         reference_logprobs=None,
     )
-    return model, batch
+    # Compare blocked and full projections with the same FP32 multiplication policy.
+    with jax.default_matmul_precision("float32"):
+        yield model, batch
 
 
 def full_softmax_scores(model, batch):

--- a/lib/levanter/tests/test_grpo_model.py
+++ b/lib/levanter/tests/test_grpo_model.py
@@ -58,7 +58,13 @@ def full_softmax_scores(model, batch):
     tokens = batch.tokens.rearrange(("batch", "position"))
     width = batch.response_mask.axis_size("response")
     # Explicit shifted full-vocabulary reference, independent of fused CE slicing.
-    logprobs = jax.nn.log_softmax(logits.array.astype(jnp.float32)[:, :-1], axis=-1)
+    logits = logits.array.astype(jnp.float32)[:, :-1]
+    shifted = logits - jax.lax.stop_gradient(jnp.max(logits, axis=-1, keepdims=True))
+    # TPU's default log approximation is not a full-precision reference.
+    accuracy = jax.lax.AccuracyMode.HIGHEST if jax.default_backend() == "tpu" else None
+    logprobs = shifted - jax.lax.log(
+        jnp.sum(jax.lax.exp(shifted, accuracy=accuracy), axis=-1, keepdims=True), accuracy=accuracy
+    )
     selected = jnp.take_along_axis(logprobs, tokens.array[:, 1:, None], axis=-1)[..., 0]
     return hax.named(selected[:, -width:], batch.response_mask.axes)
 

--- a/lib/levanter/tests/test_grpo_pipeline.py
+++ b/lib/levanter/tests/test_grpo_pipeline.py
@@ -1,0 +1,255 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import jmp
+import numpy as np
+import pytest
+from levanter.grpo import GrpoConfig, KlGradient, grpo_loss
+from levanter.grpo_model import GrpoExample
+from levanter.grpo_pipeline import (
+    pipeline_batch,
+    packed_pipeline_batch,
+    PipelineBatch,
+    RoutingDropPolicy,
+    validate_routing_drops,
+    _pipeline_value_and_grad,
+    _scorer_repeatability_details,
+    pipeline_loss,
+)
+from levanter.grug.sharding import compact_grug_mesh
+
+
+class Stage(eqx.Module):
+    weight: jax.Array
+    bias: jax.Array
+
+    def embed(self, tokens):
+        return jax.nn.one_hot(tokens, self.weight.shape[0])
+
+    def run_blocks(self, hidden, attention_mask, position_ids):
+        return jnp.tanh(hidden @ self.weight + self.bias + position_ids[..., None] * 0.01) * attention_mask[..., None]
+
+    def finish(self, hidden):
+        return hidden
+
+    def get_lm_head(self):
+        return self.weight.T
+
+
+@pytest.mark.parametrize("compute_dtype", ["float32", "bfloat16"])
+def test_pipeline_objective_preserves_response_alignment_masks_and_full_batch_weights(compute_dtype):
+    rows = 2 * jax.device_count()
+    Batch, Response = hax.Axis("batch", rows), hax.Axis("response", 2)
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        stages = tuple(
+            Stage(jax.random.normal(jax.random.PRNGKey(i), (8, 8)) * 0.1, jnp.arange(8) * 0.001) for i in range(2)
+        )
+        selected, frozen = zip(*(eqx.partition(stage, eqx.is_inexact_array) for stage in stages), strict=True)
+        tokens = jnp.tile(jnp.array([[0, 0, 1, 2, 3], [0, 4, 5, 6, 7]]), (rows // 2, 1))
+        mask = (tokens != 0).astype(jnp.int32)
+        positions = jnp.maximum(jnp.cumsum(mask, -1) - 1, 0)
+        advantages = jnp.tile(jnp.array([[1.0, 0.0], [-1.0, -1.0]]), (rows // 2, 1))
+        weights = jnp.tile(jnp.array([[1.0, 0.0], [0.5, 0.5]]), (rows // 2, 1)) / rows
+        batch = PipelineBatch(
+            tokens,
+            mask,
+            mask,
+            positions,
+            advantages,
+            weights,
+            weights,
+            jnp.full((rows, 2), -2.0),
+            jnp.full((rows, 2), -2.1),
+        )
+        config = GrpoConfig(0.2, 0.2, 0.001, KlGradient.DETACHED)
+        policy = jmp.get_policy(f"params=float32,compute={compute_dtype},output=float32")
+
+        def actual(params):
+            return pipeline_loss(params, frozen, batch, config=config, mp_policy=policy)[0]
+
+        def expected(params):
+            combined = eqx.combine(policy.cast_to_compute(params), frozen)
+            hidden = combined[0].embed(tokens)
+            for stage in combined:
+                hidden = stage.run_blocks(hidden, mask, positions)
+            logits = hidden @ combined[-1].get_lm_head()
+            logprobs = jax.nn.log_softmax(logits[:, -3:-1], axis=-1)
+            selected_probs = jnp.take_along_axis(logprobs, tokens[:, -2:, None], axis=-1)[..., 0]
+            inputs = (selected_probs, batch.old_logprobs, batch.reference_logprobs, advantages, weights, weights)
+            return grpo_loss(
+                *(hax.named(value, (Batch, Response)) for value in inputs), config=config, accumulation_steps=1
+            )[0]
+
+        value, grads = eqx.filter_jit(eqx.filter_value_and_grad(actual))(selected)
+        reference, reference_grads = eqx.filter_jit(eqx.filter_value_and_grad(expected))(selected)
+        np.testing.assert_allclose(value, reference, atol=1e-7, rtol=1e-6)
+        for actual_grad, expected_grad in zip(jax.tree.leaves(grads), jax.tree.leaves(reference_grads), strict=True):
+            np.testing.assert_allclose(actual_grad, expected_grad, atol=1e-7, rtol=1e-5)
+
+
+def test_hoisted_bf16_weights_preserve_per_microbatch_fp32_gradient_accumulation():
+    rows = 2 * jax.device_count()
+    policy = jmp.get_policy("params=float32,compute=bfloat16,output=float32")
+    config = GrpoConfig(0.2, 0.2, 0.0, KlGradient.DETACHED)
+    stage = Stage(jax.random.normal(jax.random.PRNGKey(9), (8, 8)) * 0.2, jnp.arange(8) * 0.001)
+    selected = (eqx.tree_at(lambda value: value.bias, stage, None),)
+    frozen = (eqx.tree_at(lambda value: value.weight, stage, None),)
+    compute = policy.cast_to_compute(selected)
+    actual_gradients, expected_gradients, bf16_gradients = [], [], []
+    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+        for index in range(3):
+            tokens = (jnp.tile(jnp.array([[0, 1, 2, 3], [4, 5, 6, 7]]), (rows // 2, 1)) + index) % 8
+            mask = jnp.ones_like(tokens)
+            positions = jnp.broadcast_to(jnp.arange(4), tokens.shape)
+            advantages = jnp.tile(jnp.array([[0.37 + index, -0.71], [1.13, 0.19 - index]]), (rows // 2, 1))
+            weights = jnp.ones_like(advantages) / (6 * rows)
+            batch = PipelineBatch(
+                tokens,
+                mask,
+                mask,
+                positions,
+                advantages,
+                weights,
+                weights,
+                jnp.full((rows, 2), -2.0),
+                jnp.zeros((rows, 2)),
+            )
+
+            def reference(masters):
+                return pipeline_loss(masters, frozen, batch, config=config, mp_policy=policy)[0]
+
+            expected_value, expected = jax.value_and_grad(reference)(selected)
+            (actual_value, _), actual = _pipeline_value_and_grad(
+                compute, frozen, batch, config=config, mp_policy=policy, mark=lambda value: value
+            )
+            np.testing.assert_array_equal(actual_value, expected_value)
+            for result, wanted in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True):
+                assert result.dtype == jnp.float32
+                np.testing.assert_array_equal(result, wanted)
+            (bf16_value, _), bf16_gradient = _pipeline_value_and_grad(
+                compute,
+                frozen,
+                batch,
+                config=config,
+                mp_policy=policy,
+                mark=lambda value: value,
+                gradient_accum_dtype="bfloat16",
+            )
+            np.testing.assert_array_equal(bf16_value, expected_value)
+            for result, wanted in zip(jax.tree.leaves(bf16_gradient), jax.tree.leaves(expected), strict=True):
+                assert result.dtype == jnp.bfloat16
+                np.testing.assert_array_equal(result, wanted.astype(jnp.bfloat16))
+            bf16_gradients.append(bf16_gradient)
+            actual_gradients.append(actual)
+            expected_gradients.append(expected)
+        actual_total = jax.tree.map(lambda *values: sum(values), *actual_gradients)
+        expected_total = jax.tree.map(lambda *values: sum(values), *expected_gradients)
+        for result, wanted in zip(jax.tree.leaves(actual_total), jax.tree.leaves(expected_total), strict=True):
+            np.testing.assert_array_equal(result, wanted)
+        # This example detects moving the FP32 cast after the temporal reduction.
+        bf16_total = jax.tree.map(
+            lambda *values: sum(value.astype(jnp.bfloat16) for value in values), *actual_gradients
+        )
+        actual_bf16_total = jax.tree.map(lambda *values: sum(values).astype(jnp.float32), *bf16_gradients)
+        for result, wanted in zip(jax.tree.leaves(actual_bf16_total), jax.tree.leaves(bf16_total), strict=True):
+            assert result.dtype == jnp.float32
+            np.testing.assert_array_equal(result, wanted.astype(jnp.float32))
+        assert any(
+            np.any(np.asarray(correct) != np.asarray(rounded.astype(jnp.float32)))
+            for correct, rounded in zip(jax.tree.leaves(actual_total), jax.tree.leaves(bf16_total), strict=True)
+        )
+
+
+def test_scorer_repeatability_reports_routing_separately_from_logprobs():
+    first = jnp.array([[-2.0, -3.0, -4.0]])
+    repeated = jnp.array([[-2.0, -2.0, -2.0]])
+    weights = jnp.array([[0.5, 0.5, 0.0]])
+    routing = {"routing_sender_drops": jnp.array(0)}
+    repeated_routing = {"routing_sender_drops": jnp.array(395)}
+    details = _scorer_repeatability_details(first, repeated, weights, routing, repeated_routing)
+    assert details["active_logprob_max_abs"] == 1.0
+    assert details["inactive_logprob_max_abs"] == 2.0
+    assert details["active_logprob_changed"] == 1
+    assert details["inactive_logprob_changed"] == 1
+    assert details["routing"]["routing_sender_drops"] == {"first": 0, "repeated": 395}
+    counters_only = _scorer_repeatability_details(first, first, weights, routing, repeated_routing)
+    assert counters_only["active_logprob_max_abs"] == 0.0
+    assert counters_only["inactive_logprob_max_abs"] == 0.0
+
+
+@pytest.mark.parametrize("counter", ["routing_sender_drops", "routing_receiver_drops"])
+def test_routing_drop_experiment_is_explicit_and_reports_unchanged_counts(counter, caplog):
+    metrics = {"routing_assignments": 48, "routing_sender_drops": 0, "routing_receiver_drops": 0}
+    metrics[counter] = 40
+    with pytest.raises(FloatingPointError, match="capacity dropped assignments"):
+        validate_routing_drops(metrics, context="test scorer")
+    validate_routing_drops(metrics, context="test scorer", policy=RoutingDropPolicy.REPORT)
+    assert "test scorer" in caplog.text
+    assert "padding included" in caplog.text
+    assert str(metrics) in caplog.text
+    assert metrics[counter] == 40
+    assert metrics["routing_assignments"] == 48
+
+
+def test_packing_preserves_response_objectives_positions_and_segment_boundaries():
+    Batch, Position, Response = hax.Axis("batch", 4), hax.Axis("position", 8), hax.Axis("response", 4)
+    tokens = jnp.array(
+        [
+            [0, 0, 1, 2, 3, 4, 0, 0],
+            [0, 5, 6, 7, 8, 0, 0, 0],
+            [0, 0, 0, 9, 10, 11, 12, 0],
+            [0, 13, 14, 15, 16, 17, 0, 0],
+        ]
+    )
+    attention = (tokens != 0).astype(jnp.int32)
+    response_mask = attention[:, 4:].astype(jnp.float32)
+    policy_weights = response_mask / (response_mask.sum(axis=1, keepdims=True) * 4)
+    positions = jnp.maximum(attention.cumsum(axis=1) - 1, 0)
+    # Nonzero offsets ensure packing preserves source positions instead of regenerating them.
+    positions = positions + jnp.arange(4)[:, None] * attention
+
+    def seq(x):
+        return hax.named(x, (Batch, Position))
+
+    def resp(x):
+        return hax.named(x, (Batch, Response))
+
+    example = GrpoExample(
+        seq(tokens),
+        seq(attention),
+        seq(positions),
+        resp(response_mask),
+        resp(response_mask * jnp.array([1.0, -0.6, 0.3, -1.0])[:, None]),
+        resp(policy_weights),
+        resp(policy_weights * 0.7),
+        resp(jnp.full((4, 4), -3.2)),
+        resp(jnp.full((4, 4), -3.1)),
+    )
+    unpacked = pipeline_batch(example, microbatches=2)
+    packed = packed_pipeline_batch(
+        example, sequence_length=10, rows_per_microbatch=1, pad_token_id=0, minimum_microbatches=3
+    )
+    assert packed.tokens.shape == (3, 1, 10)
+    assert np.all(np.asarray(packed.segment_ids[-1]) == -1)
+    for name in ("advantages", "policy_weights", "kl_weights", "old_logprobs", "reference_logprobs"):
+        before = np.asarray(getattr(unpacked, name))[np.asarray(unpacked.policy_weights) > 0]
+        after = np.asarray(getattr(packed, name))[np.asarray(packed.policy_weights) > 0]
+        np.testing.assert_array_equal(after, before)
+    for document in range(4):
+        locations = np.asarray(packed.segment_ids) == document
+        np.testing.assert_array_equal(
+            np.asarray(packed.tokens)[locations], np.asarray(tokens[document])[attention[document] > 0]
+        )
+        np.testing.assert_array_equal(
+            np.asarray(packed.position_ids)[locations], np.asarray(positions[document])[attention[document] > 0]
+        )
+    segments = np.asarray(packed.segment_ids)
+    boundary = (segments[..., 1:] != segments[..., :-1]) | (segments[..., 1:] < 0)
+    assert np.all(np.asarray(packed.policy_weights)[boundary] == 0)
+    assert np.all(np.asarray(packed.kl_weights)[boundary] == 0)
+    with pytest.raises(ValueError, match="exceeds"):
+        packed_pipeline_batch(example, sequence_length=4, rows_per_microbatch=1, pad_token_id=0)

--- a/lib/levanter/tests/test_grpo_pipeline.py
+++ b/lib/levanter/tests/test_grpo_pipeline.py
@@ -1,6 +1,8 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import equinox as eqx
 import haliax as hax
 import jax
@@ -188,11 +190,7 @@ def test_routing_drop_experiment_is_explicit_and_reports_unchanged_counts(counte
     with pytest.raises(FloatingPointError, match="capacity dropped assignments"):
         validate_routing_drops(metrics, context="test scorer")
     validate_routing_drops(metrics, context="test scorer", policy=RoutingDropPolicy.REPORT)
-    assert "test scorer" in caplog.text
-    assert "padding included" in caplog.text
-    assert str(metrics) in caplog.text
-    assert metrics[counter] == 40
-    assert metrics["routing_assignments"] == 48
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
 
 
 def test_packing_preserves_response_objectives_positions_and_segment_boundaries():

--- a/lib/levanter/tests/test_grpo_pipeline.py
+++ b/lib/levanter/tests/test_grpo_pipeline.py
@@ -80,15 +80,25 @@ def test_pipeline_objective_preserves_response_alignment_masks_and_full_batch_we
             for stage in combined:
                 hidden = stage.run_blocks(hidden, mask, positions)
             logits = hidden @ combined[-1].get_lm_head()
-            logprobs = jax.nn.log_softmax(logits[:, -3:-1], axis=-1)
+            logits = logits[:, -3:-1]
+            shifted = logits - jax.lax.stop_gradient(jnp.max(logits, axis=-1, keepdims=True))
+            accuracy = jax.lax.AccuracyMode.HIGHEST if jax.default_backend() == "tpu" else None
+            logprobs = shifted - jax.lax.log(
+                jnp.sum(jax.lax.exp(shifted, accuracy=accuracy), axis=-1, keepdims=True), accuracy=accuracy
+            )
             selected_probs = jnp.take_along_axis(logprobs, tokens[:, -2:, None], axis=-1)[..., 0]
             inputs = (selected_probs, batch.old_logprobs, batch.reference_logprobs, advantages, weights, weights)
             return grpo_loss(
                 *(hax.named(value, (Batch, Response)) for value in inputs), config=config, accumulation_steps=1
             )[0]
 
-        value, grads = eqx.filter_jit(eqx.filter_value_and_grad(actual))(selected)
-        reference, reference_grads = eqx.filter_jit(eqx.filter_value_and_grad(expected))(selected)
+        # Preserve the same BF16 rounding across the shard_map and dense graphs.
+        # TPU excess precision can otherwise remove only the dense graph's casts.
+        compiler_options = {"xla_allow_excess_precision": False}
+        value, grads = eqx.filter_jit(eqx.filter_value_and_grad(actual), compiler_options=compiler_options)(selected)
+        reference, reference_grads = eqx.filter_jit(
+            eqx.filter_value_and_grad(expected), compiler_options=compiler_options
+        )(selected)
         np.testing.assert_allclose(value, reference, atol=1e-7, rtol=1e-6)
         for actual_grad, expected_grad in zip(jax.tree.leaves(grads), jax.tree.leaves(reference_grads), strict=True):
             np.testing.assert_allclose(actual_grad, expected_grad, atol=1e-7, rtol=1e-5)

--- a/lib/levanter/tests/test_grpo_pipeline.py
+++ b/lib/levanter/tests/test_grpo_pipeline.py
@@ -46,7 +46,8 @@ class Stage(eqx.Module):
 def test_pipeline_objective_preserves_response_alignment_masks_and_full_batch_weights(compute_dtype):
     rows = 2 * jax.device_count()
     Batch, Response = hax.Axis("batch", rows), hax.Axis("response", 2)
-    with jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
+    # TPU may otherwise approximate FP32 contractions differently across CE shapes.
+    with jax.default_matmul_precision("float32"), jax.set_mesh(compact_grug_mesh(expert_axis_size=1)):
         stages = tuple(
             Stage(jax.random.normal(jax.random.PRNGKey(i), (8, 8)) * 0.1, jnp.arange(8) * 0.001) for i in range(2)
         )

--- a/lib/marin/src/marin/rl/grpo_artifact.py
+++ b/lib/marin/src/marin/rl/grpo_artifact.py
@@ -7,8 +7,8 @@ import dataclasses
 import json
 from dataclasses import dataclass
 
-import fsspec
 import numpy as np
+from rigging.filesystem.storage_path import StoragePath
 
 
 @dataclass(frozen=True)
@@ -72,13 +72,13 @@ def write_golden_rollout(uri: str, batch: GoldenRollout, manifest: dict) -> None
         field.name: value for field in dataclasses.fields(batch) if (value := getattr(batch, field.name)) is not None
     }
     arrays["manifest"] = np.asarray(json.dumps({"schema_version": 1, **manifest}, allow_nan=False, sort_keys=True))
-    with fsspec.open(uri, "wb") as output:
+    with StoragePath(uri).open("wb") as output:
         np.savez_compressed(output, **arrays)
 
 
 def read_golden_rollout(uri: str) -> tuple[GoldenRollout, dict]:
     """Read a capture without allowing executable pickle payloads."""
-    with fsspec.open(uri, "rb") as source, np.load(source, allow_pickle=False) as archive:
+    with StoragePath(uri).open("rb") as source, np.load(source, allow_pickle=False) as archive:
         manifest = json.loads(str(archive["manifest"]))
         if manifest["schema_version"] != 1:
             raise ValueError(f"Unsupported golden rollout schema: {manifest['schema_version']}")

--- a/lib/marin/src/marin/rl/grpo_artifact.py
+++ b/lib/marin/src/marin/rl/grpo_artifact.py
@@ -1,0 +1,89 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Portable, pickle-free captures at the rollout-to-learner boundary."""
+
+import dataclasses
+import json
+from dataclasses import dataclass
+
+import fsspec
+import numpy as np
+
+
+@dataclass(frozen=True)
+class GoldenRollout:
+    """A complete admitted batch, with distinct sampling and raw-policy scores.
+
+    Sequences and attention masks include prompts. Remaining token arrays are
+    aligned to response positions, including environment tokens masked out of
+    the objective. Partition IDs describe the oracle's loss normalization groups,
+    independently of the execution microbatches used to replay the objective.
+    """
+
+    sequences: np.ndarray
+    attention_mask: np.ndarray
+    response_mask: np.ndarray
+    loss_mask: np.ndarray
+    rewards: np.ndarray
+    advantages: np.ndarray
+    old_logprobs: np.ndarray
+    behavior_logprobs: np.ndarray
+    group_ids: np.ndarray
+    objective_partition_ids: np.ndarray
+    reference_logprobs: np.ndarray | None = None
+    current_logprobs: np.ndarray | None = None
+    logprob_gradients: np.ndarray | None = None
+
+    def validate(self) -> None:
+        if self.old_logprobs.ndim != 2:
+            raise ValueError("old_logprobs must be a nonempty trajectory-by-response array")
+        batch, width = self.old_logprobs.shape
+        if batch == 0 or width == 0:
+            raise ValueError("old_logprobs must be a nonempty trajectory-by-response array")
+        if self.sequences.ndim != 2 or self.sequences.shape[0] != batch:
+            raise ValueError("sequences must have one row per trajectory")
+        if width > self.sequences.shape[1]:
+            raise ValueError("response width cannot exceed sequence width")
+        if self.attention_mask.shape != self.sequences.shape:
+            raise ValueError("attention_mask must align to sequences")
+        for name in ("group_ids", "objective_partition_ids"):
+            values = getattr(self, name)
+            if values.shape != (batch,) or values.dtype.kind not in "iu":
+                raise ValueError(f"{name} must be integer trajectory IDs")
+        if self.sequences.dtype.kind not in "iu":
+            raise ValueError("sequences must contain integer token IDs")
+        for field in dataclasses.fields(self):
+            if field.name in ("sequences", "attention_mask", "group_ids", "objective_partition_ids"):
+                continue
+            values = getattr(self, field.name)
+            if values is not None and values.shape != (batch, width):
+                raise ValueError(f"{field.name} must align to response logprobs")
+        if np.any(self.loss_mask < 0) or np.any(self.loss_mask > self.response_mask):
+            raise ValueError("loss_mask must be nonnegative and contained in response_mask")
+        if np.any((self.response_mask != 0) & (self.response_mask != 1)):
+            raise ValueError("response_mask must be binary")
+
+
+def write_golden_rollout(uri: str, batch: GoldenRollout, manifest: dict) -> None:
+    """Write arrays and their provenance together through the configured filesystem."""
+    batch.validate()
+    arrays = {
+        field.name: value for field in dataclasses.fields(batch) if (value := getattr(batch, field.name)) is not None
+    }
+    arrays["manifest"] = np.asarray(json.dumps({"schema_version": 1, **manifest}, allow_nan=False, sort_keys=True))
+    with fsspec.open(uri, "wb") as output:
+        np.savez_compressed(output, **arrays)
+
+
+def read_golden_rollout(uri: str) -> tuple[GoldenRollout, dict]:
+    """Read a capture without allowing executable pickle payloads."""
+    with fsspec.open(uri, "rb") as source, np.load(source, allow_pickle=False) as archive:
+        manifest = json.loads(str(archive["manifest"]))
+        if manifest["schema_version"] != 1:
+            raise ValueError(f"Unsupported golden rollout schema: {manifest['schema_version']}")
+        batch = GoldenRollout(
+            **{field.name: archive[field.name] for field in dataclasses.fields(GoldenRollout) if field.name in archive}
+        )
+    batch.validate()
+    return batch, manifest

--- a/lib/marin/src/marin/rl/grpo_replay.py
+++ b/lib/marin/src/marin/rl/grpo_replay.py
@@ -1,0 +1,179 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check captured Torch GRPO values and logprob gradients against JAX."""
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+
+import fsspec
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+from levanter.grpo import GrpoConfig, KlGradient, grpo_advantages, grpo_loss, grpo_objective_weights
+from marin.rl.grpo_artifact import read_golden_rollout
+
+POLICY_DIAGNOSTICS = (
+    "ppo_clip_ratio",
+    "ppo_clip_ratio_low",
+    "ppo_clip_ratio_high",
+    "ppo_clip_pressure_low",
+    "ppo_clip_pressure_high",
+    "ppo_ratio_exact_unit_fraction",
+)
+MARINSKYRL_ORACLE_COMMIT = "8e33e01707b7225ecde1d6b8ad172a3dd4dc8661"
+
+
+@dataclass(frozen=True)
+class ReplayComparison:
+    max_absolute_error: float
+    mean_absolute_error: float
+
+
+@dataclass(frozen=True)
+class GrpoReplayResult:
+    trajectories: int
+    response_tokens: int
+    objective_partitions: int
+    loss: float
+    advantages: ReplayComparison
+    loss_error: ReplayComparison
+    logprob_gradients: ReplayComparison
+    diagnostic_errors: dict[str, ReplayComparison]
+
+
+def _compare(actual, expected, *, atol: float, rtol: float, name: str, scale=None) -> ReplayComparison:
+    actual = np.asarray(actual)
+    expected = np.asarray(expected)
+    checked_actual = actual if scale is None else actual / scale
+    checked_expected = expected if scale is None else expected / scale
+    np.testing.assert_allclose(checked_actual, checked_expected, atol=atol, rtol=rtol, err_msg=name, equal_nan=False)
+    error = np.abs(actual - expected)
+    return ReplayComparison(float(error.max()), float(error.mean()))
+
+
+def replay_golden_rollout(uri: str, *, atol: float, rtol: float) -> GrpoReplayResult:
+    """Verify a persisted oracle batch, raising on unsupported recipes or mismatch.
+
+    This checks the loss boundary only. It does not load a language model or
+    establish full-model optimizer-update parity.
+    """
+    batch, manifest = read_golden_rollout(uri)
+    provenance = manifest["provenance"]
+    if provenance["oracle_base_commit"] != MARINSKYRL_ORACLE_COMMIT or provenance["kl_gradient"] != "detached":
+        raise ValueError("Replay requires the pinned MarinSkyRL oracle with detached KL")
+    algorithm = manifest["config"]["trainer"]["algorithm"]
+    required = {
+        "advantage_estimator": "grpo",
+        "policy_loss_type": "regular",
+        "loss_reduction": "token_mean",
+        "advantage_batch_normalize": False,
+        "use_kl_in_reward": False,
+        "use_entropy_loss": False,
+        "use_tis": False,
+        "think_token_weight": 1.0,
+    }
+    for key, expected in required.items():
+        if algorithm[key] != expected:
+            raise ValueError(f"GRPO replay requires {key}={expected!r}, got {algorithm[key]!r}")
+    if not np.array_equal(batch.loss_mask, batch.response_mask):
+        raise ValueError("This oracle recipe requires loss_mask to equal response_mask")
+    if batch.logprob_gradients is None:
+        raise ValueError("Capture must include independent Torch logprob gradients")
+    use_kl = algorithm["use_kl_loss"]
+    if use_kl and (algorithm["kl_estimator_type"] != "k3" or batch.reference_logprobs is None):
+        raise ValueError("KL replay requires k3 and captured reference logprobs")
+    config = GrpoConfig(
+        eps_clip_low=algorithm["eps_clip_low"],
+        eps_clip_high=algorithm["eps_clip_high"],
+        kl_loss_coef=algorithm["kl_loss_coef"] if use_kl else 0.0,
+        kl_gradient=KlGradient(manifest["provenance"]["kl_gradient"]),
+    )
+    Batch, Position = (hax.Axis("batch", batch.old_logprobs.shape[0]), hax.Axis("position", batch.old_logprobs.shape[1]))
+    _, group_ids = np.unique(batch.group_ids, return_inverse=True)
+    _, partition_ids = np.unique(batch.objective_partition_ids, return_inverse=True)
+    num_groups = int(group_ids.max()) + 1
+    num_partitions = int(partition_ids.max()) + 1
+    mask = hax.named(jnp.asarray(batch.response_mask), (Batch, Position))
+    advantages = grpo_advantages(
+        hax.named(jnp.asarray(batch.rewards), (Batch, Position)),
+        mask,
+        hax.named(jnp.asarray(group_ids), Batch),
+        Batch=Batch,
+        Position=Position,
+        num_groups=num_groups,
+        normalize_by_std=algorithm["grpo_norm_by_std"],
+    )
+    policy_weights, kl_weights = grpo_objective_weights(
+        mask,
+        hax.named(jnp.asarray(partition_ids), Batch),
+        Batch=Batch,
+        Position=Position,
+        num_partitions=num_partitions,
+    )
+    old = hax.named(jnp.asarray(batch.old_logprobs), (Batch, Position))
+    reference = hax.named(
+        jnp.asarray(batch.reference_logprobs) if use_kl else jnp.zeros_like(old.array), (Batch, Position)
+    )
+
+    def loss(logprobs):
+        return grpo_loss(
+            hax.named(logprobs, (Batch, Position)),
+            old,
+            reference,
+            advantages,
+            policy_weights,
+            kl_weights,
+            config=config,
+            accumulation_steps=1,
+        )
+
+    current = batch.old_logprobs if batch.current_logprobs is None else batch.current_logprobs
+    (value, metrics), gradient = jax.jit(jax.value_and_grad(loss, has_aux=True))(jnp.asarray(current))
+    oracle_metrics = manifest["oracle"]["metrics"]
+    if set(oracle_metrics) != set(POLICY_DIAGNOSTICS):
+        raise ValueError("Capture must contain exactly the six regular-PPO clipping diagnostics")
+    diagnostic_errors = {
+        name: _compare(metrics[name].value(), oracle_metrics[name], atol=atol, rtol=rtol, name=name)
+        for name in POLICY_DIAGNOSTICS
+    }
+    masked = batch.response_mask == 0
+    np.testing.assert_array_equal(np.asarray(gradient)[masked], 0, err_msg="JAX padding gradient")
+    np.testing.assert_array_equal(batch.logprob_gradients[masked], 0, err_msg="Torch padding gradient")
+    return GrpoReplayResult(
+        trajectories=Batch.size,
+        response_tokens=int(batch.response_mask.sum()),
+        objective_partitions=num_partitions,
+        loss=float(value),
+        diagnostic_errors=diagnostic_errors,
+        advantages=_compare(advantages.array, batch.advantages, atol=atol, rtol=rtol, name="advantages"),
+        loss_error=_compare(value, manifest["oracle"]["loss"], atol=atol, rtol=rtol, name="loss"),
+        logprob_gradients=_compare(
+            gradient,
+            batch.logprob_gradients,
+            atol=atol,
+            rtol=rtol,
+            name="logprob gradients",
+            scale=np.where(np.asarray(policy_weights.array) > 0, np.asarray(policy_weights.array), 1.0),
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", help="Local or regional object-store capture URI")
+    parser.add_argument("--output-uri", help="Write the comparison JSON to this local or regional URI")
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-5)
+    args = parser.parse_args()
+    result = asdict(replay_golden_rollout(args.capture, atol=args.atol, rtol=args.rtol))
+    if args.output_uri:
+        with fsspec.open(args.output_uri, "wt") as output:
+            json.dump(result, output, indent=2, allow_nan=False)
+    print(json.dumps(result, indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/marin/src/marin/rl/grpo_replay.py
+++ b/lib/marin/src/marin/rl/grpo_replay.py
@@ -7,13 +7,13 @@ import argparse
 import json
 from dataclasses import asdict, dataclass
 
-import fsspec
 import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
 from levanter.grpo import GrpoConfig, KlGradient, grpo_advantages, grpo_loss, grpo_objective_weights
 from marin.rl.grpo_artifact import read_golden_rollout
+from rigging.filesystem.storage_path import StoragePath
 
 POLICY_DIAGNOSTICS = (
     "ppo_clip_ratio",
@@ -170,7 +170,7 @@ def main() -> None:
     args = parser.parse_args()
     result = asdict(replay_golden_rollout(args.capture, atol=args.atol, rtol=args.rtol))
     if args.output_uri:
-        with fsspec.open(args.output_uri, "wt") as output:
+        with StoragePath(args.output_uri).open("wt") as output:
             json.dump(result, output, indent=2, allow_nan=False)
     print(json.dumps(result, indent=2, allow_nan=False))
 

--- a/lib/marin/src/marin/rl/train_grpo.py
+++ b/lib/marin/src/marin/rl/train_grpo.py
@@ -1,0 +1,268 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Train a Levanter policy on an ordered stream of completed GRPO batches."""
+
+import dataclasses
+import hashlib
+import json
+import logging
+import posixpath
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any
+
+import draccus
+import equinox as eqx
+import fsspec
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import levanter.config
+import numpy as np
+from haliax.partitioning import named_jit, round_axis_for_partitioning
+from levanter.checkpoint import is_checkpoint_path, save_checkpoint
+from levanter.grpo import GrpoConfig, KlGradient, grpo_advantages, grpo_objective_weights
+from levanter.grpo_model import GrpoExample, grpo_model_loss, response_logprobs
+from levanter.main.model_init import load_model_from_source, prepare_model_init_context
+from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.config import AdamConfig
+from levanter.trainer import Trainer, TrainerConfig, initialize
+from marin.rl.grpo_artifact import GoldenRollout, read_golden_rollout
+from transformers import AutoTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OfflineGrpoConfig:
+    captures: list[str]
+    initial_model: str
+    tokenizer: str
+    hf_save_path: str
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    model: LmConfig = field(default_factory=Qwen3Config)
+    optimizer: AdamConfig = field(
+        default_factory=lambda: AdamConfig(
+            learning_rate=1e-6,
+            beta1=0.9,
+            beta2=0.999,
+            epsilon=1e-8,
+            weight_decay=0.01,
+            max_grad_norm=1.0,
+            warmup=0,
+            lr_schedule="constant",
+            default_weight_decay_mask=False,
+        )
+    )
+    grpo: GrpoConfig = field(default_factory=lambda: GrpoConfig(0.2, 0.2, 0.0, KlGradient.DETACHED))
+    normalize_by_std: bool = True
+    vocab_block_size: int = 1024
+    use_hf_model_config: bool = True
+    stop_after: int | None = None
+    """Stop at this absolute learner step, preserving the full schedule for resumption."""
+
+    def trainable_filter(self, model: LmHeadModel) -> Any:
+        return True
+
+
+def prepare_grpo_example(rollout: GoldenRollout, *, normalize_by_std: bool) -> GrpoExample:
+    """Preserve complete groups and objective partitions before execution slicing."""
+    rollout.validate()
+    batch_size, response_width = rollout.old_logprobs.shape
+    sequence_width = rollout.sequences.shape[1]
+    if response_width >= sequence_width:
+        raise ValueError("Each response needs a preceding prompt token")
+    if not np.array_equal(rollout.loss_mask, rollout.response_mask):
+        raise ValueError("Offline GRPO currently requires binary response-only loss masks")
+    attention = rollout.attention_mask
+    if np.any((attention != 0) & (attention != 1)):
+        raise ValueError("attention_mask must be binary")
+    if np.any(rollout.response_mask > attention[:, -response_width:]):
+        raise ValueError("Response tokens cannot occupy padding positions")
+    if np.any(rollout.response_mask > attention[:, -response_width - 1 : -1]):
+        raise ValueError("Each response token must have an attended predecessor")
+    Batch, Position, Response = (
+        hax.Axis("batch", batch_size),
+        hax.Axis("position", sequence_width),
+        hax.Axis("response", response_width),
+    )
+    _, groups = np.unique(rollout.group_ids, return_inverse=True)
+    _, partitions = np.unique(rollout.objective_partition_ids, return_inverse=True)
+    mask = hax.named(jnp.asarray(rollout.response_mask), (Batch, Response))
+    advantages = grpo_advantages(
+        hax.named(jnp.asarray(rollout.rewards), (Batch, Response)),
+        mask,
+        hax.named(jnp.asarray(groups), Batch),
+        Batch=Batch,
+        Position=Response,
+        num_groups=int(groups.max()) + 1,
+        normalize_by_std=normalize_by_std,
+    )
+    policy_weights, kl_weights = grpo_objective_weights(
+        mask,
+        hax.named(jnp.asarray(partitions), Batch),
+        Batch=Batch,
+        Position=Response,
+        num_partitions=int(partitions.max()) + 1,
+    )
+    return GrpoExample(
+        tokens=hax.named(jnp.asarray(rollout.sequences), (Batch, Position)),
+        attention_mask=hax.named(jnp.asarray(attention), (Batch, Position)),
+        position_ids=hax.named(jnp.asarray(np.maximum(attention.cumsum(-1) - 1, 0), dtype=jnp.int32), (Batch, Position)),
+        response_mask=mask,
+        advantages=advantages,
+        policy_weights=policy_weights,
+        kl_weights=kl_weights,
+        old_logprobs=hax.zeros((Batch, Response), dtype=jnp.float32),
+        reference_logprobs=(
+            None
+            if rollout.reference_logprobs is None
+            else hax.named(jnp.asarray(rollout.reference_logprobs), (Batch, Response))
+        ),
+    )
+
+
+@named_jit
+def _score_microbatch(model, microbatch, *, mp, block_size):
+    return response_logprobs(mp.cast_to_compute(model), microbatch, block_size=block_size)
+
+
+def _slice_scoring_batch(value, *, start: int, size: int):
+    if not isinstance(value, hax.NamedArray):
+        return value
+    Batch = value.resolve_axis("batch")
+    array = jax.lax.slice_in_dim(value.array, start, start + size, axis=value.axis_indices(Batch))
+    return hax.named(array, tuple(axis.resize(size) if axis == Batch else axis for axis in value.axes))
+
+
+def score_grpo_batch(trainer: Trainer, model: LmHeadModel, batch: GrpoExample, *, block_size: int) -> GrpoExample:
+    """Recompute raw old-policy scores at the same execution shape as training."""
+    Batch = batch.tokens.resolve_axis("batch")
+    microbatch_size = trainer.config.microbatch_size or Batch.size
+    if Batch.size % microbatch_size:
+        raise ValueError("Complete rollout batch must divide evenly into execution microbatches")
+
+    scores = []
+    for start in range(0, Batch.size, microbatch_size):
+        microbatch = jax.tree.map(
+            partial(_slice_scoring_batch, start=start, size=microbatch_size),
+            batch,
+            is_leaf=lambda x: isinstance(x, hax.NamedArray),
+        )
+        with hax.axis_mapping(trainer.compute_axis_mapping):
+            scores.append(_score_microbatch(model, microbatch, mp=trainer.mp, block_size=block_size))
+    old_logprobs = hax.concatenate(Batch, scores)
+    return eqx.tree_at(lambda x: x.old_logprobs, batch, old_logprobs)
+
+
+def _capture_identity(uri: str) -> dict[str, str]:
+    digest = hashlib.sha256()
+    with fsspec.open(uri, "rb") as source:
+        for chunk in iter(partial(source.read, 1024 * 1024), b""):
+            digest.update(chunk)
+    return {"uri": uri, "sha256": digest.hexdigest()}
+
+
+def main(config: OfflineGrpoConfig):
+    if config.trainer.initialize_from or config.trainer.load_checkpoint_path:
+        raise ValueError("Resume offline runs using the same checkpointer base path and run id")
+    if config.trainer.batch_axis_name != "batch":
+        raise ValueError("Offline GRPO uses the batch axis named 'batch'")
+    if config.trainer.num_train_steps != len(config.captures) or not config.captures:
+        raise ValueError("num_train_steps must equal the number of ordered capture batches")
+    if config.stop_after is not None and not 0 < config.stop_after <= len(config.captures):
+        raise ValueError("stop_after must select a step in the ordered capture stream")
+    tokenizer = AutoTokenizer.from_pretrained(config.tokenizer)
+    context = prepare_model_init_context(
+        config.model,
+        tokenizer=tokenizer,
+        initialize_from_hf=config.initial_model,
+        use_hf_model_config=config.use_hf_model_config,
+    )
+    config = dataclasses.replace(config, model=context.model)
+    initialize(config)
+    microbatch_size = config.trainer.microbatch_size or config.trainer.TrainBatch.size
+    accumulation_steps = config.trainer.TrainBatch.size // microbatch_size
+    loss = partial(
+        grpo_model_loss, config=config.grpo, accumulation_steps=accumulation_steps, block_size=config.vocab_block_size
+    )
+    with Trainer(
+        config.trainer, config.optimizer.build(config.trainer.num_train_steps), loss, add_default_hooks=False
+    ) as trainer:
+        contract = {
+            "captures": [_capture_identity(uri) for uri in config.captures],
+            "initial_model": config.initial_model,
+            "tokenizer": config.tokenizer,
+            "optimizer": draccus.encode(config.optimizer),
+            "grpo": draccus.encode(config.grpo),
+            "normalize_by_std": config.normalize_by_std,
+            "num_train_steps": config.trainer.num_train_steps,
+            "model": draccus.encode(config.model),
+            "mp": str(config.trainer.mp),
+            "seed": config.trainer.seed,
+            "train_batch_size": config.trainer.train_batch_size,
+            "microbatch_size": microbatch_size,
+            "vocab_block_size": config.vocab_block_size,
+        }
+        contract_uri = posixpath.join(trainer.checkpoint_path, "offline-grpo.json")
+        fs, path = fsspec.core.url_to_fs(contract_uri)
+        if fs.exists(path):
+            with fs.open(path) as source:
+                if json.load(source) != contract:
+                    raise ValueError("Offline continuation requires the same capture stream and training recipe")
+        elif is_checkpoint_path(trainer.checkpoint_path):
+            raise ValueError("Existing checkpoints need their offline capture-stream contract")
+        elif jax.process_index() == 0:
+            fs.makedirs(posixpath.dirname(path), exist_ok=True)
+            with fs.open(path, "wt") as output:
+                json.dump(contract, output, indent=2)
+        Vocab = round_axis_for_partitioning(hax.Axis("vocab", len(tokenizer)), trainer.parameter_axis_mapping)
+        model_key, training_key = jax.random.split(jax.random.PRNGKey(config.trainer.seed))
+        state = trainer.initial_state(
+            training_key,
+            is_trainable=config.trainable_filter(eqx.filter_eval_shape(context.model.build, Vocab, key=model_key)),
+            model_init=partial(
+                load_model_from_source,
+                context=context,
+                Vocab=Vocab,
+                model_key=model_key,
+                parameter_axis_mapping=trainer.parameter_axis_mapping,
+                compute_dtype=trainer.mp.param_dtype,
+                cast_to_param=trainer.mp.cast_to_param,
+                hf_ref=config.initial_model,
+            ),
+        )
+        end_step = config.stop_after or config.trainer.num_train_steps
+        while int(state.step) < end_step:
+            uri = config.captures[int(state.step)]
+            rollout, manifest = read_golden_rollout(uri)
+            if manifest["tokenizer"] != config.tokenizer:
+                raise ValueError("Capture tokenizer does not match the policy tokenizer")
+            if rollout.sequences.min() < 0 or rollout.sequences.max() >= len(tokenizer):
+                raise ValueError("Capture contains token IDs outside the policy vocabulary")
+            batch = prepare_grpo_example(rollout, normalize_by_std=config.normalize_by_std)
+            if batch.tokens.axis_size("batch") != trainer.TrainBatch.size:
+                raise ValueError("Each capture must contain exactly one full trainer batch")
+            if config.grpo.kl_loss_coef and batch.reference_logprobs is None:
+                raise ValueError("KL requires fixed reference logprobs in the capture")
+            batch = hax.shard(batch, trainer.compute_axis_mapping)
+            batch = score_grpo_batch(trainer, state.model, batch, block_size=config.vocab_block_size)
+            info = trainer.train_step(state, batch)
+            state = info.state
+            save_checkpoint(
+                state,
+                int(state.step),
+                posixpath.join(trainer.checkpoint_path, f"step-{int(state.step)}"),
+                is_temporary=False,
+            )
+            logger.info("Completed offline GRPO step %d from %s: loss=%g", int(state.step), uri, info.loss)
+        if int(state.step) == config.trainer.num_train_steps:
+            assert context.converter is not None
+            context.converter.save_pretrained(state.model, config.hf_save_path, upload_to_hf=False)
+    trainer.tracker.finish()
+
+
+if __name__ == "__main__":
+    levanter.config.main(main)()

--- a/lib/marin/src/marin/rl/train_grpo.py
+++ b/lib/marin/src/marin/rl/train_grpo.py
@@ -7,14 +7,12 @@ import dataclasses
 import hashlib
 import json
 import logging
-import posixpath
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any
 
 import draccus
 import equinox as eqx
-import fsspec
 import haliax as hax
 import jax
 import jax.numpy as jnp
@@ -30,6 +28,7 @@ from levanter.models.qwen import Qwen3Config
 from levanter.optim.config import AdamConfig
 from levanter.trainer import Trainer, TrainerConfig, initialize
 from marin.rl.grpo_artifact import GoldenRollout, read_golden_rollout
+from rigging.filesystem.storage_path import StoragePath
 from transformers import AutoTokenizer
 
 logger = logging.getLogger(__name__)
@@ -63,7 +62,8 @@ class OfflineGrpoConfig:
     stop_after: int | None = None
     """Stop at this absolute learner step, preserving the full schedule for resumption."""
 
-    def trainable_filter(self, model: LmHeadModel) -> Any:
+    def trainable_filter(self, _model: LmHeadModel) -> Any:
+        """Return an Equinox filter tree; model adapters may select individual leaves."""
         return True
 
 
@@ -159,7 +159,7 @@ def score_grpo_batch(trainer: Trainer, model: LmHeadModel, batch: GrpoExample, *
 
 def _capture_identity(uri: str) -> dict[str, str]:
     digest = hashlib.sha256()
-    with fsspec.open(uri, "rb") as source:
+    with StoragePath(uri).open("rb") as source:
         for chunk in iter(partial(source.read, 1024 * 1024), b""):
             digest.update(chunk)
     return {"uri": uri, "sha256": digest.hexdigest()}
@@ -206,17 +206,16 @@ def main(config: OfflineGrpoConfig):
             "microbatch_size": microbatch_size,
             "vocab_block_size": config.vocab_block_size,
         }
-        contract_uri = posixpath.join(trainer.checkpoint_path, "offline-grpo.json")
-        fs, path = fsspec.core.url_to_fs(contract_uri)
-        if fs.exists(path):
-            with fs.open(path) as source:
+        contract_path = StoragePath(trainer.checkpoint_path) / "offline-grpo.json"
+        if contract_path.exists():
+            with contract_path.open("r") as source:
                 if json.load(source) != contract:
                     raise ValueError("Offline continuation requires the same capture stream and training recipe")
         elif is_checkpoint_path(trainer.checkpoint_path):
             raise ValueError("Existing checkpoints need their offline capture-stream contract")
         elif jax.process_index() == 0:
-            fs.makedirs(posixpath.dirname(path), exist_ok=True)
-            with fs.open(path, "wt") as output:
+            contract_path.parent.mkdirs()
+            with contract_path.open("wt") as output:
                 json.dump(contract, output, indent=2)
         Vocab = round_axis_for_partitioning(hax.Axis("vocab", len(tokenizer)), trainer.parameter_axis_mapping)
         model_key, training_key = jax.random.split(jax.random.PRNGKey(config.trainer.seed))
@@ -254,7 +253,7 @@ def main(config: OfflineGrpoConfig):
             save_checkpoint(
                 state,
                 int(state.step),
-                posixpath.join(trainer.checkpoint_path, f"step-{int(state.step)}"),
+                str(StoragePath(trainer.checkpoint_path) / f"step-{int(state.step)}"),
                 is_temporary=False,
             )
             logger.info("Completed offline GRPO step %d from %s: loss=%g", int(state.step), uri, info.loss)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Specifying Hardware Resources: references/resource-config.md
       - Default Steps: references/default-steps.md
       - Training Configuration: references/train-config.md
+      - GRPO Replay: references/grpo-replay.md
       - HBM Optimization: references/hbm-optimization.md
       - Perplexity Gap Analysis: references/perplexity-gap-analysis.md
       - Browsing Buckets with fsutil: references/fsutil.md

--- a/scripts/rl/compare_skyrl_golden_updates.py
+++ b/scripts/rl/compare_skyrl_golden_updates.py
@@ -6,16 +6,15 @@
 import argparse
 import json
 import logging
-import posixpath
 
-import fsspec
 import numpy as np
+from rigging.filesystem.storage_path import StoragePath
 
 LOGGER = logging.getLogger(__name__)
 
 
 def read_json(uri: str) -> dict:
-    with fsspec.open(uri, "rt") as source:
+    with StoragePath(uri).open("rt") as source:
         return json.load(source)
 
 
@@ -45,7 +44,7 @@ def compare_updates(first_uri: str, replay_uri: str, ranks: int) -> dict:
     identity_fields = ("uri", "size", "etag", "version_id", "checksum_sha256")
     source_objects = []
     for uri in (first_uri, replay_uri):
-        identity_uri = posixpath.join(posixpath.dirname(uri), "source-identity.json")
+        identity_uri = str(StoragePath(uri).parent / "source-identity.json")
         record = read_json(identity_uri)
         source_objects.append(
             sorted(
@@ -61,8 +60,8 @@ def compare_updates(first_uri: str, replay_uri: str, ranks: int) -> dict:
         }
     }
     with (
-        fsspec.open(first_uri, "rb") as first_source,
-        fsspec.open(replay_uri, "rb") as replay_source,
+        StoragePath(first_uri).open("rb") as first_source,
+        StoragePath(replay_uri).open("rb") as replay_source,
         np.load(first_source, allow_pickle=False) as first,
         np.load(replay_source, allow_pickle=False) as replay,
     ):
@@ -125,7 +124,7 @@ def main() -> None:
     if args.ranks < 1:
         raise ValueError("ranks must be positive")
     result = compare_updates(args.first_uri, args.replay_uri, args.ranks)
-    with fsspec.open(args.output_uri, "wt") as output:
+    with StoragePath(args.output_uri).open("wt") as output:
         json.dump(result, output, indent=2, allow_nan=False)
     LOGGER.info("Replay comparison passed=%s: %s", result["passed"], args.output_uri)
     if not result["passed"]:

--- a/scripts/rl/compare_skyrl_golden_updates.py
+++ b/scripts/rl/compare_skyrl_golden_updates.py
@@ -1,0 +1,137 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare captured and offline-replayed Torch updates in the artifact's region."""
+
+import argparse
+import json
+import logging
+import posixpath
+
+import fsspec
+import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+
+
+def read_json(uri: str) -> dict:
+    with fsspec.open(uri, "rt") as source:
+        return json.load(source)
+
+
+def deviation(actual, expected, *, atol: float, rtol: float) -> dict:
+    actual = np.asarray(actual)
+    expected = np.asarray(expected)
+    if actual.shape != expected.shape:
+        return {"passed": False, "actual_shape": list(actual.shape), "expected_shape": list(expected.shape)}
+    difference = np.abs(actual.astype(np.float64) - expected.astype(np.float64))
+    return {
+        "passed": bool(np.allclose(actual, expected, atol=atol, rtol=rtol)),
+        "max_abs": float(difference.max(initial=0)),
+        "mean_abs": float(difference.mean()) if difference.size else 0.0,
+        "atol": atol,
+        "rtol": rtol,
+    }
+
+
+def canonical_group_ids(group_ids: np.ndarray) -> np.ndarray:
+    """Number groups in first-occurrence order, independently of opaque labels."""
+    _, first, inverse = np.unique(group_ids, return_index=True, return_inverse=True)
+    return np.argsort(np.argsort(first))[inverse]
+
+
+def compare_updates(first_uri: str, replay_uri: str, ranks: int) -> dict:
+    """Check token-level replay and bounded model/master-parameter update probes."""
+    identity_fields = ("uri", "size", "etag", "version_id", "checksum_sha256")
+    source_objects = []
+    for uri in (first_uri, replay_uri):
+        identity_uri = posixpath.join(posixpath.dirname(uri), "source-identity.json")
+        record = read_json(identity_uri)
+        source_objects.append(
+            sorted(
+                ({name: item[name] for name in identity_fields} for item in record["source_objects"]),
+                key=lambda item: item["uri"],
+            )
+        )
+    checks = {
+        "provenance/source_objects": {
+            "passed": bool(source_objects[0]) and source_objects[0] == source_objects[1],
+            "first_object_count": len(source_objects[0]),
+            "replay_object_count": len(source_objects[1]),
+        }
+    }
+    with (
+        fsspec.open(first_uri, "rb") as first_source,
+        fsspec.open(replay_uri, "rb") as replay_source,
+        np.load(first_source, allow_pickle=False) as first,
+        np.load(replay_source, allow_pickle=False) as replay,
+    ):
+        for name in (
+            "sequences",
+            "attention_mask",
+            "response_mask",
+            "loss_mask",
+            "objective_partition_ids",
+            "rewards",
+            "behavior_logprobs",
+        ):
+            checks[name] = deviation(replay[name], first[name], atol=0, rtol=0)
+        checks["group_ids"] = deviation(
+            canonical_group_ids(replay["group_ids"]), canonical_group_ids(first["group_ids"]), atol=0, rtol=0
+        )
+        for name in ("old_logprobs", "advantages", "logprob_gradients"):
+            checks[name] = deviation(replay[name], first[name], atol=1e-7, rtol=1e-5)
+        first_manifest = json.loads(str(first["manifest"]))
+        replay_manifest = json.loads(str(replay["manifest"]))
+        checks["oracle_loss"] = deviation(
+            replay_manifest["oracle"]["loss"], first_manifest["oracle"]["loss"], atol=1e-7, rtol=1e-5
+        )
+        for name in ("algorithm", "policy"):
+            checks[f"config/{name}"] = {
+                "passed": first_manifest["config"]["trainer"][name] == replay_manifest["config"]["trainer"][name]
+            }
+        for name in ("source_sha256", "initial_policy", "initial_optimizer", "rng_seed", "torch_version"):
+            checks[f"provenance/{name}"] = {
+                "passed": first_manifest["provenance"][name] == replay_manifest["provenance"][name]
+            }
+    for rank in range(ranks):
+        first = read_json(f"{first_uri}.rank-{rank}.json")
+        replay = read_json(f"{replay_uri}.rank-{rank}.json")
+        prefix = f"rank/{rank}"
+        checks[f"{prefix}/layout"] = {"passed": first["before"]["names"] == replay["before"]["names"]}
+        checks[f"{prefix}/grad_norm"] = deviation(replay["grad_norm"], first["grad_norm"], atol=1e-7, rtol=1e-5)
+        for name in ("values", "optimizer_parameter_values"):
+            checks[f"{prefix}/initial/{name}"] = deviation(replay["before"][name], first["before"][name], atol=0, rtol=0)
+            first_delta = np.subtract(first["after"][name], first["before"][name])
+            replay_delta = np.subtract(replay["after"][name], replay["before"][name])
+            checks[f"{prefix}/update/{name}"] = deviation(replay_delta, first_delta, atol=1e-8, rtol=1e-4)
+    return {
+        "passed": all(check["passed"] for check in checks.values()),
+        "first_uri": first_uri,
+        "replay_uri": replay_uri,
+        "ranks": ranks,
+        "checks": checks,
+        "scope": "fixed-rollout Torch replay with bounded parameter probes; not full optimizer-state equivalence",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--first-uri", required=True)
+    parser.add_argument("--replay-uri", required=True)
+    parser.add_argument("--ranks", type=int, required=True)
+    parser.add_argument("--output-uri", required=True)
+    args = parser.parse_args()
+    if args.ranks < 1:
+        raise ValueError("ranks must be positive")
+    result = compare_updates(args.first_uri, args.replay_uri, args.ranks)
+    with fsspec.open(args.output_uri, "wt") as output:
+        json.dump(result, output, indent=2, allow_nan=False)
+    LOGGER.info("Replay comparison passed=%s: %s", result["passed"], args.output_uri)
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/rl/test_grpo_artifact.py
+++ b/tests/rl/test_grpo_artifact.py
@@ -1,0 +1,127 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import json
+
+import numpy as np
+import pytest
+from marin.rl.grpo_artifact import GoldenRollout, read_golden_rollout, write_golden_rollout
+
+from scripts.rl.compare_skyrl_golden_updates import compare_updates
+
+
+@pytest.fixture
+def golden_rollout():
+    mask = np.array([[1, 1, 0], [1, 0, 0]], dtype=np.int32)
+    old = np.array([[-2, -3, 0], [-4, 0, 0]], dtype=np.float32)
+    batch = GoldenRollout(
+        sequences=np.array([[8, 9, 1, 2, 0], [7, 6, 3, 0, 0]]),
+        attention_mask=np.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]]),
+        response_mask=mask,
+        loss_mask=mask,
+        rewards=np.array([[0, 1, 0], [0, 0, 0]], dtype=np.float32),
+        advantages=np.array([[0.7, 0.7, 0], [-0.7, 0, 0]], dtype=np.float32),
+        old_logprobs=old,
+        behavior_logprobs=old - 0.2 * mask,
+        group_ids=np.array([0, 0]),
+        objective_partition_ids=np.array([0, 1]),
+        reference_logprobs=old - 0.1 * mask,
+        current_logprobs=old + 0.01 * mask,
+        logprob_gradients=np.array([[-0.175, -0.175, 0], [0.35, 0, 0]], dtype=np.float32),
+    )
+    return batch
+
+
+def test_golden_rollout_preserves_replay_inputs_and_optional_reference(tmp_path, golden_rollout):
+    batch = golden_rollout
+    old = batch.old_logprobs
+    mask = batch.loss_mask
+    path = str(tmp_path / "batch.npz")
+    manifest = {"provenance": {"policy_version": 3}, "oracle": {"loss": 0.25}}
+    write_golden_rollout(path, batch, manifest)
+    restored, metadata = read_golden_rollout(path)
+    for field in dataclasses.fields(batch):
+        np.testing.assert_array_equal(getattr(restored, field.name), getattr(batch, field.name))
+    assert metadata == {"schema_version": 1, **manifest}
+    write_golden_rollout(path, dataclasses.replace(batch, reference_logprobs=None), manifest)
+    assert read_golden_rollout(path)[0].reference_logprobs is None
+
+    with pytest.raises(ValueError, match="contained in response_mask"):
+        write_golden_rollout(path, dataclasses.replace(batch, loss_mask=np.ones_like(mask)), manifest)
+    # A rejected write must leave the previously usable artifact intact.
+    np.testing.assert_array_equal(read_golden_rollout(path)[0].old_logprobs, old)
+
+
+@pytest.mark.parametrize("rows,width", [(0, 3), (2, 0), (2, 4)])
+def test_golden_rollout_rejects_non_replayable_dimensions(rows, width):
+    tokens = np.zeros((rows, 3), dtype=np.int32)
+    values = np.zeros((rows, width), dtype=np.float32)
+    batch = GoldenRollout(
+        sequences=tokens,
+        attention_mask=tokens,
+        response_mask=values,
+        loss_mask=values,
+        rewards=values,
+        advantages=values,
+        old_logprobs=values,
+        behavior_logprobs=values,
+        group_ids=np.zeros(rows, dtype=np.int32),
+        objective_partition_ids=np.zeros(rows, dtype=np.int32),
+    )
+    with pytest.raises(ValueError, match=r"nonempty|response width"):
+        batch.validate()
+
+
+def test_golden_update_comparison_rejects_changed_membership_and_checkpoint_overwrite(tmp_path, golden_rollout):
+    manifest = {
+        "config": {"trainer": {"algorithm": {}, "policy": {}}},
+        "oracle": {"loss": 0.25},
+        "provenance": {
+            "source_sha256": {},
+            "initial_policy": {"uri": "s3://model/weights", "identity": "step-0"},
+            "initial_optimizer": {"step": 0},
+            "rng_seed": 17,
+            "torch_version": "2.11.0",
+        },
+    }
+    objects = {
+        "source_objects": [
+            {
+                "uri": "s3://model/weights/shard-0",
+                "size": 1024,
+                "etag": "original-content",
+                "version_id": None,
+                "checksum_sha256": None,
+            }
+        ]
+    }
+    probes = {"names": ["weight"], "values": [0.25], "optimizer_parameter_values": [0.25001]}
+    for name in ("first", "replay"):
+        directory = tmp_path / name
+        directory.mkdir()
+        write_golden_rollout(str(directory / "golden.npz"), golden_rollout, manifest)
+        (directory / "source-identity.json").write_text(json.dumps(objects))
+        (directory / "golden.npz.rank-0.json").write_text(
+            json.dumps({"before": probes, "after": probes, "grad_norm": 0.5})
+        )
+    first = str(tmp_path / "first/golden.npz")
+    replay = str(tmp_path / "replay/golden.npz")
+    assert compare_updates(first, replay, 1)["passed"]
+
+    relabeled = dataclasses.replace(golden_rollout, group_ids=np.array([37, 37]))
+    write_golden_rollout(replay, relabeled, manifest)
+    assert compare_updates(first, replay, 1)["passed"]
+    write_golden_rollout(replay, dataclasses.replace(golden_rollout, group_ids=np.array([37, 38])), manifest)
+    membership_result = compare_updates(first, replay, 1)
+    assert not membership_result["passed"]
+    assert not membership_result["checks"]["group_ids"]["passed"]
+    write_golden_rollout(replay, relabeled, manifest)
+
+    # The logical model URI and even bounded probes can survive a shard overwrite.
+    objects["source_objects"][0]["etag"] = "different-content"
+    (tmp_path / "replay/source-identity.json").write_text(json.dumps(objects))
+    result = compare_updates(first, replay, 1)
+    assert not result["passed"]
+    assert not result["checks"]["provenance/source_objects"]["passed"]
+    assert result["checks"]["provenance/initial_policy"]["passed"]

--- a/tests/rl/test_grpo_replay.py
+++ b/tests/rl/test_grpo_replay.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+from marin.rl.grpo_artifact import GoldenRollout, write_golden_rollout
+from marin.rl.grpo_replay import replay_golden_rollout
+
+
+def test_replay_preserves_original_partitions_for_unequal_response_lengths(tmp_path):
+    # Two responses with scores 0 and 2 have sample std sqrt(2). Each was a
+    # separate oracle microbatch: both responses have half the objective weight.
+    advantage = 1 / (np.sqrt(2) + 1e-6)
+    advantages = np.asarray([[-advantage, -advantage], [advantage, 0]], dtype=np.float32)
+    gradients = np.asarray([[advantage / 4, advantage / 4], [-advantage / 2, 0]], dtype=np.float32)
+    mask = np.asarray([[1, 1], [1, 0]], dtype=np.float32)
+    batch = GoldenRollout(
+        sequences=np.asarray([[5, 7, 8], [5, 9, 0]], dtype=np.int32),
+        attention_mask=np.asarray([[1, 1, 1], [1, 1, 0]]),
+        response_mask=mask,
+        loss_mask=mask,
+        rewards=np.asarray([[0, 0], [2, 0]], dtype=np.float32),
+        advantages=advantages,
+        old_logprobs=np.full((2, 2), -2, dtype=np.float32),
+        behavior_logprobs=np.full((2, 2), -3, dtype=np.float32),
+        group_ids=np.asarray([91, 91]),
+        objective_partition_ids=np.asarray([10, 20]),
+        logprob_gradients=gradients,
+    )
+    algorithm = {
+        "advantage_estimator": "grpo",
+        "policy_loss_type": "regular",
+        "loss_reduction": "token_mean",
+        "advantage_batch_normalize": False,
+        "use_kl_in_reward": False,
+        "use_entropy_loss": False,
+        "use_tis": False,
+        "think_token_weight": 1.0,
+        "use_kl_loss": False,
+        "eps_clip_low": 0.2,
+        "eps_clip_high": 0.2,
+        "grpo_norm_by_std": True,
+    }
+    manifest = {
+        "config": {"trainer": {"algorithm": algorithm}},
+        "oracle": {
+            "loss": 0.0,
+            "metrics": {
+                "ppo_clip_ratio": 0.0,
+                "ppo_clip_ratio_low": 0.0,
+                "ppo_clip_ratio_high": 0.0,
+                "ppo_clip_pressure_low": 0.0,
+                "ppo_clip_pressure_high": 0.0,
+                "ppo_ratio_exact_unit_fraction": 1.0,
+            },
+        },
+        "provenance": {"kl_gradient": "detached", "oracle_base_commit": "8e33e01707b7225ecde1d6b8ad172a3dd4dc8661"},
+    }
+    uri = str(tmp_path / "capture.npz")
+    write_golden_rollout(uri, batch, manifest)
+    result = replay_golden_rollout(uri, atol=1e-5, rtol=1e-5)
+    assert result.logprob_gradients.max_absolute_error < 1e-5
+    assert result.advantages.max_absolute_error < 1e-5
+    assert result.response_tokens == 3
+    assert result.loss == pytest.approx(0, abs=1e-5)
+
+    # A capture whose recorded oracle loss differs must fail replay, even if
+    # its arrays and schema remain valid.
+    manifest["oracle"]["loss"] = 0.5
+    write_golden_rollout(uri, batch, manifest)
+    with pytest.raises(AssertionError, match="loss"):
+        replay_golden_rollout(uri, atol=1e-5, rtol=1e-5)
+
+    manifest["oracle"]["loss"] = 0.0
+    manifest["oracle"]["metrics"]["ppo_ratio_exact_unit_fraction"] = 0.5
+    write_golden_rollout(uri, batch, manifest)
+    with pytest.raises(AssertionError, match="ppo_ratio_exact_unit_fraction"):
+        replay_golden_rollout(uri, atol=1e-5, rtol=1e-5)

--- a/tests/rl/test_train_grpo.py
+++ b/tests/rl/test_train_grpo.py
@@ -1,0 +1,196 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import json
+from functools import partial
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jmp
+import numpy as np
+import optax
+import pytest
+from levanter.checkpoint import CheckpointerConfig, save_checkpoint
+from levanter.distributed import DistributedConfig
+from levanter.grpo import GrpoConfig, KlGradient
+from levanter.grpo_model import grpo_model_loss
+from levanter.models.llama import LlamaConfig
+from levanter.tracker.json_file import JsonFileTrackerConfig
+from levanter.tracker.tracker import NoopConfig
+from levanter.trainer import Trainer, TrainerConfig
+from marin.rl.grpo_artifact import GoldenRollout, write_golden_rollout
+from marin.rl.train_grpo import OfflineGrpoConfig, main, prepare_grpo_example, score_grpo_batch
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from transformers import LlamaConfig as HfLlamaConfig
+from transformers import LlamaForCausalLM, PreTrainedTokenizerFast
+
+
+def _rollout():
+    mask = np.array([[1, 1, 0], [1, 0, 0], [1, 1, 1], [1, 0, 0]], dtype=np.int32)
+    return GoldenRollout(
+        sequences=np.array([[0, 2, 3, 4, 0], [2, 3, 5, 0, 0], [0, 4, 6, 7, 8], [3, 4, 9, 0, 0]]),
+        attention_mask=np.array([[0, 1, 1, 1, 0], [1, 1, 1, 0, 0], [0, 1, 1, 1, 1], [1, 1, 1, 0, 0]]),
+        response_mask=mask,
+        loss_mask=mask,
+        rewards=np.array([[0, 1, 0], [0, 0, 0], [0, 0, 2], [-1, 0, 0]], dtype=np.float32),
+        advantages=np.zeros((4, 3), dtype=np.float32),
+        old_logprobs=np.full((4, 3), -9.0, dtype=np.float32),
+        behavior_logprobs=np.full((4, 3), -10.0, dtype=np.float32),
+        group_ids=np.array([0, 0, 1, 1]),
+        objective_partition_ids=np.array([0, 1, 0, 1]),
+    )
+
+
+def _model():
+    return LlamaConfig(
+        max_seq_len=5,
+        hidden_dim=8,
+        intermediate_dim=16,
+        num_layers=1,
+        num_heads=2,
+        num_kv_heads=2,
+        gradient_checkpointing=False,
+    ).build(hax.Axis("vocab", 16), key=jax.random.PRNGKey(7))
+
+
+def _trainer(tmp_path, microbatch, checkpoint=None):
+    config = TrainerConfig(
+        id="offline-grpo-test",
+        train_batch_size=4,
+        per_device_parallelism=microbatch,
+        num_train_steps=2,
+        tracker=NoopConfig(),
+        require_accelerator=False,
+        mp=jmp.get_policy("f32"),
+        log_dir=str(tmp_path),
+        log_jaxprs=False,
+        log_xla_hlo=False,
+        load_checkpoint=checkpoint is not None,
+        load_checkpoint_path=checkpoint,
+    )
+    loss = partial(
+        grpo_model_loss,
+        config=GrpoConfig(0.2, 0.2, 0.0, KlGradient.DETACHED),
+        accumulation_steps=4 // microbatch,
+        block_size=8,
+    )
+    return Trainer(config, optax.adam(1e-3), loss, add_default_hooks=False)
+
+
+def _arrays(tree):
+    return [np.asarray(x).copy() for x in jax.tree.leaves(eqx.filter(tree, eqx.is_array))]
+
+
+@pytest.mark.timeout(180)
+def test_offline_grpo_optimizer_update_preserves_objective_across_microbatches(tmp_path):
+    batch = prepare_grpo_example(_rollout(), normalize_by_std=True)
+    initial = _arrays(_model())
+    outcomes = []
+    for microbatch in (4, 2):
+        with _trainer(tmp_path, microbatch) as trainer:
+            state = trainer.initial_state(jax.random.PRNGKey(17), model=_model())
+            scored = score_grpo_batch(trainer, state.model, batch, block_size=8)
+            assert not np.allclose(scored.old_logprobs.array, _rollout().old_logprobs)
+            result = trainer.train_step(state, scored)
+            outcomes.append((float(result.loss), _arrays(result.state.model), _arrays(result.state.opt_state)))
+    assert any(not np.array_equal(a, b) for a, b in zip(initial, outcomes[0][1], strict=True))
+    np.testing.assert_allclose(outcomes[0][0], outcomes[1][0], atol=1e-6, rtol=1e-5)
+    for full, micro in zip(outcomes[0][1] + outcomes[0][2], outcomes[1][1] + outcomes[1][2], strict=True):
+        np.testing.assert_allclose(full, micro, atol=1e-6, rtol=1e-5)
+
+
+@pytest.mark.timeout(180)
+def test_offline_grpo_checkpoint_resume_reproduces_second_optimizer_step(tmp_path):
+    batch = prepare_grpo_example(_rollout(), normalize_by_std=True)
+    checkpoint = str(tmp_path / "step-1")
+    with _trainer(tmp_path, 2) as trainer:
+        state = trainer.initial_state(jax.random.PRNGKey(17), model=_model())
+        scored = score_grpo_batch(trainer, state.model, batch, block_size=8)
+        state = trainer.train_step(state, scored).state
+        first_step = _arrays((state.model, state.opt_state, state.training_key, state.step))
+        save_checkpoint(state, int(state.step), checkpoint, is_temporary=False)
+        scored = score_grpo_batch(trainer, state.model, batch, block_size=8)
+        uninterrupted = trainer.train_step(state, scored)
+        expected = _arrays(
+            (
+                uninterrupted.state.model,
+                uninterrupted.state.opt_state,
+                uninterrupted.state.training_key,
+                uninterrupted.state.step,
+            )
+        )
+    with _trainer(tmp_path, 2, checkpoint) as trainer:
+        # A different seed makes failure to restore the training RNG observable.
+        restored = trainer.initial_state(jax.random.PRNGKey(999), model=_model())
+        for saved, loaded in zip(
+            first_step, _arrays((restored.model, restored.opt_state, restored.training_key, restored.step)), strict=True
+        ):
+            np.testing.assert_array_equal(saved, loaded)
+        scored = score_grpo_batch(trainer, restored.model, batch, block_size=8)
+        resumed = trainer.train_step(restored, scored)
+        actual = _arrays((resumed.state.model, resumed.state.opt_state, resumed.state.training_key, resumed.state.step))
+        assert int(resumed.state.step) == 2
+        for direct, loaded in zip(expected, actual, strict=True):
+            np.testing.assert_array_equal(direct, loaded)
+        np.testing.assert_array_equal(uninterrupted.loss, resumed.loss)
+
+
+@pytest.mark.timeout(180)
+def test_offline_grpo_main_rejects_rewritten_capture_on_continuation(tmp_path):
+    model_path = str(tmp_path / "initial")
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=Tokenizer(WordLevel({f"token{i}": i for i in range(16)}, unk_token="token0")),
+        unk_token="token0",
+        pad_token="token0",
+    )
+    tokenizer.save_pretrained(model_path)
+    model = LlamaForCausalLM(
+        HfLlamaConfig(
+            vocab_size=16,
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=5,
+        )
+    )
+    model.save_pretrained(model_path)
+    captures = [str(tmp_path / f"capture{i}.npz") for i in range(2)]
+    for uri in captures:
+        write_golden_rollout(uri, _rollout(), {"tokenizer": model_path})
+    config = OfflineGrpoConfig(
+        captures=captures,
+        initial_model=model_path,
+        tokenizer=model_path,
+        hf_save_path=str(tmp_path / "export"),
+        stop_after=1,
+        model=LlamaConfig(),
+        trainer=TrainerConfig(
+            id="capture-contract",
+            train_batch_size=4,
+            per_device_parallelism=2,
+            num_train_steps=2,
+            tracker=JsonFileTrackerConfig(output_path=str(tmp_path / "metrics")),
+            require_accelerator=False,
+            distributed=DistributedConfig(initialize_jax_distributed=False),
+            mp=jmp.get_policy("f32"),
+            log_dir=str(tmp_path / "logs"),
+            log_jaxprs=False,
+            log_xla_hlo=False,
+            checkpointer=CheckpointerConfig(base_path=str(tmp_path / "checkpoints")),
+        ),
+        vocab_block_size=8,
+    )
+    main(config)
+    with (tmp_path / "metrics" / "eval_results.json").open() as source:
+        metrics = json.load(source)
+    assert metrics["train/ppo_ratio_exact_unit_fraction"] == 1.0
+    assert np.isfinite(metrics["train/log_ratio_abs_max"])
+    changed = dataclasses.replace(_rollout(), rewards=_rollout().rewards + 0.25 * _rollout().response_mask)
+    write_golden_rollout(captures[1], changed, {"tokenizer": model_path})
+    with pytest.raises(ValueError, match="same capture stream"):
+        main(dataclasses.replace(config, stop_after=None))


### PR DESCRIPTION
Add GRPO objectives, captured-batch replay, and an offline Levanter learner. Group advantages and objective weights are computed before execution microbatching so packing and accumulation preserve the captured loss normalization. Replay checks loss and logprob gradients against the pinned MarinSkyRL oracle; the learner recomputes raw-policy scores before each update and uses existing Levanter checkpoint continuation.

The model-independent JaxPP path packs complete trajectories, preserves segment and response alignment, and clips the global gradient before stage-local optimizer updates. A scorer-only boundary after each stage's compute-weight cast blocks fusion across that boundary while preserving the training gradient graph.

The combined June integration measured zero maximum absolute difference between recomputed old-policy logprobs and training-forward logprobs on positive-policy-weight tokens before each of three 67B updates, using 32 H100s with PP4/EP8 and no routing drops. That run also used separate Snowball and kernel changes. This extracted branch passed 523 affected CPU tests, including objective gradients, response alignment, packing, and offline continuation; distributed JaxPP execution evidence comes from the combined run. [Numerical evidence and runtime configuration](https://marina.oa.dev/echo/wiki/363).

Snowball model support is packaged separately. June pipeline checkpoint integration remains with the work coordinated in #8972; this change does not add an online rollout coordinator or policy publication.

Uses the shared TPU cross-entropy accuracy correction landed in #8960. Independent dense-reference tests request accurate TPU transcendental operations; pipeline objective and gradient comparisons additionally preserve explicit BF16 casts. All 18 combined GRPO/CE TPU cases pass without changing tolerances. [TPU precision evidence](https://marina.oa.dev/echo/wiki/373).
