### PR TITLE
Split Ruff import configuration by package

### DIFF
--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -848,9 +848,11 @@ PRECOMMIT_CONFIGS = [
         ],
     ),
     PrecommitConfig(
-        patterns=["lib/marin/src/**/*.py"],
+        patterns=["lib/marin/**/*.py"],
         checks=[
             partial(check_ruff, config=MARIN_RUFF_CONFIG),
+            check_black,
+            partial(check_license_headers, license_file=MARIN_LICENSE),
         ],
     ),
     PrecommitConfig(

--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -45,6 +45,7 @@ HALIAX_LICENSE = ROOT_DIR / "lib/haliax/etc/license_header.txt"
 MARIN_LICENSE = ROOT_DIR / "etc/license_header.txt"
 LEVANTER_BLACK_CONFIG = ROOT_DIR / "lib/levanter/pyproject.toml"
 HALIAX_BLACK_CONFIG = ROOT_DIR / "lib/haliax/pyproject.toml"
+MARIN_RUFF_CONFIG = ROOT_DIR / "lib/marin/pyproject.toml"
 
 EXCLUDE_PATTERNS = [
     ".git/**",
@@ -190,11 +191,13 @@ def _record(name: str, exit_code: int, output: str = "") -> int:
     return exit_code
 
 
-def check_ruff(files: list[pathlib.Path], fix: bool) -> int:
+def check_ruff(files: list[pathlib.Path], fix: bool, config: pathlib.Path | None = None) -> int:
     if not files:
         return 0
 
     args = ["uvx", "ruff@0.14.3", "check"]
+    if config is not None:
+        args.extend(["--config", str(config)])
     if fix:
         args.extend(["--fix", "--exit-non-zero-on-fix"])
 
@@ -845,8 +848,14 @@ PRECOMMIT_CONFIGS = [
         ],
     ),
     PrecommitConfig(
+        patterns=["lib/marin/src/**/*.py"],
+        checks=[
+            partial(check_ruff, config=MARIN_RUFF_CONFIG),
+        ],
+    ),
+    PrecommitConfig(
         patterns=["**/*.py"],
-        exclude_patterns=["lib/levanter/**", "lib/haliax/**", "lib/**/vendor/**"],
+        exclude_patterns=["lib/levanter/**", "lib/haliax/**", "lib/marin/**", "lib/**/vendor/**"],
         checks=[
             check_ruff,
             check_black,

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -226,3 +226,10 @@ exclude = [
   "src/marin/inference/dashboard/dist",
   "src/marin/inference/dashboard/.rsbuild",
 ]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.isort]
+known-first-party = ["marin"]
+known-local-folder = []

--- a/lib/marin/src/marin/rl/skyrl.py
+++ b/lib/marin/src/marin/rl/skyrl.py
@@ -16,6 +16,8 @@ from enum import StrEnum
 from pathlib import PurePosixPath
 from typing import cast
 
+from rigging.filesystem.storage_path import prefix_join
+
 from marin.evaluation.model_config import ModelConfig
 from marin.evaluation.utils import discover_hf_checkpoints
 from marin.execution.artifact import Artifact
@@ -23,7 +25,6 @@ from marin.execution.lazy import ArtifactStep, StepContext
 from marin.execution.remote import sanitize_job_name
 from marin.external_dependencies import MARIN_SKYRL
 from marin.training.training import LevanterCheckpoint, temporary_storage_base_path
-from rigging.filesystem.storage_path import prefix_join
 
 _EXECUTION = "skyrl_execution"
 _LAUNCHER_PYTHON = "3.12"

--- a/lib/marin/src/marin/transform/ar5iv/transform_ar5iv.py
+++ b/lib/marin/src/marin/transform/ar5iv/transform_ar5iv.py
@@ -13,6 +13,11 @@ import re
 from dataclasses import dataclass
 
 from bs4 import BeautifulSoup
+from rigging.filesystem.storage_path import StoragePath
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.readers import load_jsonl
+
 from marin.schemas.web.convert import ExtractionConfig
 from marin.transform.ar5iv.transform import (
     clean_li,
@@ -31,10 +36,6 @@ from marin.transform.ar5iv.transform import (
     unwrap_eqn,
 )
 from marin.web.convert import convert_page
-from rigging.filesystem.storage_path import StoragePath
-from zephyr.context import ZephyrContext
-from zephyr.dataset import Dataset
-from zephyr.readers import load_jsonl
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -23,14 +23,15 @@ import datasets
 import draccus
 import fsspec
 from fray.types import ResourceConfig
-from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
-from marin.utils import load_dataset_with_backoff
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_jsonl
 from zephyr.writers import write_jsonl_file
+
+from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
+from marin.utils import load_dataset_with_backoff
 
 from .adapters import TransformAdapter
 

--- a/lib/marin/src/marin/transform/conversation/transform_preference_data.py
+++ b/lib/marin/src/marin/transform/conversation/transform_preference_data.py
@@ -18,11 +18,12 @@ from dataclasses import dataclass, field
 import datasets
 import draccus
 from datasets import get_dataset_config_info
-from marin.utils import is_path_like
 from rigging.filesystem.storage_path import StoragePath
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.writers import write_jsonl_file
+
+from marin.utils import is_path_like
 
 from .preference_data_adapters import PreferenceTransformAdapter, get_preference_adapter
 from .transform_conversation import get_shard_dir

--- a/lib/marin/src/marin/transform/evaluation/continuation_records.py
+++ b/lib/marin/src/marin/transform/evaluation/continuation_records.py
@@ -21,6 +21,10 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol, TypeVar
 
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.factory import open_url
+from rigging.filesystem.storage_path import StoragePath
+
 from marin.datakit.ingestion_manifest import (
     IngestionSourceManifest,
     JsonValue,
@@ -28,9 +32,6 @@ from marin.datakit.ingestion_manifest import (
     verify_content_fingerprint,
     write_ingestion_metadata_json,
 )
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.factory import open_url
-from rigging.filesystem.storage_path import StoragePath
 
 E = TypeVar("E")
 

--- a/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
+++ b/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
@@ -12,6 +12,10 @@ from importlib import resources
 from typing import Any
 
 import yaml
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.factory import open_url
+from rigging.filesystem.storage_path import StoragePath
+
 from marin.datakit.ingestion_manifest import (
     IngestionSourceManifest,
     MaterializedOutputMetadata,
@@ -19,9 +23,6 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.transform.hf_parquet_splits import load_hf_split_iterable
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.factory import open_url
-from rigging.filesystem.storage_path import StoragePath
 
 
 class LmEvalRawRenderer(StrEnum):

--- a/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
+++ b/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
@@ -18,11 +18,12 @@ from typing import Any
 
 import draccus
 from datasets import get_dataset_config_names, load_dataset
-from marin.core.data import QAExample, QAExampleMetadata
-from marin.utilities.dataclass_utils import asdict_without_nones
 from rigging.filesystem.factory import filesystem as marin_filesystem
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
+
+from marin.core.data import QAExample, QAExampleMetadata
+from marin.utilities.dataclass_utils import asdict_without_nones
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
+++ b/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
@@ -23,6 +23,10 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.readers import load_jsonl, load_parquet
+
 from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_EMPTY_FIELD,
     DEFAULT_ZEEK_SEPARATOR,
@@ -30,9 +34,6 @@ from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_UNSET_FIELD,
     render_zeek_tsv_log,
 )
-from zephyr.context import ZephyrContext
-from zephyr.dataset import Dataset
-from zephyr.readers import load_jsonl, load_parquet
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/simple_html_to_md/process.py
+++ b/lib/marin/src/marin/transform/simple_html_to_md/process.py
@@ -10,11 +10,12 @@ containing html content, it will convert them to markdown and save them in a new
 import logging
 from dataclasses import dataclass, field
 
-from marin.schemas.web.convert import ExtractionConfig, HtmlToMarkdownConfig
-from marin.web.convert import convert_page
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_jsonl
+
+from marin.schemas.web.convert import ExtractionConfig, HtmlToMarkdownConfig
+from marin.web.convert import convert_page
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/stackexchange/transform_stackexchange.py
+++ b/lib/marin/src/marin/transform/stackexchange/transform_stackexchange.py
@@ -14,12 +14,13 @@ import random
 from dataclasses import dataclass
 
 import draccus
-from marin.schemas.web.convert import ExtractionConfig
-from marin.web.convert import convert_page
 from rigging.filesystem.storage_path import StoragePath
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_jsonl
+
+from marin.schemas.web.convert import ExtractionConfig
+from marin.web.convert import convert_page
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/structured_text/table_records.py
+++ b/lib/marin/src/marin/transform/structured_text/table_records.py
@@ -18,6 +18,10 @@ import posixpath
 from dataclasses import dataclass, field
 from typing import Any
 
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.factory import open_url
+from rigging.filesystem.storage_path import StoragePath
+
 from marin.datakit.ingestion_manifest import (
     IngestionSourceManifest,
     MaterializedOutputMetadata,
@@ -25,9 +29,6 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.transform.hf_parquet_splits import load_hf_split_iterable
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.factory import open_url
-from rigging.filesystem.storage_path import StoragePath
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/structured_text/web_data_commons.py
+++ b/lib/marin/src/marin/transform/structured_text/web_data_commons.py
@@ -26,15 +26,16 @@ from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
 import requests
+from rigging.filesystem.atomic import atomic_rename
+from rigging.filesystem.factory import open_url
+from rigging.filesystem.storage_path import StoragePath
+
 from marin.datakit.ingestion_manifest import (
     IngestionSourceManifest,
     MaterializedOutputMetadata,
     verify_content_fingerprint,
     write_ingestion_metadata_json,
 )
-from rigging.filesystem.atomic import atomic_rename
-from rigging.filesystem.factory import open_url
-from rigging.filesystem.storage_path import StoragePath
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/wikipedia/transform_wikipedia.py
+++ b/lib/marin/src/marin/transform/wikipedia/transform_wikipedia.py
@@ -15,12 +15,13 @@ from dataclasses import dataclass
 
 import draccus
 from bs4 import BeautifulSoup
-from marin.schemas.web.convert import ExtractionConfig
-from marin.web.convert import convert_page
 from rigging.filesystem.storage_path import StoragePath
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_jsonl
+
+from marin.schemas.web.convert import ExtractionConfig
+from marin.web.convert import convert_page
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/validate/validate.py
+++ b/lib/marin/src/marin/validate/validate.py
@@ -18,11 +18,12 @@ from dataclasses import dataclass
 
 import draccus
 import numpy as np
-from marin.utilities.validation_utils import compute_global_mean_std, summarize_document
 from rigging.filesystem.storage_path import StoragePath
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_jsonl
+
+from marin.utilities.validation_utils import compute_global_mean_std, summarize_document
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ known-first-party = ["experiments"]
 # "config" is the local module in infra/tpu-ci/{setup,vm_manager}.py. The repo-root
 # config/ directory (cluster YAMLs) would otherwise make isort treat ``import config``
 # as first-party and reorder it, so pin it to the third-party group it already sits in.
-known-third-party = ["wandb", "config"]
+known-third-party = ["wandb", "config", "marin"]
 
 
 # Pyrefly type checker configuration


### PR DESCRIPTION
Run root and Marin package files under separate Ruff configurations. The root
configuration keeps `experiments` local and groups Marin imports consistently;
`lib/marin/pyproject.toml` extends the root rules while treating Marin as
first-party.

`infra/pre-commit.py` excludes `lib/marin` from the generic Python pass and
invokes its package configuration separately. This prevents Ruff from moving
individual Marin imports across the `experiments` boundary. The affected source
changes are import-only reorganizations.
