### PR TITLE
[grug] Return the EP hero to the ragged all-to-all transport

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -16,25 +16,21 @@ data-parallel rack uses one 64-device expert mesh.
   diagnostic uses 1024 sequences.
 - Router: top-8 quantile balancing uses a global histogram with 10,000 bins. It has next-step,
   stop-gradient expert biases and no auxiliary balancing loss.
-- MoE backend: `fixed_pooled_wave_all_to_all`, as a temporary fallback. Each sender uses one fixed
-  pool per destination and stripes it over three static waves. The receiver runs all six local
-  experts in each wave and drops rows above the fixed expert capacity. Expert IDs travel in the
-  activation payload, so the method does not use a metadata collective. The receiver and sender
-  capacity factors are 1.15. `ragged_all_to_all` is the intended default and takes the hero back
-  once it stops hanging an 11-rack run after a watch step
-  ([#8870](https://github.com/marin-community/marin/issues/8870)): one update carries each (peer,
-  local expert) pair, so rows arrive grouped by expert, and it reaches XLA's device-initiated
-  (NCCL LSA) kernel, which needs Marin's patched PJRT build, installed on GB200 through the `gpu`
-  extra (`lib/marin/pyproject.toml`).
+- MoE backend: `ragged_all_to_all`. One update carries each (peer, local expert) pair, so rows
+  arrive grouped by expert, and local experts run in two chunks that share the 1.15 receiver
+  capacity. The transport reaches XLA's device-initiated (NCCL LSA) kernel, which needs Marin's patched
+  PJRT build, installed on GB200 through the `gpu` extra (`lib/marin/pyproject.toml`); a run that
+  reaches the stock plugin fails at startup.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Weights: bf16 on device with a pinned-host fp32 master, which the pooled-wave device peak needs.
-  A checkpoint written with a master restores natively here. A master-less checkpoint, which the
-  hero writes when it keeps fp32 weights on device under the ragged transport, cannot restore into
-  this mode: synthesizing a master is refused. The reverse direction migrates in process, so a
-  master-bearing checkpoint reaches either mode.
+- Weights: fp32 on device with bf16 compute. A checkpoint written with a pinned-host fp32 master
+  migrates in process on restore: its stored fp32 master is read directly into the run's params
+  (the bf16 compute copy goes unread), and the next save writes the new layout. The reverse
+  (synthesizing a master) is refused.
 - Runtime: Each GPU has one JAX process. The recipe uses `cuda_async`, no PGLE, and no GPU
-  command buffers. The layer carry stays in HBM, which only the ragged transport offloads. Inline
-  watch uses collective overlap limit 1. A disabled watch uses limit 4.
+  command buffers. The ragged transport stages each layer's residual carry on pinned host, which
+  frees the HBM the latency-hiding scheduler needs to run. Collective overlap stays at 1: the
+  offload, the scheduler, and a higher limit corrupt training together, though no pair of them
+  does.
 - Resources: Each four-GPU worker requests 120 CPU, 890 GB of RAM, and 1 TB of disk.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -21,6 +21,8 @@ data-parallel rack uses one 64-device expert mesh.
   capacity. The transport reaches XLA's device-initiated (NCCL LSA) kernel, which needs Marin's patched
   PJRT build, installed on GB200 through the `gpu` extra (`lib/marin/pyproject.toml`); a run that
   reaches the stock plugin fails at startup.
+  The production hero trained on `fixed_pooled_wave_all_to_all` through step 81716 (3.77T of its 18T
+  tokens); `hero-ragged_a2a-ep-step81k` continues from that checkpoint on the ragged transport.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
 - Weights: fp32 on device with bf16 compute. A checkpoint written with a pinned-host fp32 master
   migrates in process on restore: its stored fp32 master is read directly into the run's params

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -38,12 +38,8 @@ HERO_NODE_CPU = 120
 HERO_NODE_RAM = "890g"
 HERO_NODE_DISK = "1t"
 HERO_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
-# The pooled-wave transport peaks at 149.9 GiB of device memory with fp32 weights on device
-# (#8549), above the 138.2 GiB `cuda_async` release threshold, so this fallback keeps the fp32
-# master on pinned host and leaves the device copy in bf16. The mode is part of the checkpoint
-# layout: a master-less checkpoint cannot restore into it, because synthesizing a master is
-# refused. The diagnostics, soak, and benchmarks follow the hero.
-HERO_MASTER_PARAM_MODE = MasterParamMode.FP32_PINNED_HOST
+# The hero keeps fp32 weights on device; the diagnostics, soak, and benchmarks follow it.
+HERO_MASTER_PARAM_MODE = MasterParamMode.DEVICE
 # An fp32 master keeps the device copy in bf16; without one the device weights are the fp32 copy.
 HERO_MIXED_PRECISION_BY_MASTER_PARAM_MODE = {
     MasterParamMode.FP32_PINNED_HOST: HERO_MIXED_PRECISION,

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -9,9 +9,8 @@ pairs it with the fixed hero model spec so a launcher gets both configs back fro
 ``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
 
 The hero model is d6144 with 48 layers and 384 routed experts. Each expert has width 3,072, and
-the router selects eight experts per token. Expert parallelism moves tokens with the pooled-wave
-all-to-all transport at 1.15 sender and receiver capacity factors, until the ragged transport is
-fit to take the default back.
+the router selects eight experts per token. Expert parallelism moves tokens with the ragged
+all-to-all transport at a 1.15 receiver capacity factor.
 """
 
 import math
@@ -106,11 +105,9 @@ HERO_MODEL = GrugModelConfig(
     qk_mult=1.3,
     sconv=True,
     attention_implementation="gpu_fa4_cute_wide",
-    # Temporary fallback while the ragged transport is debugged: it hangs an 11-rack hero after
-    # a watch step (#8870). `ragged_all_to_all` takes this back once that is fixed.
-    moe_implementation="fixed_pooled_wave_all_to_all",
-    pooled_transport_capacity_factor=1.15,
-    num_expert_waves=3,
+    moe_implementation="ragged_all_to_all",
+    pooled_transport_capacity_factor=1.15,  # pooled-wave only
+    num_expert_waves=3,  # pooled-wave only
     expert_chunks=1,
     report_capacity_overflow=True,
     rope_fused=True,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -28,6 +28,7 @@ Changelog:
         (see ``trigger_hero.sh``).
     2026-09-09 (#8870): the ragged all-to-all transport with fp32 weights on device returns as the
         default after the pooled-wave fallback of 2026-09-03 (#8884).
+        hero-ragged_a2a-ep-step81k forks hero-wd-gate-router-p02-step58k at step 81716 (see ``trigger_hero.sh``).
 """
 
 import dataclasses

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -4,7 +4,7 @@
 """Hero-shape scaling ladder: one recipe, five widths.
 
 Every rung trains the *same* EP hero recipe -- 384 routed experts, top-8, hidden/2-wide experts in a
-hidden/2 latent, pooled-wave all-to-all transport, the Harrier 2026.08.18 two-phase mixture on the
+hidden/2 latent, ragged all-to-all transport, the Harrier 2026.08.18 two-phase mixture on the
 Marin tokenizer, offloaded MuonH state, the QB histogram estimator, and a dropless held-out eval --
 and differs only in width and the rack count it spans. Behaviour is uniform across the ladder so a
 rung predicts the d6144 hero. ``d6144`` is the hero itself.
@@ -26,6 +26,8 @@ Changelog:
         resumes at the right step); pass ``--gate-router-weight-decay 0`` to opt out.
         hero-wd-gate-router-p02-step58k forks hero-12d8b6f0-dee637 at step 58014 on the pooled-wave transport
         (see ``trigger_hero.sh``).
+    2026-09-09 (#8870): the ragged all-to-all transport with fp32 weights on device returns as the
+        default after the pooled-wave fallback of 2026-09-03 (#8884).
 """
 
 import dataclasses

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -9,7 +9,7 @@ This run puts the same hooks on a one-step cadence on up to two GB200 trays, so 
 100 checkpoints, tagged evaluations, and dropless evaluations.
 
 The shape is downsized but the memory-relevant machinery is the hero's: MuonH optimizer state
-offloaded to pinned host memory, and the ragged all-to-all transport. Those decide what the
+offloaded to pinned host memory, and the hero's all-to-all transport. Those decide what the
 checkpoint path has to move through host memory, which is what the soak measures.
 
 Checkpoints go to a one-day temporary prefix, never to the hero's own checkpoint root.

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -9,7 +9,7 @@ This run puts the same hooks on a one-step cadence on up to two GB200 trays, so 
 100 checkpoints, tagged evaluations, and dropless evaluations.
 
 The shape is downsized but the memory-relevant machinery is the hero's: MuonH optimizer state
-offloaded to pinned host memory, and the hero's all-to-all transport. Those decide what the
+offloaded to pinned host memory, and the ragged all-to-all transport. Those decide what the
 checkpoint path has to move through host memory, which is what the soak measures.
 
 Checkpoints go to a one-day temporary prefix, never to the hero's own checkpoint root.

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,10 +11,11 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
-# Gate/router weight-decay continuation: forks the hero's full state from its step-58014 checkpoint
-# under its own run id and tree, and trains with the decay on by default (0.02, annealed).
-RUN_ID=hero-wd-gate-router-p02-step58k
-HANDOFF_CHECKPOINT=s3://hero-checkpoints/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/grug/hero-12d8b6f0-dee637/2026.08.19.2/checkpoints/step-58014
+# Ragged all-to-all continuation: forks the hero's full state from the checkpoint forced on the
+# pooled-wave run at step 81716 (its metadata is marked non-temporary so the hourly save keeps it)
+# under its own run id and tree.
+RUN_ID=hero-ragged_a2a-ep-step81k
+HANDOFF_CHECKPOINT=s3://hero-checkpoints/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/grug/hero-wd-gate-router-p02-step58k/2026.08.19.2/checkpoints/step-81716
 HERO_ISSUE=https://github.com/marin-community/marin/issues/8506
 TARGET_CLUSTER=cw-us-east-08a
 TARGET_DESCRIPTION='11 x NVL72'

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -72,7 +72,7 @@ def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
         1.15,
         1.15,
         3,
-        "fixed_pooled_wave_all_to_all",
+        "ragged_all_to_all",
         model.QbEstimator.HIST,
         10_000,
         1024,
@@ -80,9 +80,9 @@ def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
         4,
         10,
         1_000_000_000,
+        jnp.float32,
         jnp.bfloat16,
-        jnp.bfloat16,
-        train.MasterParamMode.FP32_PINNED_HOST,
+        train.MasterParamMode.DEVICE,
     )
 
 


### PR DESCRIPTION
Restore `ragged_all_to_all` as the hero's MoE backend with fp32 weights on device, reverting the pooled-wave fallback from #8884. The diagnostics, soak, and benchmarks follow the hero.

The fallback was taken after two ragged hero attempts hung silently on one rack at 11 racks (#8870). Since then, one train-step executable per rank removed the duplicate symmetric-window registration (#8911), the PJRT wheel moved to the balanced ragged device kernel with 128-thread CTAs (#8976), and QuACK 0.6.4 replaces the grouped-GEMM scheduler that left outputs unwritten under contention (#8959, merge first). The hang's root cause is still open. The strongest lead is a fabric fault on specific NVL72 domains, which the 2026-09-05 NVLink fault on the pooled-wave hero also fits. The redeployment is a 200-step trial against the pooled-wave run on the same batches, with rollback to the pooled-wave commit.

The live hero's checkpoints carry a pinned-host fp32 master, which restores into device mode in process. The reverse migration is refused, so a rollback resumes the pooled-wave run's own tree.

`trigger_hero.sh` launches `hero-ragged_a2a-ep-step81k` from the checkpoint forced on `hero-wd-gate-router-p02-step58k` at step 81716 (3.77T tokens on the pooled-wave transport); its metadata is marked non-temporary so the old run's hourly save keeps it while the old run trains the 200-step control window.

Part of #8870.
