### PR TITLE
[loom] Lower Marina session reasoning effort

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -73,7 +73,7 @@ config:
       agent: codex
       description: Interactive questions over read-only Marina application APIs
       model: gpt-5.6-sol
-      effort: xhigh
+      effort: low
       protocol: acp
       mode: auto
       class: interactive


### PR DESCRIPTION
Run new sessions launched through Marina's embedded agent panel at low reasoning effort. This favors response latency for bounded, read-only page questions.

Existing sessions retain the effort recorded in their launch snapshot. The production Loom deployment must be applied after merge for new sessions to inherit the setting.
