### PR TITLE
[sft] Preserve chat prefixes across content representations

### DIFF
--- a/docs/tutorials/add-chat-dataset.md
+++ b/docs/tutorials/add-chat-dataset.md
@@ -193,14 +193,24 @@ normalized = source.normalized
 `StepRunner().run([source.normalized], max_concurrent=1)` builds the full dependency
 chain. Rendering preserves input IDs and duplicate rows; standard normalization assigns content hashes and
 deduplicates the rendered text. The original chat IDs become `source_id` in the
-normalized text. The structured Harmony artifact remains available through
-`source.chat_normalized`.
+normalized text. Deduplication compares rendered bytes: equivalent conversations
+rendered with different templates need not deduplicate. Use the same template
+version when combining rendered sources. The structured Harmony artifact remains
+available through `source.chat_normalized`.
+
+Stored text omits BOS; the standard text tokenizer prepends it and appends its
+normal space-plus-EOS document separator after the final chat EOT. Direct
+`render_marin_chat` calls include BOS by default for inference.
 
 Python converts Harmony messages to Hugging Face message dictionaries, then Hugging Face
 renders them with `MARIN_CHAT_TEMPLATE` in `marin.datakit.chat_template`. Tokenizer
-export uses the same template. The adapter joins adjacent assistant analysis, commentary, and function calls
+export uses the same template. The rendering behavior described here is the current Marin format; changes
+to the prompt wording or a switch to Harmony wire tokens require separate
+training and serving validation. The adapter joins adjacent assistant analysis, commentary, and function calls
 into one turn. The template emits one end-of-turn token after all parallel calls,
-so generation can reach the tool handoff. Analysis uses Marin think tokens,
+so generation can reach the tool handoff. The trace evaluation processor also
+keeps inline tool calls in one assistant turn while labeling prose and calls
+separately. Analysis uses Marin think tokens,
 function calls use `<tool_call>` JSON blocks, and named tool replies use
 `<tool_response>` blocks. The template also accepts `reasoning_content` from
 inference clients and serializes structured tool definitions as JSON. API tool

--- a/docs/tutorials/add-chat-dataset.md
+++ b/docs/tutorials/add-chat-dataset.md
@@ -196,10 +196,15 @@ deduplicates the rendered text. The original chat IDs become `source_id` in the
 normalized text. The structured Harmony artifact remains available through
 `source.chat_normalized`.
 
-Python prepares message bodies and uses f-strings for headers and separators,
-reproducing `MARIN_CHAT_TEMPLATE` in `experiments/marin_tokenizer.py`. The renderer
-joins adjacent assistant analysis and response messages into one turn, wraps analysis
-in think tokens, and renders function calls and named tool replies. Reasoning
+Python converts Harmony messages to Hugging Face message dictionaries, then Hugging Face
+renders them with `MARIN_CHAT_TEMPLATE` in `marin.datakit.chat_template`. Tokenizer
+export uses the same template. The adapter joins adjacent assistant analysis, commentary, and function calls
+into one turn. The template emits one end-of-turn token after all parallel calls,
+so generation can reach the tool handoff. Analysis uses Marin think tokens,
+function calls use `<tool_call>` JSON blocks, and named tool replies use
+`<tool_response>` blocks. The template also accepts `reasoning_content` from
+inference clients and serializes structured tool definitions as JSON. API tool
+reply IDs are resolved to function names; the rendered text omits the IDs. Reasoning
 from earlier turns is retained, including records ending in analysis or unanswered
 tool calls. Supported per-record `chat_template_kwargs` are `tools` (a list of
 recorded function definitions), `enable_thinking` (a boolean), and
@@ -210,6 +215,31 @@ All rendering helpers are in `marin.datakit.chat_render`.
 For an existing directory of normalized chat Parquet, use
 `render_chat_to_parquet(input_path=..., output_path=...)`. For a conversation in
 memory, `render_marin_chat(messages)` returns the rendered string. Bump
-`CHAT_RENDER_VERSION` when changing rendering so existing artifacts retain their
-original format. The inference-consistency tests live in
+`CHAT_RENDER_VERSION` when changing the Harmony conversion. The template itself
+is included in the rendering step hash, so template changes also produce a new
+artifact. The inference-consistency tests live in
 `tests/test_marin_tokenizer.py`.
+
+
+For inference, export this template with the model's tokenizer; the existing
+`marin-community/marin-tokenizer` revision
+`a5ca45f2feb6c959bd87b81689aa7279b5bdcaa2` contains the older template:
+
+```python
+from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("path/to/model")
+tokenizer.chat_template = MARIN_CHAT_TEMPLATE
+tokenizer.save_pretrained("path/to/model")
+```
+
+Point MarinSkyRL's policy tokenizer at that same artifact and enable tool parsing
+in the generator's `engine_init_kwargs` with `enable_auto_tool_choice: true` and
+`tool_call_parser: hermes`. This preserves the existing Marin header and reasoning
+tokens. The [pinned MarinSkyRL wrapper](https://github.com/marin-community/MarinSkyRL/blob/93d84333acdf27275d258f0f25dad24129f0cf6e/skyrl-train/skyrl_train/inference_engines/vllm/utils.py)
+forwards tool-parser settings but does not forward a reasoning parser. Reasoning
+therefore remains in assistant `content`; tool-enabled requests preserve its
+think markers. Returning a separate reasoning field in OpenAI chat-completion
+responses requires a MarinSkyRL wrapper change. Native Harmony wire tokens are not used by this
+renderer.

--- a/docs/tutorials/add-chat-dataset.md
+++ b/docs/tutorials/add-chat-dataset.md
@@ -196,10 +196,9 @@ output can be supplied as the `download` argument to the standard
 `normalize_step`. Rendering preserves input IDs and duplicate rows; standard
 normalization assigns content hashes afterward.
 
-Python prepares message bodies and a short Jinja template adds headers and
-separators, reproducing `MARIN_CHAT_TEMPLATE` in `experiments/marin_tokenizer.py`.
-The renderer joins
-adjacent assistant analysis and response messages into one turn, wraps analysis
+Python prepares message bodies and uses f-strings for headers and separators,
+reproducing `MARIN_CHAT_TEMPLATE` in `experiments/marin_tokenizer.py`. The renderer
+joins adjacent assistant analysis and response messages into one turn, wraps analysis
 in think tokens, and renders function calls and named tool replies. Reasoning
 from earlier turns is retained, including records ending in analysis or unanswered
 tool calls. Supported per-record `chat_template_kwargs` are `tools` (a list of

--- a/docs/tutorials/add-chat-dataset.md
+++ b/docs/tutorials/add-chat-dataset.md
@@ -174,3 +174,43 @@ deduplication counts. Normalization fails if quarantined records exceed its 5%
 health limit; investigate unexpected drops instead of raising the limit. Run near
 the source data when using Iris to avoid cross-region reads. Formatting checks do
 not establish answer quality.
+
+## 6. Render for text processing
+
+`marin.datakit.chat_render.render_chat_step` renders a normalized chat source
+into Parquet containing only `id` and `text`:
+
+```python
+from marin.datakit.chat_render import render_chat_step
+from marin.datakit.sft_sources import all_sft_sources
+
+source = all_sft_sources()["superior-reasoning"]
+rendered = render_chat_step(
+    name="rendered/superior-reasoning-marin",
+    chat=source.normalized,
+)
+```
+
+The step reads the chat normalization step's `outputs/main` directory. Its
+output can be supplied as the `download` argument to the standard
+`normalize_step`. Rendering preserves input IDs and duplicate rows; standard
+normalization assigns content hashes afterward.
+
+Python prepares message bodies and a short Jinja template adds headers and
+separators, reproducing `MARIN_CHAT_TEMPLATE` in `experiments/marin_tokenizer.py`.
+The renderer joins
+adjacent assistant analysis and response messages into one turn, wraps analysis
+in think tokens, and renders function calls and named tool replies. Reasoning
+from earlier turns is retained, including records ending in analysis or unanswered
+tool calls. Supported per-record `chat_template_kwargs` are `tools` (a list of
+recorded function definitions), `enable_thinking` (a boolean), and
+`custom_instructions` (a string). `enable_thinking` adds a `/think` or `/nothink`
+system instruction; omitting it adds neither. It does not remove reasoning.
+
+All rendering helpers are in `marin.datakit.chat_render`.
+For an existing directory of normalized chat Parquet, use
+`render_chat_to_parquet(input_path=..., output_path=...)`. For a conversation in
+memory, `render_marin_chat(messages)` returns the rendered string. Bump
+`CHAT_RENDER_VERSION` when changing rendering so existing artifacts retain their
+original format. The inference-consistency tests live in
+`tests/test_marin_tokenizer.py`.

--- a/docs/tutorials/add-chat-dataset.md
+++ b/docs/tutorials/add-chat-dataset.md
@@ -129,8 +129,9 @@ output changes so cached processed and normalized artifacts are rebuilt.
 ## 5. Register and verify the source
 
 Add the chat step factory to `all_sft_sources()` in `sft_sources.py`. Its
-`DatakitChatSource` records the name, ordered processing steps, and approximate
-token count. Existing text sources reuse their weights from `all_sources()`.
+`DatakitChatSource` records the name, structured-chat processing steps, and
+approximate token count. It appends rendering and standard text normalization
+automatically; `normalize_steps` exposes the complete chain. Existing text sources reuse their weights from `all_sources()`.
 For a chat-only source, add its explicit weight in billions to `token_counts`
 inside `all_sft_sources()`. Do not add it to the pretraining registry merely to
 supply this weight: that registry also defines the expected coverage of pinned
@@ -161,8 +162,8 @@ from marin.execution.artifact import read_artifact
 from marin.execution.step_runner import StepRunner
 
 source = all_sft_sources()["superior-reasoning"]
-StepRunner().run([source.normalized], max_concurrent=1)
-artifact = read_artifact(source.normalized.output_path, NormalizedData)
+StepRunner().run([source.chat_normalized], max_concurrent=1)
+artifact = read_artifact(source.chat_normalized.output_path, NormalizedData)
 print(artifact.main_output_dir)
 print(artifact.counters)
 ```
@@ -177,24 +178,23 @@ not establish answer quality.
 
 ## 6. Render for text processing
 
-`marin.datakit.chat_render.render_chat_step` renders a normalized chat source
-into Parquet containing only `id` and `text`:
+`all_sft_sources()` exposes both the structured conversation and its rendered
+text. `.chat_normalized` contains Harmony messages, `.rendered` contains only
+`id` and `text`, and `.normalized` contains standard Datakit normalized text:
 
 ```python
-from marin.datakit.chat_render import render_chat_step
 from marin.datakit.sft_sources import all_sft_sources
 
 source = all_sft_sources()["superior-reasoning"]
-rendered = render_chat_step(
-    name="rendered/superior-reasoning-marin",
-    chat=source.normalized,
-)
+rendered = source.rendered
+normalized = source.normalized
 ```
 
-The step reads the chat normalization step's `outputs/main` directory. Its
-output can be supplied as the `download` argument to the standard
-`normalize_step`. Rendering preserves input IDs and duplicate rows; standard
-normalization assigns content hashes afterward.
+`StepRunner().run([source.normalized], max_concurrent=1)` builds the full dependency
+chain. Rendering preserves input IDs and duplicate rows; standard normalization assigns content hashes and
+deduplicates the rendered text. The original chat IDs become `source_id` in the
+normalized text. The structured Harmony artifact remains available through
+`source.chat_normalized`.
 
 Python prepares message bodies and uses f-strings for headers and separators,
 reproducing `MARIN_CHAT_TEMPLATE` in `experiments/marin_tokenizer.py`. The renderer

--- a/experiments/marin_tokenizer.py
+++ b/experiments/marin_tokenizer.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E501  -- MARIN_CHAT_TEMPLATE has long literal lines that cannot be wrapped
-
 """
 Saves a modified version of the llama3 tokenizer with:
 1) a simple Olmo2-inspired chat format and
@@ -17,6 +15,7 @@ import os
 import tempfile
 from typing import cast
 
+from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from experiments.llama import llama3_tokenizer as llama3_tokenizer_hf_path
@@ -25,170 +24,6 @@ marin_tokenizer = "marin-community/marin-tokenizer"
 """
 The HF Hub name for the Marin tokenizer.
 The Marin tokenizer is (currently) just the Llama 3 tokenizer with a custom chat template (MARIN_CHAT_TEMPLATE).
-"""
-
-# inspired by the smollm3 template and the Olmo 2 template, using llama3's special tokens
-MARIN_CHAT_TEMPLATE = """
-{{ bos_token }}
-{%- if enable_thinking is defined -%}
-  {%- if enable_thinking is sameas true -%}
-    {%- set _reasoning_mode = "/think" -%}
-  {%- elif enable_thinking is sameas false -%}
-    {%- set _reasoning_mode = "/nothink" -%}
-  {%- else -%}
-    {%- set _reasoning_mode = enable_thinking -%}
-  {%- endif -%}
-{%- else -%}
-  {%- set _reasoning_mode = none -%}
-{%- endif -%}
-{%- set _custom_instructions = custom_instructions | default(None, true) -%}
-{%- set _xml_tools_list = xml_tools | default([], true) -%}
-{%- if tools is defined and tools -%}
-  {%- set _xml_tools_list = tools -%}
-{%- endif -%}
-{%- set _python_tools = python_tools | default([], true) -%}
-{%- set _has_aux_header = (_reasoning_mode is not none) or _custom_instructions or (_xml_tools_list) or (_python_tools) -%}
-{%- if _has_aux_header -%}
-<|start_header_id|>system<|end_header_id|>
-{%- if _reasoning_mode is not none -%}
-Reasoning: {{ _reasoning_mode }}
-{%- endif %}
-{%- if _custom_instructions %}
-{{ _custom_instructions | trim }}
-{%- endif %}
-{% if _xml_tools_list or _python_tools %}
-{{ "\n### Tools\n" }}
-You may call one or more functions to assist with the user query.
-{% if _xml_tools_list %}
-You are provided with function signatures within <tools> </tools> tags:
-
-<tools>
-{% for tool in _xml_tools_list %}
-{{ tool | string }}{% if not loop.last %}
-{% endif %}
-{% endfor %}
-</tools>
-
-For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
-<tool_call>
-{"name": <function-name>, "arguments": <args-json-object>}
-</tool_call>
-
-{% endif %}
-{% if _python_tools %}
-When you send a message containing Python code between <|python_tag|> and <|eom_id|> tags, it will be executed in a stateful Jupyter notebook environment, and you will then be given the output.
-
-You can use the following tools in your python code like regular functions:
-<tools>
-{% for tool in _python_tools %}
-{{ tool | string }}{% if not loop.last %}
-{% endif %}
-{% endfor %}
-</tools>
-{% endif %}
-{% endif %}
-<|eot_id|>
-{%- endif -%}
-{%- for message in messages -%}
-  {%- set has_tool_calls = message.get('tool_calls') is not none and message.get('tool_calls') -%}
-  {%- if not (message.get('role') in ['tool', 'ipython'] or has_tool_calls) -%}
-    {%- if message.get('role') == 'assistant' -%}
-<|start_header_id|>assistant<|end_header_id|>
-{% set content = message.get('content') %}
-{% if content is string %}
-{% generation %}{{- content | trim }}<|eot_id|>{% endgeneration %}
-{% elif content is mapping %}
-{% generation %}{{- content.get('text', '') | trim }}<|eot_id|>{% endgeneration %}
-{% elif content is iterable %}
-{% generation %}
-{%- for chunk in content -%}
-  {%- if chunk.get('type') == 'text' -%}
-    {{ chunk.get('text', '') | trim }}
-  {%- endif -%}
-{%- endfor -%}
-<|eot_id|>
-{% endgeneration %}
-{% else %}
-{% generation %}{% endgeneration %}<|eot_id|>
-{% endif %}
-    {%- else -%}
-<|start_header_id|>{{ message['role'] }}<|end_header_id|>
-{% set content = message.get('content') %}
-{% if content is string %}
-{{ content | trim }}<|eot_id|>
-{% elif content is mapping %}
-{{ content.get('text', '') | trim }}<|eot_id|>
-{% elif content is iterable %}
-{%- for chunk in content -%}
-  {%- if chunk.get('type') == 'text' -%}
-    {{ chunk.get('text', '') | trim }}
-  {%- endif -%}
-{%- endfor -%}<|eot_id|>
-{% else %}
-<|eot_id|>
-{% endif %}
-    {%- endif -%}
-
-  {%- elif message.get('role') == 'tool' -%}
-    {%- set _tool_name = message.get('name') -%}
-    {%- set _tool_id = message.get('tool_call_id') -%}
-    {%- set _attr_name = ' name=\"' ~ _tool_name ~ '\"' if _tool_name else '' -%}
-    {%- set _attr_id = ' id=\"' ~ _tool_id ~ '\"' if _tool_id else '' -%}
-<|start_header_id|>tool<|end_header_id|>
-<tool_response{{ _attr_name }}{{ _attr_id }}>
-{%- set tool_content = message.get('content') -%}
-{%- if tool_content is mapping or (tool_content is iterable and tool_content is not string) -%}
-{{- tool_content | tojson }}
-{%- else -%}
-{{- tool_content if tool_content is not none else '' }}
-{%- endif -%}
-</tool_response><|eot_id|>
-{{- "\n" -}}
-  {%- elif message.get('role') == 'ipython' -%}
-<|start_header_id|>ipython<|end_header_id|>
-{% set ipy_content = message.get('content') %}
-{% if ipy_content is string %}
-{{- { "output": ipy_content } | tojson -}}
-{% elif ipy_content is iterable %}
-{%- for chunk in ipy_content -%}
-  {%- if chunk.get('type') == 'text' -%}
-    {{- { "output": chunk.get('text', '') } | tojson -}}
-  {%- endif -%}
-{%- endfor -%}
-{% else %}
-{{- { "output": ipy_content } | tojson -}}
-{% endif %}
-<|eot_id|>
-{% elif has_tool_calls -%}
-    {%- if message.tool_calls|length != 1 -%}
-      {{- raise_exception("This template expects exactly one tool call per assistant turn.") -}}
-    {%- endif -%}
-    {%- set tool_call = message.tool_calls[0].function -%}
-<|start_header_id|>assistant<|end_header_id|>
-{% generation %}
-{{- '{\"name\": \"' + tool_call.name + '\", \"arguments\": ' -}}
-{{- tool_call.arguments | tojson -}}
-{{- \"}\" -}}<|eot_id|>
-{% endgeneration %}
-  {%- endif -%}
-{%- endfor -%}
-{%- if add_generation_prompt -%}
-<|start_header_id|>assistant<|end_header_id|>
-{% endif -%}
-""".strip()
-
-"""
-The chat template for the Marin tokenizer.
-
-This template is used to generate the chat template for the Marin tokenizer.
-It is a modified version of the Olmo 2 template.
-
-The modifications are:
-- Use the Llama 3 special tokens rather than Olmo (which doesn't use special tokens but rather just literally <|, etc.)
-- Add the {% generation -%} tag stuff that makes the assistant_mask in Levanter work.
-
-See [Levanter's documentation on Chat Templates](https://levanter.readthedocs.io/en/latest/reference/Data-Formats/#chat-format)
-for more information on how this works.
 """
 
 MARIN_CUSTOM_SPECIAL_TOKENS = {

--- a/lib/levanter/src/levanter/data/text/trace_chat.py
+++ b/lib/levanter/src/levanter/data/text/trace_chat.py
@@ -115,43 +115,21 @@ def _message_without_tool_calls(message: Mapping[str, Any], content: str) -> dic
     return chunk
 
 
-def _split_text_tool_call_message(message: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _structured_text_tool_call_message(message: Mapping[str, Any]) -> dict[str, Any]:
     content = message.get("content")
     if message.get("role") != "assistant" or not isinstance(content, str) or message.get("tool_calls"):
-        return [dict(message)]
+        return dict(message)
 
     matches = list(_TEXT_TOOL_CALL_PATTERN.finditer(content))
     if not matches:
-        return [dict(message)]
+        return dict(message)
 
-    split_messages: list[dict[str, Any]] = []
-    cursor = 0
-    parsed_any = False
-    for match in matches:
-        prefix = content[cursor : match.start()]
-        if prefix.strip():
-            split_messages.append(_message_without_tool_calls(message, prefix))
-
-        tool_call = _parsed_text_tool_call(match.group(1))
-        # Prefix/suffix text stays in adjacent assistant messages; this chunk represents only the structured call.
-        split_messages.append({"role": "assistant", "content": "", "tool_calls": [tool_call]})
-        parsed_any = True
-        cursor = match.end()
-
-    suffix = content[cursor:]
-    if suffix.strip():
-        split_messages.append(_message_without_tool_calls(message, suffix))
-
-    if not parsed_any:
-        return [dict(message)]
-    return split_messages
-
-
-def _split_text_tool_call_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    split_messages: list[dict[str, Any]] = []
-    for message in messages:
-        split_messages.extend(_split_text_tool_call_message(message))
-    return split_messages
+    # Keep the source turn intact: splitting prose and parallel calls into
+    # separate messages inserts end-of-turn tokens before the tool handoff.
+    normalized = dict(message)
+    normalized["content"] = _TEXT_TOOL_CALL_PATTERN.sub("", content)
+    normalized["tool_calls"] = [_parsed_text_tool_call(match.group(1)) for match in matches]
+    return normalized
 
 
 def _find_subsequence(haystack: Sequence[int], needle: Sequence[int]) -> int | None:
@@ -411,7 +389,7 @@ class TraceChatProcessor(BatchProcessor[dict, dict]):
         example_messages = example[self.messages_field]
         normalized_messages = [_normalize_chat_message(message) for message in example_messages]
         if self.parse_text_tool_calls:
-            normalized_messages = _split_text_tool_call_messages(normalized_messages)
+            normalized_messages = [_structured_text_tool_call_message(message) for message in normalized_messages]
 
         if self.system_prompt_field is not None and self.system_prompt_field in example:
             system_content = example[self.system_prompt_field]
@@ -628,6 +606,7 @@ class TraceChatProcessor(BatchProcessor[dict, dict]):
             "include_role_tags": self.include_role_tags,
             "include_final_assistant_tag": self.include_final_assistant_tag,
             "parse_text_tool_calls": self.parse_text_tool_calls,
+            "text_tool_call_format_version": 2,
             "label_spec": {
                 "id_to_name": {str(label_id): name for label_id, name in self.label_spec.id_to_name.items()},
                 "aggregates": {name: list(label_ids) for name, label_ids in self.label_spec.aggregates.items()},

--- a/lib/levanter/tests/test_text_chat.py
+++ b/lib/levanter/tests/test_text_chat.py
@@ -551,7 +551,7 @@ def test_trace_chat_processor_labels_multi_tool_and_interleaved_user_turns(token
     assert "The issue is in the eval callback test." in final_text
 
 
-def test_trace_chat_processor_splits_text_tool_calls(tokenizer: MarinTokenizer):
+def test_trace_chat_processor_labels_text_tool_calls(tokenizer: MarinTokenizer):
     processor = TraceChatProcessor(
         tokenizer,
         chat_template=MULTI_TOOL_TEMPLATE,

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -10,7 +10,6 @@ from itertools import groupby
 
 import pyarrow as pa
 from fray.types import ResourceConfig
-from jinja2 import Environment, StrictUndefined
 from openai_harmony import Message, Role
 from rigging.filesystem.storage_path import prefix_join
 from zephyr.context import ZephyrContext
@@ -45,23 +44,6 @@ For each function call, pass a json object with function name and arguments with
 </tool_call>
 
 """
-
-
-# Python prepares message bodies; Jinja owns only the conversation frame.
-_CHAT_TEMPLATE = Environment(undefined=StrictUndefined, autoescape=False).from_string(
-    """{{ bos_token }}
-{%- if system is not none -%}
-<|start_header_id|>system<|end_header_id|>{{ system }}<|eot_id|>
-{%- endif -%}
-{%- for turn in turns -%}
-<|start_header_id|>{{ turn.role.value }}<|end_header_id|>
-{{ turn.content }}<|eot_id|>{{ turn.separator }}
-{%- endfor -%}
-{%- if add_generation_prompt -%}
-<|start_header_id|>assistant<|end_header_id|>{{ "\\n" }}
-{%- endif -%}
-"""
-)
 
 
 @dataclass(frozen=True)
@@ -140,12 +122,13 @@ def render_marin_chat(
         auxiliary.append(custom_instructions.strip())
     if tools:
         auxiliary.append(_TOOL_INSTRUCTIONS + "".join(str(tool) for tool in tools) + _TOOL_CALL_INSTRUCTIONS)
-    return _CHAT_TEMPLATE.render(
-        bos_token=bos_token,
-        system="".join(auxiliary) if auxiliary else None,
-        turns=_chat_turns(messages),
-        add_generation_prompt=add_generation_prompt,
+    system = f"<|start_header_id|>system<|end_header_id|>{''.join(auxiliary)}<|eot_id|>" if auxiliary else ""
+    conversation = "".join(
+        f"<|start_header_id|>{turn.role.value}<|end_header_id|>\n{turn.content}<|eot_id|>{turn.separator}"
+        for turn in _chat_turns(messages)
     )
+    prefix = "<|start_header_id|>assistant<|end_header_id|>\n" if add_generation_prompt else ""
+    return bos_token + system + conversation + prefix
 
 
 def render_chat_record(record: dict) -> dict:

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -1,0 +1,186 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render normalized Harmony conversations for the Marin tokenizer."""
+
+import json
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from itertools import groupby
+
+import pyarrow as pa
+from fray.types import ResourceConfig
+from jinja2 import Environment, StrictUndefined
+from openai_harmony import Message, Role
+from rigging.filesystem.storage_path import prefix_join
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.readers import load_parquet
+
+from marin.datakit.chat_normalize import ChatChannel, message_text
+from marin.datakit.normalize import DEFAULT_MAX_WORKERS
+from marin.execution.step_spec import StepSpec
+
+CHAT_RENDER_VERSION = "marin-v1"
+MARIN_BOS_TOKEN = "<|begin_of_text|>"
+START_THINK = "<|start_think|>"
+END_THINK = "<|end_think|>"
+RENDERED_CHAT_SCHEMA = pa.schema(
+    [pa.field("id", pa.string(), nullable=False), pa.field("text", pa.string(), nullable=False)]
+)
+
+_TOOL_INSTRUCTIONS = """
+### Tools
+
+You may call one or more functions to assist with the user query.
+You are provided with function signatures within <tools> </tools> tags:
+
+<tools>
+"""
+_TOOL_CALL_INSTRUCTIONS = """</tools>
+
+For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call>
+
+"""
+
+
+# Python prepares message bodies; Jinja owns only the conversation frame.
+_CHAT_TEMPLATE = Environment(undefined=StrictUndefined, autoescape=False).from_string(
+    """{{ bos_token }}
+{%- if system is not none -%}
+<|start_header_id|>system<|end_header_id|>{{ system }}<|eot_id|>
+{%- endif -%}
+{%- for turn in turns -%}
+<|start_header_id|>{{ turn.role.value }}<|end_header_id|>
+{{ turn.content }}<|eot_id|>{{ turn.separator }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+<|start_header_id|>assistant<|end_header_id|>{{ "\\n" }}
+{%- endif -%}
+"""
+)
+
+
+@dataclass(frozen=True)
+class _Turn:
+    role: Role
+    content: str
+    separator: str
+
+
+def _assistant_content(message: Message) -> str:
+    text = message_text(message)
+    match message.channel:
+        case ChatChannel.ANALYSIS:
+            return START_THINK + text + END_THINK
+        case ChatChannel.COMMENTARY | ChatChannel.FINAL:
+            return text
+        case _:
+            raise ValueError(f"Unsupported assistant channel: {message.channel!r}")
+
+
+def _message_turn(message: Message) -> _Turn:
+    text = message_text(message)
+    match message.author.role:
+        case Role.SYSTEM | Role.DEVELOPER | Role.USER:
+            return _Turn(message.author.role, text.strip(), "\n")
+        case Role.ASSISTANT:
+            recipient = message.recipient
+            if message.channel != ChatChannel.COMMENTARY or recipient is None or not recipient.startswith("functions."):
+                raise ValueError("Tool calls require commentary addressed to functions.<name>")
+            arguments = json.loads(text)
+            if not isinstance(arguments, dict):
+                raise ValueError("Tool-call arguments must be a JSON object")
+            name = recipient.removeprefix("functions.")
+            body = '{"name": "' + name + '", "arguments": ' + json.dumps(arguments, ensure_ascii=False) + "}"
+            return _Turn(Role.ASSISTANT, body, "\n")
+        case Role.TOOL:
+            name = message.author.name
+            if name is None or not name.startswith("functions."):
+                raise ValueError("Tool observations require a functions.<name> author")
+            name = name.removeprefix("functions.")
+            return _Turn(Role.TOOL, f'<tool_response name="{name}">{text}</tool_response>', "\n")
+
+
+def _chat_turns(messages: Sequence[Message]) -> Iterator[_Turn]:
+    # Analysis and final are separate Harmony messages but one Marin assistant
+    # turn. Tool calls retain their own turn, as required by the inference template.
+    for assistant_text, group in groupby(
+        messages, key=lambda message: message.author.role == Role.ASSISTANT and message.recipient is None
+    ):
+        if assistant_text:
+            content = "".join(_assistant_content(message) for message in group).strip()
+            yield _Turn(Role.ASSISTANT, content, "")
+        else:
+            yield from (_message_turn(message) for message in group)
+
+
+def render_marin_chat(
+    messages: Sequence[Message],
+    *,
+    bos_token: str = MARIN_BOS_TOKEN,
+    tools: Sequence[dict] = (),
+    enable_thinking: bool | None = None,
+    custom_instructions: str = "",
+    add_generation_prompt: bool = False,
+) -> str:
+    """Render Harmony as Marin chat text, retaining reasoning from every turn.
+
+    Uses the existing Marin inference template's headers, whitespace, JSON and
+    tool syntax. Tool call IDs are absent from normalized Harmony; ordered calls
+    and named observations supply their association.
+    """
+    auxiliary: list[str] = []
+    if enable_thinking is not None:
+        auxiliary.append("Reasoning: /think" if enable_thinking else "Reasoning: /nothink")
+    if custom_instructions:
+        auxiliary.append(custom_instructions.strip())
+    if tools:
+        auxiliary.append(_TOOL_INSTRUCTIONS + "".join(str(tool) for tool in tools) + _TOOL_CALL_INSTRUCTIONS)
+    return _CHAT_TEMPLATE.render(
+        bos_token=bos_token,
+        system="".join(auxiliary) if auxiliary else None,
+        turns=_chat_turns(messages),
+        add_generation_prompt=add_generation_prompt,
+    )
+
+
+def render_chat_record(record: dict) -> dict:
+    """Project a normalized chat row into the standard normalizer's id/text input."""
+    messages = [Message.from_dict(message) for message in record["messages"]]
+    kwargs = json.loads(record["chat_template_kwargs"]) if record.get("chat_template_kwargs") else {}
+    return {"id": record["id"], "text": render_marin_chat(messages, **kwargs)}
+
+
+def render_chat_to_parquet(
+    *,
+    input_path: str,
+    output_path: str,
+    worker_resources: ResourceConfig | None = None,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+) -> None:
+    """Write id/text Parquet from a directory of normalized Harmony chat shards."""
+    pipeline = (
+        Dataset.from_files(prefix_join(input_path, "*.parquet"))
+        .flat_map(load_parquet)
+        .map(render_chat_record)
+        .write_parquet(prefix_join(output_path, "part-{shard:05d}-of-{total:05d}.parquet"), schema=RENDERED_CHAT_SCHEMA)
+    )
+    ZephyrContext(
+        name="render-chat", resources=worker_resources or ResourceConfig(cpu=2, ram="4g"), max_workers=max_workers
+    ).execute(pipeline)
+
+
+def render_chat_step(*, name: str, chat: StepSpec) -> StepSpec:
+    """Create an id/text rendering step from a chat normalization step."""
+    return StepSpec(
+        name=name,
+        fn=lambda output_path: render_chat_to_parquet(
+            input_path=prefix_join(chat.output_path, "outputs/main"), output_path=output_path
+        ),
+        deps=[chat],
+        hash_attrs={"version": CHAT_RENDER_VERSION},
+    )

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -21,7 +21,7 @@ from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from marin.datakit.normalize import DEFAULT_MAX_WORKERS
 from marin.execution.step_spec import StepSpec
 
-CHAT_RENDER_VERSION = "marin-v2"
+CHAT_RENDER_VERSION = "marin-v3"
 MARIN_BOS_TOKEN = "<|begin_of_text|>"
 START_THINK = "<|start_think|>"
 END_THINK = "<|end_think|>"
@@ -113,7 +113,7 @@ def render_chat_record(record: dict) -> dict:
     """Project a normalized chat row into the standard normalizer's id/text input."""
     messages = [Message.from_dict(message) for message in record["messages"]]
     kwargs = json.loads(record["chat_template_kwargs"]) if record.get("chat_template_kwargs") else {}
-    return {"id": record["id"], "text": render_marin_chat(messages, **kwargs)}
+    return {"id": record["id"], "text": render_marin_chat(messages, bos_token="", **kwargs)}
 
 
 def render_chat_to_parquet(

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from itertools import groupby
+from textwrap import dedent
 
 import pyarrow as pa
 from fray.types import ResourceConfig
@@ -31,21 +32,23 @@ RENDERED_CHAT_SCHEMA = pa.schema(
 
 def _tool_instructions(tools: Sequence[dict]) -> str:
     definitions = "".join(str(tool) for tool in tools)
-    return f"""
-### Tools
+    return dedent(
+        f"""
+        ### Tools
 
-You may call one or more functions to assist with the user query.
-You are provided with function signatures within <tools> </tools> tags:
+        You may call one or more functions to assist with the user query.
+        You are provided with function signatures within <tools> </tools> tags:
 
-<tools>
-{definitions}</tools>
+        <tools>
+        {definitions}</tools>
 
-For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
-<tool_call>
-{{"name": <function-name>, "arguments": <args-json-object>}}
-</tool_call>
+        For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
+        <tool_call>
+        {{"name": <function-name>, "arguments": <args-json-object>}}
+        </tool_call>
 
-"""
+        """
+    )
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -28,19 +28,21 @@ RENDERED_CHAT_SCHEMA = pa.schema(
     [pa.field("id", pa.string(), nullable=False), pa.field("text", pa.string(), nullable=False)]
 )
 
-_TOOL_INSTRUCTIONS = """
+
+def _tool_instructions(tools: Sequence[dict]) -> str:
+    definitions = "".join(str(tool) for tool in tools)
+    return f"""
 ### Tools
 
 You may call one or more functions to assist with the user query.
 You are provided with function signatures within <tools> </tools> tags:
 
 <tools>
-"""
-_TOOL_CALL_INSTRUCTIONS = """</tools>
+{definitions}</tools>
 
 For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
 <tool_call>
-{"name": <function-name>, "arguments": <args-json-object>}
+{{"name": <function-name>, "arguments": <args-json-object>}}
 </tool_call>
 
 """
@@ -57,7 +59,7 @@ def _assistant_content(message: Message) -> str:
     text = message_text(message)
     match message.channel:
         case ChatChannel.ANALYSIS:
-            return START_THINK + text + END_THINK
+            return f"{START_THINK}{text}{END_THINK}"
         case ChatChannel.COMMENTARY | ChatChannel.FINAL:
             return text
         case _:
@@ -77,7 +79,7 @@ def _message_turn(message: Message) -> _Turn:
             if not isinstance(arguments, dict):
                 raise ValueError("Tool-call arguments must be a JSON object")
             name = recipient.removeprefix("functions.")
-            body = '{"name": "' + name + '", "arguments": ' + json.dumps(arguments, ensure_ascii=False) + "}"
+            body = json.dumps({"name": name, "arguments": arguments}, ensure_ascii=False)
             return _Turn(Role.ASSISTANT, body, "\n")
         case Role.TOOL:
             name = message.author.name
@@ -121,14 +123,14 @@ def render_marin_chat(
     if custom_instructions:
         auxiliary.append(custom_instructions.strip())
     if tools:
-        auxiliary.append(_TOOL_INSTRUCTIONS + "".join(str(tool) for tool in tools) + _TOOL_CALL_INSTRUCTIONS)
+        auxiliary.append(_tool_instructions(tools))
     system = f"<|start_header_id|>system<|end_header_id|>{''.join(auxiliary)}<|eot_id|>" if auxiliary else ""
     conversation = "".join(
         f"<|start_header_id|>{turn.role.value}<|end_header_id|>\n{turn.content}<|eot_id|>{turn.separator}"
         for turn in _chat_turns(messages)
     )
     prefix = "<|start_header_id|>assistant<|end_header_id|>\n" if add_generation_prompt else ""
-    return bos_token + system + conversation + prefix
+    return f"{bos_token}{system}{conversation}{prefix}"
 
 
 def render_chat_record(record: dict) -> dict:

--- a/lib/marin/src/marin/datakit/chat_render.py
+++ b/lib/marin/src/marin/datakit/chat_render.py
@@ -5,57 +5,29 @@
 
 import json
 from collections.abc import Iterator, Sequence
-from dataclasses import dataclass
 from itertools import groupby
-from textwrap import dedent
 
 import pyarrow as pa
 from fray.types import ResourceConfig
 from openai_harmony import Message, Role
 from rigging.filesystem.storage_path import prefix_join
+from transformers.utils.chat_template_utils import render_jinja_template
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.readers import load_parquet
 
 from marin.datakit.chat_normalize import ChatChannel, message_text
+from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from marin.datakit.normalize import DEFAULT_MAX_WORKERS
 from marin.execution.step_spec import StepSpec
 
-CHAT_RENDER_VERSION = "marin-v1"
+CHAT_RENDER_VERSION = "marin-v2"
 MARIN_BOS_TOKEN = "<|begin_of_text|>"
 START_THINK = "<|start_think|>"
 END_THINK = "<|end_think|>"
 RENDERED_CHAT_SCHEMA = pa.schema(
     [pa.field("id", pa.string(), nullable=False), pa.field("text", pa.string(), nullable=False)]
 )
-
-
-def _tool_instructions(tools: Sequence[dict]) -> str:
-    definitions = "".join(str(tool) for tool in tools)
-    return dedent(
-        f"""
-        ### Tools
-
-        You may call one or more functions to assist with the user query.
-        You are provided with function signatures within <tools> </tools> tags:
-
-        <tools>
-        {definitions}</tools>
-
-        For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
-        <tool_call>
-        {{"name": <function-name>, "arguments": <args-json-object>}}
-        </tool_call>
-
-        """
-    )
-
-
-@dataclass(frozen=True)
-class _Turn:
-    role: Role
-    content: str
-    separator: str
 
 
 def _assistant_content(message: Message) -> str:
@@ -69,11 +41,11 @@ def _assistant_content(message: Message) -> str:
             raise ValueError(f"Unsupported assistant channel: {message.channel!r}")
 
 
-def _message_turn(message: Message) -> _Turn:
+def _inference_message(message: Message) -> dict:
     text = message_text(message)
     match message.author.role:
         case Role.SYSTEM | Role.DEVELOPER | Role.USER:
-            return _Turn(message.author.role, text.strip(), "\n")
+            return {"role": message.author.role.value, "content": text}
         case Role.ASSISTANT:
             recipient = message.recipient
             if message.channel != ChatChannel.COMMENTARY or recipient is None or not recipient.startswith("functions."):
@@ -82,27 +54,29 @@ def _message_turn(message: Message) -> _Turn:
             if not isinstance(arguments, dict):
                 raise ValueError("Tool-call arguments must be a JSON object")
             name = recipient.removeprefix("functions.")
-            body = json.dumps({"name": name, "arguments": arguments}, ensure_ascii=False)
-            return _Turn(Role.ASSISTANT, body, "\n")
+            return {
+                "role": "assistant",
+                "tool_calls": [{"type": "function", "function": {"name": name, "arguments": arguments}}],
+            }
         case Role.TOOL:
             name = message.author.name
             if name is None or not name.startswith("functions."):
                 raise ValueError("Tool observations require a functions.<name> author")
             name = name.removeprefix("functions.")
-            return _Turn(Role.TOOL, f'<tool_response name="{name}">{text}</tool_response>', "\n")
+            return {"role": "tool", "name": name, "content": text}
 
 
-def _chat_turns(messages: Sequence[Message]) -> Iterator[_Turn]:
-    # Analysis and final are separate Harmony messages but one Marin assistant
-    # turn. Tool calls retain their own turn, as required by the inference template.
-    for assistant_text, group in groupby(
-        messages, key=lambda message: message.author.role == Role.ASSISTANT and message.recipient is None
-    ):
-        if assistant_text:
-            content = "".join(_assistant_content(message) for message in group).strip()
-            yield _Turn(Role.ASSISTANT, content, "")
+def _inference_messages(messages: Sequence[Message]) -> Iterator[dict]:
+    # A tool handoff ends an assistant turn. Analysis, commentary, and parallel
+    # calls before that handoff must share one end-of-turn token.
+    for role, group in groupby(messages, key=lambda message: message.author.role):
+        if role == Role.ASSISTANT:
+            turn = list(group)
+            content = "".join(_assistant_content(message) for message in turn if message.recipient is None)
+            calls = [_inference_message(message)["tool_calls"][0] for message in turn if message.recipient is not None]
+            yield {"role": "assistant", "content": content, "tool_calls": calls}
         else:
-            yield from (_message_turn(message) for message in group)
+            yield from (_inference_message(message) for message in group)
 
 
 def render_marin_chat(
@@ -120,20 +94,19 @@ def render_marin_chat(
     tool syntax. Tool call IDs are absent from normalized Harmony; ordered calls
     and named observations supply their association.
     """
-    auxiliary: list[str] = []
-    if enable_thinking is not None:
-        auxiliary.append("Reasoning: /think" if enable_thinking else "Reasoning: /nothink")
-    if custom_instructions:
-        auxiliary.append(custom_instructions.strip())
-    if tools:
-        auxiliary.append(_tool_instructions(tools))
-    system = f"<|start_header_id|>system<|end_header_id|>{''.join(auxiliary)}<|eot_id|>" if auxiliary else ""
-    conversation = "".join(
-        f"<|start_header_id|>{turn.role.value}<|end_header_id|>\n{turn.content}<|eot_id|>{turn.separator}"
-        for turn in _chat_turns(messages)
+    # Omit absent options: the inference template distinguishes an undefined
+    # reasoning mode from an explicitly supplied value.
+    kwargs = {"enable_thinking": enable_thinking} if enable_thinking is not None else {}
+    rendered, _ = render_jinja_template(
+        conversations=[list(_inference_messages(messages))],
+        chat_template=MARIN_CHAT_TEMPLATE,
+        bos_token=bos_token,
+        tools=list(tools),
+        custom_instructions=custom_instructions,
+        add_generation_prompt=add_generation_prompt,
+        **kwargs,
     )
-    prefix = "<|start_header_id|>assistant<|end_header_id|>\n" if add_generation_prompt else ""
-    return f"{bos_token}{system}{conversation}{prefix}"
+    return rendered[0]
 
 
 def render_chat_record(record: dict) -> dict:
@@ -170,5 +143,5 @@ def render_chat_step(*, name: str, chat: StepSpec) -> StepSpec:
             input_path=prefix_join(chat.output_path, "outputs/main"), output_path=output_path
         ),
         deps=[chat],
-        hash_attrs={"version": CHAT_RENDER_VERSION},
+        hash_attrs={"version": CHAT_RENDER_VERSION, "chat_template": MARIN_CHAT_TEMPLATE},
     )

--- a/lib/marin/src/marin/datakit/chat_template.py
+++ b/lib/marin/src/marin/datakit/chat_template.py
@@ -71,12 +71,12 @@ You can use the following tools in your python code like regular functions:
 {%- endif -%}
 {%- macro text(content) -%}
   {%- if content is string -%}
-    {{- content | trim -}}
+    {{- content -}}
   {%- elif content is mapping -%}
-    {{- content.get('text', '') | trim -}}
+    {{- content.get('text', '') -}}
   {%- elif content is iterable -%}
     {%- for chunk in content if chunk.get('type') == 'text' -%}
-      {{- chunk.text | trim -}}
+      {{- chunk.text -}}
     {%- endfor -%}
   {%- endif -%}
 {%- endmacro -%}
@@ -97,13 +97,18 @@ You can use the following tools in your python code like regular functions:
 {%- endmacro -%}
 
 {%- for message in messages -%}
+  {%- set content = message.get('content') -%}
+  {%- set text_content = content is string
+      or (content is mapping and content.get('text') is string)
+      or (content is sequence and content is not string and content is not mapping
+          and content | selectattr('type', 'equalto', 'text') | list | length == content | length) -%}
   {{- '<|start_header_id|>' ~ message.role ~ '<|end_header_id|>\n' -}}
   {%- if message.role == 'assistant' -%}
     {% generation %}
     {%- if message.get('reasoning_content') -%}
       {{- '<|start_think|>' ~ message.reasoning_content ~ '<|end_think|>' -}}
     {%- endif -%}
-    {{- text(message.get('content')) -}}
+    {{- text(content) | trim -}}
     {{- tool_calls(message.get('tool_calls') or []) -}}
     {{- '<|eot_id|>' -}}
     {% endgeneration %}
@@ -112,21 +117,13 @@ You can use the following tools in your python code like regular functions:
     {%- set name = message.get('name') or tool_names.by_id.get(message.get('tool_call_id')) -%}
     {%- if name -%}{{- ' name="' ~ name ~ '"' -}}{%- endif -%}
     {{- '>' -}}
-    {%- set content = message.get('content') -%}
-    {{- content if content is string else content | tojson if content is not none else '' -}}
+    {{- text(content) if text_content else content | tojson if content is not none else '' -}}
     {{- '</tool_response><|eot_id|>\n' -}}
   {%- elif message.role == 'ipython' -%}
-    {%- set content = message.get('content') -%}
-    {%- if content is iterable and content is not string and content is not mapping -%}
-      {%- for chunk in content if chunk.get('type') == 'text' -%}
-        {{- {"output": chunk.text} | tojson -}}
-      {%- endfor -%}
-    {%- else -%}
-      {{- {"output": content} | tojson -}}
-    {%- endif -%}
+    {{- {"output": text(content) if text_content else content} | tojson -}}
     {{- '<|eot_id|>\n' -}}
   {%- else -%}
-    {{- text(message.get('content')) ~ '<|eot_id|>\n' -}}
+    {{- (text(content) | trim) ~ '<|eot_id|>\n' -}}
   {%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}

--- a/lib/marin/src/marin/datakit/chat_template.py
+++ b/lib/marin/src/marin/datakit/chat_template.py
@@ -1,0 +1,135 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# ruff: noqa: E501 -- Inference prompt text preserves its original line breaks.
+
+"""Shared Marin chat template for tokenizer export and Datakit rendering.
+
+The template must remain self-contained so Hugging Face and vLLM can load it
+from tokenizer artifacts without importing Marin. Generation blocks identify
+assistant output without changing the rendered text.
+"""
+
+MARIN_CHAT_TEMPLATE = """
+{{ bos_token }}
+{%- if enable_thinking is defined -%}
+  {%- if enable_thinking is sameas true -%}
+    {%- set _reasoning_mode = "/think" -%}
+  {%- elif enable_thinking is sameas false -%}
+    {%- set _reasoning_mode = "/nothink" -%}
+  {%- else -%}
+    {%- set _reasoning_mode = enable_thinking -%}
+  {%- endif -%}
+{%- else -%}
+  {%- set _reasoning_mode = none -%}
+{%- endif -%}
+{%- set _custom_instructions = custom_instructions | default(None, true) -%}
+{%- set _xml_tools_list = xml_tools | default([], true) -%}
+{%- if tools is defined and tools -%}
+  {%- set _xml_tools_list = tools -%}
+{%- endif -%}
+{%- set _python_tools = python_tools | default([], true) -%}
+{%- set _has_aux_header = (_reasoning_mode is not none) or _custom_instructions or (_xml_tools_list) or (_python_tools) -%}
+{%- if _has_aux_header -%}
+<|start_header_id|>system<|end_header_id|>
+{%- if _reasoning_mode is not none -%}
+Reasoning: {{ _reasoning_mode }}
+{%- endif %}
+{%- if _custom_instructions %}
+{{ _custom_instructions | trim }}
+{%- endif %}
+{% if _xml_tools_list or _python_tools %}
+{{ "\n### Tools\n" }}
+You may call one or more functions to assist with the user query.
+{% if _xml_tools_list %}
+You are provided with function signatures within <tools> </tools> tags:
+
+<tools>
+{% for tool in _xml_tools_list %}
+{{ tool if tool is string else tool | tojson }}{{ "\n" }}
+{% endfor %}
+</tools>
+
+For each function call, pass a json object with function name and arguments within <tool_call> </tool_call> tags:
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call>
+
+{% endif %}
+{% if _python_tools %}
+When you send a message containing Python code between <|python_tag|> and <|eom_id|> tags, it will be executed in a stateful Jupyter notebook environment, and you will then be given the output.
+
+You can use the following tools in your python code like regular functions:
+<tools>
+{% for tool in _python_tools %}
+{{ tool if tool is string else tool | tojson }}{{ "\n" }}
+{% endfor %}
+</tools>
+{% endif %}
+{% endif %}
+<|eot_id|>
+{%- endif -%}
+{%- macro text(content) -%}
+  {%- if content is string -%}
+    {{- content | trim -}}
+  {%- elif content is mapping -%}
+    {{- content.get('text', '') | trim -}}
+  {%- elif content is iterable -%}
+    {%- for chunk in content if chunk.get('type') == 'text' -%}
+      {{- chunk.text | trim -}}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- set tool_names = namespace(by_id={}) -%}
+{%- macro tool_calls(calls) -%}
+  {%- for call in calls -%}
+    {%- set function = call.function -%}
+    {%- if call.get('id') -%}
+      {%- set tool_names.by_id = dict(tool_names.by_id, **{call.id: function.name}) -%}
+    {%- endif -%}
+    {{- '<tool_call>\n{"name": ' -}}
+    {{- function.name | tojson -}}
+    {{- ', "arguments": ' -}}
+    {{- function.arguments if function.arguments is string else function.arguments | tojson -}}
+    {{- '}\n</tool_call>' -}}
+  {%- endfor -%}
+{%- endmacro -%}
+
+{%- for message in messages -%}
+  {{- '<|start_header_id|>' ~ message.role ~ '<|end_header_id|>\n' -}}
+  {%- if message.role == 'assistant' -%}
+    {% generation %}
+    {%- if message.get('reasoning_content') -%}
+      {{- '<|start_think|>' ~ message.reasoning_content ~ '<|end_think|>' -}}
+    {%- endif -%}
+    {{- text(message.get('content')) -}}
+    {{- tool_calls(message.get('tool_calls') or []) -}}
+    {{- '<|eot_id|>' -}}
+    {% endgeneration %}
+  {%- elif message.role == 'tool' -%}
+    {{- '<tool_response' -}}
+    {%- set name = message.get('name') or tool_names.by_id.get(message.get('tool_call_id')) -%}
+    {%- if name -%}{{- ' name="' ~ name ~ '"' -}}{%- endif -%}
+    {{- '>' -}}
+    {%- set content = message.get('content') -%}
+    {{- content if content is string else content | tojson if content is not none else '' -}}
+    {{- '</tool_response><|eot_id|>\n' -}}
+  {%- elif message.role == 'ipython' -%}
+    {%- set content = message.get('content') -%}
+    {%- if content is iterable and content is not string and content is not mapping -%}
+      {%- for chunk in content if chunk.get('type') == 'text' -%}
+        {{- {"output": chunk.text} | tojson -}}
+      {%- endfor -%}
+    {%- else -%}
+      {{- {"output": content} | tojson -}}
+    {%- endif -%}
+    {{- '<|eot_id|>\n' -}}
+  {%- else -%}
+    {{- text(message.get('content')) ~ '<|eot_id|>\n' -}}
+  {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {{- '<|start_header_id|>assistant<|end_header_id|>\n' -}}
+{%- endif -%}
+""".strip()

--- a/lib/marin/src/marin/datakit/sft_sources.py
+++ b/lib/marin/src/marin/datakit/sft_sources.py
@@ -5,8 +5,9 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cache
+from functools import cache, cached_property
 
+from marin.datakit.chat_render import render_chat_step
 from marin.datakit.download.agenttrove import agenttrove_chat_normalize_steps
 from marin.datakit.download.coderforge import coderforge_chat_normalize_steps
 from marin.datakit.download.davinci_dev import davinci_dev_env_native_chat_normalize_steps
@@ -23,21 +24,34 @@ from marin.datakit.download.superior_reasoning import superior_reasoning_chat_no
 from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_chat_normalize_steps
 from marin.datakit.download.swe_zero_12m import swe_zero_12m_chat_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_chat_normalize_steps
+from marin.datakit.normalize import normalize_step
 from marin.datakit.sources import all_sources
 from marin.execution.step_spec import StepSpec
 
 
 @dataclass(frozen=True)
 class DatakitChatSource:
-    """A source whose normalized artifact contains structured Harmony messages."""
+    """An SFT source with structured chat and normalized rendered-text artifacts."""
 
     name: str
-    normalize_steps: tuple[StepSpec, ...]
+    chat_steps: tuple[StepSpec, ...]
     rough_token_count_b: float
 
     @property
+    def chat_normalized(self) -> StepSpec:
+        return self.chat_steps[-1]
+
+    @cached_property
+    def rendered(self) -> StepSpec:
+        return render_chat_step(name=f"rendered/sft/{self.name}", chat=self.chat_normalized)
+
+    @cached_property
     def normalized(self) -> StepSpec:
-        return self.normalize_steps[-1]
+        return normalize_step(name=f"normalized/sft/{self.name}", download=self.rendered)
+
+    @property
+    def normalize_steps(self) -> tuple[StepSpec, ...]:
+        return (*self.chat_steps, self.rendered, self.normalized)
 
 
 _EXCLUDED_CHAT_SOURCES = frozenset(
@@ -53,7 +67,7 @@ _ChatSourceRow = tuple[str, Callable[[], tuple[StepSpec, ...]]]
 
 @cache
 def all_sft_sources() -> dict[str, DatakitChatSource]:
-    """Return sources whose canonical artifact contains Harmony messages."""
+    """Return SFT sources with Harmony-to-text normalization pipelines."""
     penfever_steps = cache(penfever_rollouts_chat_normalize_steps)
     nemotron_steps = cache(nemotron_sft_chat_normalize_steps)
     rows: list[_ChatSourceRow] = [
@@ -90,7 +104,7 @@ def all_sft_sources() -> dict[str, DatakitChatSource]:
     return {
         name: DatakitChatSource(
             name=name,
-            normalize_steps=factory(),
+            chat_steps=factory(),
             rough_token_count_b=token_counts[name],
         )
         for name, factory in rows

--- a/tests/datakit/test_chat_render.py
+++ b/tests/datakit/test_chat_render.py
@@ -8,11 +8,14 @@ import pyarrow.parquet as pq
 from fray.current_client import set_current_client
 from fray.local_backend import LocalClient
 from marin.datakit.chat_normalize import CHAT_SCHEMA
-from marin.datakit.chat_render import render_chat_to_parquet
+from marin.datakit.normalize import generate_id
+from marin.datakit.sft_sources import DatakitChatSource
+from marin.execution.step_spec import StepSpec
 from openai_harmony import Message, Role
 
 
-def test_rendered_parquet_preserves_ids_and_duplicates(tmp_path):
+def test_sft_source_renders_then_normalizes_and_deduplicates(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path / "artifacts"))
     messages = [
         Message.from_role_and_content(Role.USER, "What is 2 + 2?"),
         Message.from_role_and_content(Role.ASSISTANT, "Add two and two.").with_channel("analysis"),
@@ -26,15 +29,21 @@ def test_rendered_parquet_preserves_ids_and_duplicates(tmp_path):
         }
         for source_id in ["first-source-id", "second-source-id"]
     ]
-    input_path = tmp_path / "input"
-    input_path.mkdir()
+    input_path = tmp_path / "chat" / "outputs" / "main"
+    input_path.mkdir(parents=True)
     pq.write_table(pa.Table.from_pylist(records, schema=CHAT_SCHEMA), input_path / "part-00000.parquet")
-    output_path = tmp_path / "rendered"
+    source = DatakitChatSource(
+        name="fixture",
+        chat_steps=(StepSpec(name="fixture-chat", override_output_path=str(tmp_path / "chat")),),
+        rough_token_count_b=0,
+    )
 
     with set_current_client(LocalClient()):
-        render_chat_to_parquet(input_path=str(input_path), output_path=str(output_path), max_workers=1)
+        for step in source.normalize_steps[1:]:
+            assert step.fn is not None
+            step.fn(step.output_path)
 
-    table = pq.read_table(output_path)
+    table = pq.read_table(source.rendered.output_path)
     assert table.column_names == ["id", "text"]
     expected_text = (
         "<|begin_of_text|><|start_header_id|>system<|end_header_id|>Reasoning: /think<|eot_id|>"
@@ -46,3 +55,14 @@ def test_rendered_parquet_preserves_ids_and_duplicates(tmp_path):
         {"id": "first-source-id", "text": expected_text},
         {"id": "second-source-id", "text": expected_text},
     ]
+
+    normalized = pq.read_table(f"{source.normalized.output_path}/outputs/main").to_pylist()
+    duplicates = pq.read_table(f"{source.normalized.output_path}/outputs/dups").to_pylist()
+    assert len(normalized) == len(duplicates) == 1
+    assert normalized[0]["id"] == generate_id(expected_text)
+    assert normalized[0]["text"] == expected_text
+    assert {normalized[0]["source_id"], duplicates[0]["source_id"]} == {"first-source-id", "second-source-id"}
+    assert (
+        pq.read_table(f"{source.chat_normalized.output_path}/outputs/main").to_pylist()
+        == pa.Table.from_pylist(records, schema=CHAT_SCHEMA).to_pylist()
+    )

--- a/tests/datakit/test_chat_render.py
+++ b/tests/datakit/test_chat_render.py
@@ -46,7 +46,7 @@ def test_sft_source_renders_then_normalizes_and_deduplicates(tmp_path, monkeypat
     table = pq.read_table(source.rendered.output_path)
     assert table.column_names == ["id", "text"]
     expected_text = (
-        "<|begin_of_text|><|start_header_id|>system<|end_header_id|>Reasoning: /think<|eot_id|>"
+        "<|start_header_id|>system<|end_header_id|>Reasoning: /think<|eot_id|>"
         "<|start_header_id|>user<|end_header_id|>\nWhat is 2 + 2?<|eot_id|>\n"
         "<|start_header_id|>assistant<|end_header_id|>\n"
         "<|start_think|>Add two and two.<|end_think|>4<|eot_id|>"

--- a/tests/datakit/test_chat_render.py
+++ b/tests/datakit/test_chat_render.py
@@ -1,0 +1,48 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from fray.current_client import set_current_client
+from fray.local_backend import LocalClient
+from marin.datakit.chat_normalize import CHAT_SCHEMA
+from marin.datakit.chat_render import render_chat_to_parquet
+from openai_harmony import Message, Role
+
+
+def test_rendered_parquet_preserves_ids_and_duplicates(tmp_path):
+    messages = [
+        Message.from_role_and_content(Role.USER, "What is 2 + 2?"),
+        Message.from_role_and_content(Role.ASSISTANT, "Add two and two.").with_channel("analysis"),
+        Message.from_role_and_content(Role.ASSISTANT, "4").with_channel("final"),
+    ]
+    records = [
+        {
+            "id": source_id,
+            "messages": [message.to_dict() for message in messages],
+            "chat_template_kwargs": json.dumps({"enable_thinking": True}),
+        }
+        for source_id in ["first-source-id", "second-source-id"]
+    ]
+    input_path = tmp_path / "input"
+    input_path.mkdir()
+    pq.write_table(pa.Table.from_pylist(records, schema=CHAT_SCHEMA), input_path / "part-00000.parquet")
+    output_path = tmp_path / "rendered"
+
+    with set_current_client(LocalClient()):
+        render_chat_to_parquet(input_path=str(input_path), output_path=str(output_path), max_workers=1)
+
+    table = pq.read_table(output_path)
+    assert table.column_names == ["id", "text"]
+    expected_text = (
+        "<|begin_of_text|><|start_header_id|>system<|end_header_id|>Reasoning: /think<|eot_id|>"
+        "<|start_header_id|>user<|end_header_id|>\nWhat is 2 + 2?<|eot_id|>\n"
+        "<|start_header_id|>assistant<|end_header_id|>\n"
+        "<|start_think|>Add two and two.<|end_think|>4<|eot_id|>"
+    )
+    assert sorted(table.to_pylist(), key=lambda row: row["id"]) == [
+        {"id": "first-source-id", "text": expected_text},
+        {"id": "second-source-id", "text": expected_text},
+    ]

--- a/tests/evals/test_trace_labeled_eval.py
+++ b/tests/evals/test_trace_labeled_eval.py
@@ -7,6 +7,7 @@ from levanter.data.sharded_datasource import FirstRowsShardedDataSource, Sharded
 from levanter.data.text.datasets import UrlDatasetSourceConfig
 from levanter.data.text.trace_chat import TraceChatEvaluationFormat
 from levanter.tokenizers import load_tokenizer
+from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from marin.evaluation.trace_labeled_eval import (
     DEFAULT_OUTCOME_JUDGE_PROMPT,
     TraceLabeledEvalDatasetConfig,
@@ -16,8 +17,6 @@ from marin.evaluation.trace_labeled_eval import (
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import WhitespaceSplit
-
-from experiments.marin_tokenizer import MARIN_CHAT_TEMPLATE
 
 
 class FailingAfterLimitSource(ShardedDataSource[int]):

--- a/tests/test_marin_tokenizer.py
+++ b/tests/test_marin_tokenizer.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import re
 from dataclasses import dataclass
 from itertools import pairwise
 
@@ -15,11 +17,11 @@ from levanter.data.text.trace_chat import (
 )
 from levanter.tokenizers import MarinTokenizer, load_tokenizer
 from marin.datakit.chat_render import render_marin_chat
+from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from openai_harmony import Author, Message, Role
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from experiments.marin_tokenizer import (
-    MARIN_CHAT_TEMPLATE,
     MARIN_CUSTOM_SPECIAL_TOKENS,
     create_marin_tokenizer,
 )
@@ -219,7 +221,7 @@ def test_chat_processor_renders_tool_calls(marin_chat_tokenizer: MarinTokenizer)
 
     rendered = _decode(marin_chat_tokenizer, result["input_ids"])
     assert '{"name": "check_valid_vin", "arguments": {"vin": "1FMXK92W8YPA12345"}}' in rendered
-    assert '<tool_response name="check_valid_vin" id="call_abc">' in rendered
+    assert '<tool_response name="check_valid_vin">' in rendered
     assert result["assistant_masks"].sum() > 0
 
 
@@ -311,10 +313,9 @@ def test_chat_processor_renders_ipython_output(marin_chat_tokenizer: MarinTokeni
             ],
             [
                 {"role": "user", "content": "Calculate 2 + 2."},
-                {"role": "assistant", "content": "<|start_think|>Use the calculator.<|end_think|>Calculating now."},
                 {
                     "role": "assistant",
-                    "content": "",
+                    "content": "<|start_think|>Use the calculator.<|end_think|>Calculating now.",
                     "tool_calls": [
                         {
                             "type": "function",
@@ -380,10 +381,10 @@ def test_chat_processor_renders_ipython_output(marin_chat_tokenizer: MarinTokeni
                                 "name": "first",
                                 "arguments": {"z": "café <>&", "a": True},
                             }
-                        }
+                        },
+                        {"function": {"name": "second", "arguments": {}}},
                     ],
                 },
-                {"role": "assistant", "tool_calls": [{"function": {"name": "second", "arguments": {}}}]},
             ],
             {
                 "tools": [
@@ -429,3 +430,129 @@ def test_harmony_rendering_matches_inference_tokens(
     )
     actual = marin_tokenizer.encode(rendered, add_special_tokens=False)
     assert actual == expected["input_ids"]
+
+
+@pytest.mark.parametrize("arguments", [{"query": "café <>&"}, '{"query": "café <>&"}'])
+def test_agent_turn_retains_reasoning_content_and_parallel_calls(marin_chat_tokenizer, arguments):
+    messages = [
+        {"role": "user", "content": "Look in both places."},
+        {
+            "role": "assistant",
+            "reasoning_content": "Search both indexes.",
+            "content": "Looking now.",
+            "tool_calls": [
+                {"function": {"name": "first", "arguments": arguments}},
+                {"function": {"name": "second", "arguments": {}}},
+            ],
+        },
+        {"role": "tool", "name": "first", "content": "One result."},
+        {"role": "tool", "name": "second", "content": "No results."},
+        {"role": "assistant", "content": "Found one result."},
+    ]
+    result = marin_chat_tokenizer.apply_chat_template_with_masks([messages])
+    ids = np.array(result["input_ids"][0])
+    mask = np.array(result["assistant_masks"][0]).astype(bool)
+    rendered = marin_chat_tokenizer.decode(ids.tolist(), skip_special_tokens=False)
+    assistant_start = "<|start_header_id|>assistant<|end_header_id|>\n"
+    first_turn = rendered.split(assistant_start)[1].split("<|eot_id|>")[0]
+    assert first_turn.startswith("<|start_think|>Search both indexes.<|end_think|>Looking now.")
+    calls = [json.loads(payload) for payload in re.findall(r"<tool_call>(.*?)</tool_call>", first_turn, re.DOTALL)]
+    assert calls == [
+        {"name": "first", "arguments": {"query": "café <>&"}},
+        {"name": "second", "arguments": {}},
+    ]
+    trained = marin_chat_tokenizer.decode(ids[mask].tolist(), skip_special_tokens=False)
+    assert first_turn in trained
+    assert "Found one result." in trained
+    assert "One result." not in trained
+    assert "No results." not in trained
+
+
+def test_structured_tool_definitions_are_json(marin_chat_tokenizer):
+    tools = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}]
+    rendered = marin_chat_tokenizer.apply_chat_template(QUESTION, tools=tools, tokenize=False)
+    definitions = rendered.split("<tools>\n")[1].split("</tools>")[0]
+    assert [json.loads(line) for line in definitions.splitlines() if line.strip()] == tools
+
+
+def test_tool_reply_ids_render_like_named_harmony_observations(marin_chat_tokenizer):
+    calls = [
+        {"id": "call_a", "function": {"name": "first", "arguments": {}}},
+        {"id": "call_b", "function": {"name": "second", "arguments": {}}},
+    ]
+    prefix = [{"role": "user", "content": "Run both."}, {"role": "assistant", "tool_calls": calls}]
+    api_replies = [
+        {"role": "tool", "tool_call_id": "call_a", "content": "A"},
+        {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+    ]
+    named_replies = [
+        {"role": "tool", "name": "first", "content": "A"},
+        {"role": "tool", "name": "second", "content": "B"},
+    ]
+    assert marin_chat_tokenizer.apply_chat_template(prefix + api_replies) == marin_chat_tokenizer.apply_chat_template(
+        prefix + named_replies
+    )
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 17, 1000])
+def test_hermes_parser_round_trip(marin_tokenizer, chunk_size):
+    # vLLM is an optional serving dependency; this CPU-only test also runs in
+    # environments with the pinned MarinSkyRL vLLM installed.
+    hermes = pytest.importorskip("vllm.tool_parsers.hermes_tool_parser")
+    protocol = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
+    user = {"role": "user", "content": "Search both places."}
+    assistant = {
+        "role": "assistant",
+        "content": "<|start_think|>Need two searches.<|end_think|>Looking now.",
+        "tool_calls": [
+            {"function": {"name": "first", "arguments": {"query": "café <>&"}}},
+            {"function": {"name": "second", "arguments": {}}},
+        ],
+    }
+    prompt = marin_tokenizer.apply_chat_template([user], tokenize=False, add_generation_prompt=True)
+    full = marin_tokenizer.apply_chat_template([user, assistant], tokenize=False)
+    completion = full.removeprefix(prompt).removesuffix("<|eot_id|>")
+    request = protocol.ChatCompletionRequest(model="marin", messages=[user])
+    result = hermes.Hermes2ProToolParser(marin_tokenizer).extract_tool_calls(completion, request)
+    assert result.tools_called
+    assert result.content == assistant["content"]
+    expected = [("first", {"query": "café <>&"}), ("second", {})]
+    assert [(call.function.name, json.loads(call.function.arguments)) for call in result.tool_calls] == expected
+
+    parser = hermes.Hermes2ProToolParser(marin_tokenizer)
+    previous = ""
+    content = ""
+    calls = {}
+    for end in range(chunk_size, len(completion) + chunk_size, chunk_size):
+        current = completion[:end]
+        delta_text = current[len(previous) :]
+        delta = parser.extract_tool_calls_streaming(
+            previous,
+            current,
+            delta_text,
+            marin_tokenizer.encode(previous),
+            marin_tokenizer.encode(current),
+            marin_tokenizer.encode(delta_text),
+            request,
+        )
+        if delta:
+            content += delta.content or ""
+            for call in delta.tool_calls:
+                entry = calls.setdefault(call.index, {"name": "", "arguments": ""})
+                if call.function:
+                    entry["name"] += call.function.name or ""
+                    entry["arguments"] += call.function.arguments or ""
+        previous = current
+    assert content == result.content
+    assert [(call["name"], json.loads(call["arguments"])) for call in calls.values()] == expected
+
+    replay = {
+        "role": "assistant",
+        "content": result.content,
+        "tool_calls": [call.model_dump() for call in result.tool_calls],
+    }
+    api_replies = [{"role": "tool", "tool_call_id": call.id, "content": "Done."} for call in result.tool_calls]
+    named_replies = [{"role": "tool", "name": name, "content": "Done."} for name, _ in expected]
+    assert marin_tokenizer.apply_chat_template([user, replay, *api_replies]) == marin_tokenizer.apply_chat_template(
+        [user, assistant, *named_replies]
+    )

--- a/tests/test_marin_tokenizer.py
+++ b/tests/test_marin_tokenizer.py
@@ -8,15 +8,16 @@ from itertools import pairwise
 
 import numpy as np
 import pytest
-from levanter.data.text.formats import ChatProcessor
+from levanter.data.text.formats import ChatProcessor, TextLmDatasetFormat
 from levanter.data.text.trace_chat import (
+    TRACE_LABEL_ASSISTANT_TEXT,
     TRACE_LABEL_ASSISTANT_TOOL_CALL,
     TRACE_LABEL_FINAL_ASSISTANT,
     TRACE_LABEL_OBSERVATION,
     TraceChatProcessor,
 )
 from levanter.tokenizers import MarinTokenizer, load_tokenizer
-from marin.datakit.chat_render import render_marin_chat
+from marin.datakit.chat_render import render_chat_record, render_marin_chat
 from marin.datakit.chat_template import MARIN_CHAT_TEMPLATE
 from openai_harmony import Author, Message, Role
 from transformers import AutoTokenizer, PreTrainedTokenizer
@@ -494,65 +495,87 @@ def test_tool_reply_ids_render_like_named_harmony_observations(marin_chat_tokeni
     )
 
 
-@pytest.mark.parametrize("chunk_size", [1, 3, 17, 1000])
-def test_hermes_parser_round_trip(marin_tokenizer, chunk_size):
-    # vLLM is an optional serving dependency; this CPU-only test also runs in
-    # environments with the pinned MarinSkyRL vLLM installed.
-    hermes = pytest.importorskip("vllm.tool_parsers.hermes_tool_parser")
-    protocol = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
-    user = {"role": "user", "content": "Search both places."}
-    assistant = {
-        "role": "assistant",
-        "content": "<|start_think|>Need two searches.<|end_think|>Looking now.",
-        "tool_calls": [
-            {"function": {"name": "first", "arguments": {"query": "café <>&"}}},
-            {"function": {"name": "second", "arguments": {}}},
-        ],
-    }
-    prompt = marin_tokenizer.apply_chat_template([user], tokenize=False, add_generation_prompt=True)
-    full = marin_tokenizer.apply_chat_template([user, assistant], tokenize=False)
-    completion = full.removeprefix(prompt).removesuffix("<|eot_id|>")
-    request = protocol.ChatCompletionRequest(model="marin", messages=[user])
-    result = hermes.Hermes2ProToolParser(marin_tokenizer).extract_tool_calls(completion, request)
-    assert result.tools_called
-    assert result.content == assistant["content"]
-    expected = [("first", {"query": "café <>&"}), ("second", {})]
-    assert [(call.function.name, json.loads(call.function.arguments)) for call in result.tool_calls] == expected
-
-    parser = hermes.Hermes2ProToolParser(marin_tokenizer)
-    previous = ""
-    content = ""
-    calls = {}
-    for end in range(chunk_size, len(completion) + chunk_size, chunk_size):
-        current = completion[:end]
-        delta_text = current[len(previous) :]
-        delta = parser.extract_tool_calls_streaming(
-            previous,
-            current,
-            delta_text,
-            marin_tokenizer.encode(previous),
-            marin_tokenizer.encode(current),
-            marin_tokenizer.encode(delta_text),
-            request,
-        )
-        if delta:
-            content += delta.content or ""
-            for call in delta.tool_calls:
-                entry = calls.setdefault(call.index, {"name": "", "arguments": ""})
-                if call.function:
-                    entry["name"] += call.function.name or ""
-                    entry["arguments"] += call.function.arguments or ""
-        previous = current
-    assert content == result.content
-    assert [(call["name"], json.loads(call["arguments"])) for call in calls.values()] == expected
-
-    replay = {
-        "role": "assistant",
-        "content": result.content,
-        "tool_calls": [call.model_dump() for call in result.tool_calls],
-    }
-    api_replies = [{"role": "tool", "tool_call_id": call.id, "content": "Done."} for call in result.tool_calls]
-    named_replies = [{"role": "tool", "name": name, "content": "Done."} for name, _ in expected]
-    assert marin_tokenizer.apply_chat_template([user, replay, *api_replies]) == marin_tokenizer.apply_chat_template(
-        [user, assistant, *named_replies]
+def test_rendered_record_text_tokenizer_adds_one_bos(marin_chat_tokenizer):
+    messages = [
+        Message.from_role_and_content(Role.USER, "Hello"),
+        Message.from_role_and_content(Role.ASSISTANT, "Hi").with_channel("final"),
+    ]
+    record = render_chat_record({"id": "example", "messages": [message.to_dict() for message in messages]})
+    assert not record["text"].startswith("<|begin_of_text|>")
+    processor = TextLmDatasetFormat().build_preprocessor(marin_chat_tokenizer)
+    actual = processor([record])[0]["input_ids"]
+    expected = marin_chat_tokenizer.apply_chat_template(
+        [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}]
     )
+    # The text path adds its normal document separator after the final chat EOT.
+    expected += marin_chat_tokenizer.encode(" " + marin_chat_tokenizer.eos_token, add_special_tokens=False)
+    assert actual == expected
+
+
+def test_trace_inline_calls_preserve_assistant_turn(marin_chat_tokenizer):
+    calls = [
+        {"name": "first", "arguments": {"key": "a"}},
+        {"name": "second", "arguments": {}},
+    ]
+    user = {"role": "user", "content": "Look in both places."}
+    prose = "Looking now."
+    inline = prose + "".join(f"<tool_call>{json.dumps(call)}</tool_call>" for call in calls)
+    processor = TraceChatProcessor(marin_chat_tokenizer, loss_tags=("assistant", "assistant_text", "tool_call"))
+    actual = processor([{"messages": [user, {"role": "assistant", "content": inline}]}])[0]
+    expected = marin_chat_tokenizer.apply_chat_template(
+        [
+            user,
+            {
+                "role": "assistant",
+                "content": prose,
+                "tool_calls": [{"type": "function", "function": call} for call in calls],
+            },
+        ]
+    )
+    assert actual["input_ids"].tolist() == expected
+    labels = actual["loss_labels"]
+    assert prose in _decode(marin_chat_tokenizer, actual["input_ids"][labels == TRACE_LABEL_ASSISTANT_TEXT])
+    tool_text = _decode(marin_chat_tokenizer, actual["input_ids"][labels == TRACE_LABEL_ASSISTANT_TOOL_CALL])
+    assert [
+        json.loads(payload) for payload in re.findall(r"<tool_call>(.*?)</tool_call>", tool_text, re.DOTALL)
+    ] == calls
+
+
+@pytest.mark.parametrize("reply_role", [None, "tool", "ipython"], ids=["plain-chat", "tool-reply", "python-output"])
+def test_text_content_representations_have_identical_prefixes(marin_tokenizer, reply_role):
+    messages = [
+        {"role": "system", "content": "  Be helpful.\n"},
+        {"role": "developer", "content": "Keep responses short."},
+        {"role": "user", "content": "  Find café records.\n"},
+        {"role": "assistant", "content": "  Looking now.\n"},
+    ]
+    if reply_role is not None:
+        messages[-1]["tool_calls"] = [
+            {"id": "call_lookup", "type": "function", "function": {"name": "lookup", "arguments": {"key": "café"}}},
+        ]
+        messages.append({"role": reply_role, "tool_call_id": "call_lookup", "content": "  Found one record.\n"})
+        messages.append({"role": "assistant", "content": "Here it is."})
+    messages.append({"role": "user", "content": "  Tell me more.\n"})
+
+    expected_text = marin_tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    expected_tokens = marin_tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True)
+    for representation in ("mapping", "parts", "split-parts"):
+        converted = []
+        for message in messages:
+            content = message["content"]
+            if representation == "mapping":
+                content = {"text": content}
+            elif representation == "parts":
+                content = [{"type": "text", "text": content}]
+            else:
+                # Split at a word boundary: trimming individual parts loses the space.
+                split = content.index(" ", len(content) - len(content.lstrip()) + 1) + 1
+                content = [{"type": "text", "text": content[:split]}, {"type": "text", "text": content[split:]}]
+            converted.append({**message, "content": content})
+
+        assert (
+            marin_tokenizer.apply_chat_template(converted, tokenize=False, add_generation_prompt=True) == expected_text
+        ), representation
+        assert (
+            marin_tokenizer.apply_chat_template(converted, tokenize=True, add_generation_prompt=True) == expected_tokens
+        ), representation

--- a/tests/test_marin_tokenizer.py
+++ b/tests/test_marin_tokenizer.py
@@ -14,6 +14,8 @@ from levanter.data.text.trace_chat import (
     TraceChatProcessor,
 )
 from levanter.tokenizers import MarinTokenizer, load_tokenizer
+from marin.datakit.chat_render import render_marin_chat
+from openai_harmony import Author, Message, Role
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from experiments.marin_tokenizer import (
@@ -251,3 +253,179 @@ def test_chat_processor_renders_ipython_output(marin_chat_tokenizer: MarinTokeni
     assert "<|start_header_id|>ipython<|end_header_id|>" in rendered
     assert '{"output": "4\\n"}' in rendered
     assert result["assistant_masks"].sum() > 0
+
+
+@pytest.mark.parametrize("custom_instructions", ["", "  Keep answers short.\n"])
+@pytest.mark.parametrize("add_generation_prompt", [False, True], ids=["completed", "generation-prefix"])
+@pytest.mark.parametrize(
+    "harmony_messages,inference_messages,template_kwargs",
+    [
+        pytest.param(
+            [
+                Message.from_role_and_content(Role.SYSTEM, "Be concise."),
+                Message.from_role_and_content(Role.USER, "  Hello, café!\n"),
+                Message.from_role_and_content(Role.ASSISTANT, "こんにちは!").with_channel("final"),
+                Message.from_role_and_content(Role.USER, "Again?"),
+                Message.from_role_and_content(Role.ASSISTANT, "Hello again.").with_channel("final"),
+            ],
+            [
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "  Hello, café!\n"},
+                {"role": "assistant", "content": "こんにちは!"},
+                {"role": "user", "content": "Again?"},
+                {"role": "assistant", "content": "Hello again."},
+            ],
+            {},
+            id="multi-turn-chat",
+        ),
+        pytest.param(
+            [
+                Message.from_role_and_content(Role.USER, "What is 2 + 2?"),
+                Message.from_role_and_content(Role.ASSISTANT, "Add the two numbers.").with_channel("analysis"),
+                Message.from_role_and_content(Role.ASSISTANT, "4").with_channel("final"),
+                Message.from_role_and_content(Role.USER, "And 3 + 3?"),
+                Message.from_role_and_content(Role.ASSISTANT, "Double three.").with_channel("analysis"),
+                Message.from_role_and_content(Role.ASSISTANT, "6").with_channel("final"),
+            ],
+            [
+                {"role": "user", "content": "What is 2 + 2?"},
+                {"role": "assistant", "content": "<|start_think|>Add the two numbers.<|end_think|>4"},
+                {"role": "user", "content": "And 3 + 3?"},
+                {"role": "assistant", "content": "<|start_think|>Double three.<|end_think|>6"},
+            ],
+            {"enable_thinking": True},
+            id="preserve-earlier-reasoning",
+        ),
+        pytest.param(
+            [
+                Message.from_role_and_content(Role.USER, "Calculate 2 + 2."),
+                Message.from_role_and_content(Role.ASSISTANT, "Use the calculator.").with_channel("analysis"),
+                Message.from_role_and_content(Role.ASSISTANT, "Calculating now.").with_channel("commentary"),
+                Message.from_role_and_content(Role.ASSISTANT, '{"expression":"2 + 2"}')
+                .with_channel("commentary")
+                .with_recipient("functions.calculate"),
+                Message.from_author_and_content(Author(role=Role.TOOL, name="functions.calculate"), "4")
+                .with_channel("commentary")
+                .with_recipient("assistant"),
+                Message.from_role_and_content(Role.ASSISTANT, "The answer is 4.").with_channel("final"),
+            ],
+            [
+                {"role": "user", "content": "Calculate 2 + 2."},
+                {"role": "assistant", "content": "<|start_think|>Use the calculator.<|end_think|>Calculating now."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "calculate",
+                                "arguments": {"expression": "2 + 2"},
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "name": "calculate", "content": "4"},
+                {"role": "assistant", "content": "The answer is 4."},
+            ],
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calculate",
+                            "description": "Evaluate an arithmetic expression.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "expression": {"type": "string"},
+                                },
+                                "required": ["expression"],
+                            },
+                        },
+                    }
+                ]
+            },
+            id="tool-round-trip",
+        ),
+        pytest.param(
+            [
+                Message.from_role_and_content(Role.USER, "Work it out."),
+                Message.from_role_and_content(Role.ASSISTANT, "Still working…").with_channel("analysis"),
+            ],
+            [
+                {"role": "user", "content": "Work it out."},
+                {"role": "assistant", "content": "<|start_think|>Still working…<|end_think|>"},
+            ],
+            {"enable_thinking": False},
+            id="reasoning-only-ending",
+        ),
+        pytest.param(
+            [
+                Message.from_role_and_content(Role.USER, "Run both."),
+                Message.from_role_and_content(Role.ASSISTANT, '{"z": "café <>&", "a": true}')
+                .with_channel("commentary")
+                .with_recipient("functions.first"),
+                Message.from_role_and_content(Role.ASSISTANT, "{}")
+                .with_channel("commentary")
+                .with_recipient("functions.second"),
+            ],
+            [
+                {"role": "user", "content": "Run both."},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "first",
+                                "arguments": {"z": "café <>&", "a": True},
+                            }
+                        }
+                    ],
+                },
+                {"role": "assistant", "tool_calls": [{"function": {"name": "second", "arguments": {}}}]},
+            ],
+            {
+                "tools": [
+                    {"name": "first", "parameters": {"type": "object"}},
+                    {"name": "second", "parameters": {"type": "object"}},
+                ]
+            },
+            id="unanswered-call-batch",
+        ),
+    ],
+)
+def test_harmony_rendering_matches_inference_tokens(
+    marin_tokenizer, harmony_messages, inference_messages, template_kwargs, add_generation_prompt, custom_instructions
+):
+    # Generation resumes after the final user/tool message; retain completed
+    # earlier turns so history formatting is checked as well as the prefix.
+    if add_generation_prompt:
+        final_prompt_index = max(
+            i for i, message in enumerate(harmony_messages) if message.author.role in {Role.USER, Role.TOOL}
+        )
+        harmony_messages = harmony_messages[: final_prompt_index + 1]
+        inference_prompt_index = max(
+            i for i, message in enumerate(inference_messages) if message["role"] in {"user", "tool"}
+        )
+        inference_messages = inference_messages[: inference_prompt_index + 1]
+
+    template_kwargs = {**template_kwargs, "custom_instructions": custom_instructions}
+    expected = marin_tokenizer.apply_chat_template(
+        inference_messages,
+        tokenize=True,
+        return_dict=True,
+        add_generation_prompt=add_generation_prompt,
+        **template_kwargs,
+    )
+    rendered = render_marin_chat(
+        harmony_messages,
+        bos_token=marin_tokenizer.bos_token,
+        add_generation_prompt=add_generation_prompt,
+        **template_kwargs,
+    )
+    assert rendered == marin_tokenizer.apply_chat_template(
+        inference_messages, tokenize=False, add_generation_prompt=add_generation_prompt, **template_kwargs
+    )
+    actual = marin_tokenizer.encode(rendered, add_special_tokens=False)
+    assert actual == expected["input_ids"]


### PR DESCRIPTION
Render normalized Harmony conversations with the same template exported for inference. Keep assistant reasoning, prose, and parallel tool calls in one turn, emit tool calls inside `<tool_call>` tags, and resolve API tool reply IDs to function names. Structured tool definitions serialize as JSON.

Equivalent content represented as strings, text mappings, or lists of text parts now produces identical text and token prefixes, including tool replies. Join text parts before trimming so spaces between parts survive. Stored Datakit text omits BOS because the text tokenizer supplies it; the trace evaluation path also keeps inline calls in one assistant turn while retaining separate prose and tool loss labels.

Re-export tokenizer artifacts to deploy the template changes. Keep vLLM's `chat_template_content_format=string` pin until those artifacts are deployed. The skipped vLLM Hermes parser test is removed; local tests cover rendering and token parity, not vLLM parser integration.

Fixes #9103
