### PR TITLE
[iris] Stop terminal attempt durations from increasing

### DIFF
--- a/lib/iris/TESTING.md
+++ b/lib/iris/TESTING.md
@@ -196,6 +196,10 @@ Docker tests use a separate `docker_cluster` fixture and are marked `docker`.
 
 ## Running Tests
 
+Run dashboard unit tests with `npm test` from `lib/iris/dashboard/`. These tests
+use the Node.js test runner with native TypeScript support, as in the Finelog
+dashboard. Run `npm run build:check` for Vue and TypeScript checks and the build.
+
 ```bash
 # All unit tests
 uv run --package marin-iris --group test pytest lib/iris/tests/

--- a/lib/iris/dashboard/package.json
+++ b/lib/iris/dashboard/package.json
@@ -6,6 +6,7 @@
     "dev": "rsbuild dev",
     "build": "rsbuild build",
     "build:check": "vue-tsc --noEmit && rsbuild build",
+    "test": "node --test 'tests/*.test.ts'",
     "preview": "rsbuild preview"
   },
   "dependencies": {

--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -14,7 +14,7 @@ import {
   type EndpointInfo,
   type ListEndpointsResponse,
 } from '@/types/rpc'
-import { timestampMs, formatBytes, formatCpuMillicores, formatDuration, formatRelativeTime } from '@/utils/formatting'
+import { timestampMs, formatBytes, formatCpuMillicores, formatDuration, formatAttemptDuration, formatRelativeTime } from '@/utils/formatting'
 import { decodeArrowIpc } from '@/utils/arrow'
 import { detailSql } from '@/utils/taskStatus'
 
@@ -642,7 +642,7 @@ watch(() => props.taskId, async () => {
                   {{ attempt.exitCode ?? '-' }}
                 </td>
                 <td class="px-3 py-2 text-[13px] font-mono">
-                  {{ formatDuration(timestampMs(attempt.startedAt), timestampMs(attempt.finishedAt) || undefined) }}
+                  {{ formatAttemptDuration(attempt) }}
                 </td>
                 <!-- The reason can run to 500 chars, so the cell truncates and
                      the full text lives in the tooltip. -->

--- a/lib/iris/dashboard/src/components/controller/WorkerDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/WorkerDetail.vue
@@ -11,7 +11,7 @@ import type {
   LogEntry,
   FetchLogsResponse,
 } from '@/types/rpc'
-import { timestampMs, formatBytes, formatDuration, formatRelativeTime, formatRate, logLevelClass, formatLogTime, formatWorkerDevice } from '@/utils/formatting'
+import { timestampMs, formatBytes, formatAttemptDuration, formatRelativeTime, formatRate, logLevelClass, formatLogTime, formatWorkerDevice } from '@/utils/formatting'
 import { formatProvenance } from '@/utils/provenance'
 import { decodeArrowIpc } from '@/utils/arrow'
 
@@ -573,10 +573,7 @@ function attributeDisplay(val: { stringValue?: string; intValue?: string; floatV
             </template>
             <template #cell-duration="{ row }">
               <span class="font-mono text-xs">
-                {{ formatDuration(
-                  timestampMs((row as AttemptRow).attempt?.startedAt),
-                  timestampMs((row as AttemptRow).attempt?.finishedAt) || undefined,
-                ) }}
+                {{ formatAttemptDuration((row as AttemptRow).attempt) }}
               </span>
             </template>
           </DataTable>

--- a/lib/iris/dashboard/src/utils/formatting.ts
+++ b/lib/iris/dashboard/src/utils/formatting.ts
@@ -1,4 +1,5 @@
-import type { ProtoTimestamp } from '@/types/rpc'
+import type { ProtoTimestamp, TaskAttempt } from '@/types/rpc'
+import { stateToName } from '../types/status.ts'
 
 /** Parse a ProtoTimestamp to epoch milliseconds. */
 export function timestampMs(ts?: ProtoTimestamp): number {
@@ -61,6 +62,15 @@ export function formatDuration(startMs: number, endMs?: number): string {
   const hours = Math.floor(diffSec / 3600)
   const mins = Math.floor((diffSec % 3600) / 60)
   return `${hours}h ${mins}m`
+}
+
+/** Use the current time only for active attempts. */
+export function formatAttemptDuration(attempt?: TaskAttempt): string {
+  if (!attempt) return '-'
+  const finished = timestampMs(attempt.finishedAt)
+  const state = stateToName(attempt.state)
+  if (!finished && state !== 'assigned' && state !== 'building' && state !== 'running') return '-'
+  return formatDuration(timestampMs(attempt.startedAt), finished || undefined)
 }
 
 /**

--- a/lib/iris/dashboard/tests/formatting.test.ts
+++ b/lib/iris/dashboard/tests/formatting.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { formatAttemptDuration } from '../src/utils/formatting.ts'
+
+const startedAt = { epochMs: '1789024283002' }
+const finishedAt = { epochMs: '1789027789369' }
+const later = 1789060189369
+
+test('terminal attempts with no finish time show an unknown duration', (t) => {
+  t.mock.method(Date, 'now', () => later)
+  for (const state of ['SUCCEEDED', 'FAILED', 'KILLED', 'WORKER_FAILED', 'UNSCHEDULABLE', 'PREEMPTED', 'COSCHED_FAILED']) {
+    assert.equal(formatAttemptDuration({ attemptId: 1, state: `TASK_STATE_${state}`, startedAt }), '-')
+  }
+})
+
+test('a completed attempt keeps its duration after a retry starts', (t) => {
+  t.mock.method(Date, 'now', () => later)
+  assert.equal(formatAttemptDuration({ attemptId: 1, state: 'TASK_STATE_COSCHED_FAILED', startedAt, finishedAt }), '58m 26s')
+})
+
+test('active attempts use the current time after execution starts', (t) => {
+  t.mock.method(Date, 'now', () => Number(startedAt.epochMs) + 3_600_000)
+  for (const state of ['ASSIGNED', 'BUILDING', 'RUNNING']) {
+    assert.equal(formatAttemptDuration({ attemptId: 2, state: `TASK_STATE_${state}`, startedAt }), '1h 0m')
+    assert.equal(formatAttemptDuration({ attemptId: 2, state: `TASK_STATE_${state}` }), '-')
+  }
+})

--- a/lib/iris/dashboard/tsconfig.json
+++ b/lib/iris/dashboard/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/lib/iris/docs/task-states.md
+++ b/lib/iris/docs/task-states.md
@@ -328,6 +328,16 @@ The job detail page shows per-task attempt history. Each attempt has its own
 state badge, and worker failures are annotated with "(worker failure)" in the
 attempt rows.
 
+Attempt duration uses `started_at` and `finished_at`. Only active attempts use
+the current time when `finished_at` is absent. Terminal attempts without a
+finish time show `-`.
+
+For Kubernetes attempts, controller cancellation, preemption, timeout, and
+coscheduled termination record the controller decision time as `finished_at`.
+This timestamp does not identify the exact process exit. Worker-bound attempts
+wait for worker confirmation before the controller records `finished_at` and
+releases capacity.
+
 Pending tasks display a `pending_reason` diagnostic below the state badge when
 the controller can identify why the task cannot be scheduled (e.g., no workers
 match constraints).

--- a/lib/iris/src/iris/cluster/controller/reconcile/batches.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/batches.py
@@ -91,7 +91,7 @@ def _finish_non_terminal_tasks(
             task_state,
             error,
             now_ms,
-            stamp_attempt_finished=False,
+            stamp_attempt_finished=row.current_worker_id is None,
             exit_code=exit_code,
         )
         overlay.emit_task_event(

--- a/lib/iris/src/iris/cluster/controller/reconcile/batches.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/batches.py
@@ -84,6 +84,7 @@ def _finish_non_terminal_tasks(
 ) -> None:
     """Finish all non-terminal tasks for a job and stop their active attempts."""
     for row in overlay.active_tasks_for_job(job_id, states=NON_TERMINAL_TASK_STATES):
+        # A pending task can retain an unfinished worker attempt after preemption.
         task.merge_task_termination(
             overlay,
             row.task_id.to_wire(),
@@ -91,7 +92,7 @@ def _finish_non_terminal_tasks(
             task_state,
             error,
             now_ms,
-            stamp_attempt_finished=row.current_worker_id is None,
+            stamp_attempt_finished=row.state in ACTIVE_TASK_STATES and row.current_worker_id is None,
             exit_code=exit_code,
         )
         overlay.emit_task_event(

--- a/lib/iris/src/iris/cluster/controller/reconcile/peers.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/peers.py
@@ -45,12 +45,9 @@ def terminate_coscheduled_siblings(
     """Terminate coscheduled siblings.
 
     Each sibling is moved to ``TASK_STATE_COSCHED_FAILED``, which is
-    unconditionally terminal. The attempt is left unfinished
-    (``finished_at_ms`` NULL) so the sibling's chips stay accounted for until
-    its process is actually stopped: because the attempt is terminal but still
-    worker-bound, the reconcile planner sends the worker a ``stop`` for it
-    (``reconcile/worker.py``), and the worker's resulting terminal observation
-    finalizes the attempt and releases capacity.
+    unconditionally terminal. Worker-bound attempts stay unfinished until the
+    worker confirms termination and releases capacity. Attempts without a worker
+    use the controller termination time because no worker confirmation will arrive.
     """
     error = f"Coscheduled sibling {failed_task_id.to_wire()} failed"
 
@@ -62,7 +59,7 @@ def terminate_coscheduled_siblings(
             job_pb2.TASK_STATE_COSCHED_FAILED,
             error,
             now_ms,
-            stamp_attempt_finished=False,
+            stamp_attempt_finished=sib.current_worker_id is None,
         )
         state.emit_task_event(
             TaskActionEvent(
@@ -101,7 +98,7 @@ def requeue_coscheduled_siblings(
             job_pb2.TASK_STATE_PENDING,
             error,
             now_ms,
-            stamp_attempt_finished=False,
+            stamp_attempt_finished=sib.current_worker_id is None,
             attempt_state=job_pb2.TASK_STATE_COSCHED_FAILED,
         )
         state.emit_task_event(

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -257,7 +257,7 @@ def preempt_one(
         new_state,
         reason,
         now_ms,
-        stamp_attempt_finished=False,
+        stamp_attempt_finished=row.current_worker_id is None,
         attempt_state=job_pb2.TASK_STATE_PREEMPTED,
     )
     return TransitionOutcome(
@@ -546,5 +546,5 @@ def timeout_one(
         job_pb2.TASK_STATE_FAILED,
         reason,
         now_ms,
-        stamp_attempt_finished=False,
+        stamp_attempt_finished=row.current_worker_id is None,
     )

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -2909,6 +2909,38 @@ def test_worker_death_cascades_children_terminal(state):
     assert child_job.state == job_pb2.JOB_STATE_KILLED
 
 
+def test_parent_failure_keeps_preempted_child_capacity_until_worker_confirmation(state):
+    parent_worker = register_worker(state, "parent-worker", "parent:8080", make_worker_metadata())
+    child_worker = register_worker(state, "child-worker", "child:8080", make_worker_metadata())
+    parent = submit_job(state, "parent", make_job_request("parent"))[0]
+    child_request = make_job_request("child")
+    child_request.max_retries_preemption = 1
+    child = submit_job(state, "/test-user/parent/child", child_request)[0]
+    dispatch_task(state, parent, parent_worker)
+    dispatch_task(state, child, child_worker)
+    child_usage = _usage_for_worker(state, child_worker)
+
+    with state._db.transaction() as cur:
+        finalize(cur, [TerminalDecision(TerminalKind.PREEMPT, child.task_id, "reclaim")], now=Timestamp.now())
+    assert _query_task(state, child.task_id).state == job_pb2.TASK_STATE_PENDING
+
+    transition_task(state, parent.task_id, job_pb2.TASK_STATE_FAILED)
+
+    assert _query_task(state, child.task_id).state == job_pb2.TASK_STATE_KILLED
+    assert _query_attempt(state, child.task_id, 0).finished_at_ms is None
+    assert _usage_for_worker(state, child_worker) == child_usage
+
+    with state._db.transaction() as cur:
+        apply_task_observations(
+            cur,
+            [WorkerTaskUpdates(child_worker, [TaskUpdate(child.task_id, 0, job_pb2.TASK_STATE_KILLED)])],
+            health=state._health,
+            now=Timestamp.now(),
+        )
+    assert _query_attempt(state, child.task_id, 0).finished_at_ms is not None
+    assert _usage_for_worker(state, child_worker) == _ZERO_USAGE
+
+
 def test_worker_death_preemption_policy_terminate(state):
     """Single-task parent retried after worker death -> children killed (default TERMINATE)."""
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())

--- a/lib/iris/tests/journeys/test_coscheduling.py
+++ b/lib/iris/tests/journeys/test_coscheduling.py
@@ -8,6 +8,7 @@ def test_coscheduled_job_when_one_task_exhausts_retries_stops_the_gang(journey):
     job = journey.submit("coscheduled-failure", tasks=4, coscheduled=True)
     journey.settle()
 
+    journey.clock.advance(3600)
     journey.fail(job[2])
     journey.settle()
 
@@ -16,6 +17,7 @@ def test_coscheduled_job_when_one_task_exhausts_retries_stops_the_gang(journey):
     assert [journey.task(job[index]).state for index in (0, 1, 3)] == [
         job_pb2.TASK_STATE_COSCHED_FAILED,
     ] * 3
+    assert all(journey.task(job[index]).attempts[0].HasField("finished_at") for index in range(4))
 
 
 def test_coscheduled_job_when_one_task_retries_restarts_the_whole_gang(journey):
@@ -28,11 +30,19 @@ def test_coscheduled_job_when_one_task_retries_restarts_the_whole_gang(journey):
     )
     journey.settle()
 
+    journey.clock.advance(3600)
     journey.fail(job[2])
     journey.settle()
 
     assert [journey.task(job[index]).state for index in range(4)] == [job_pb2.TASK_STATE_RUNNING] * 4
     assert all(len(journey.task(job[index]).attempts) == 2 for index in range(4))
+    first_attempt = journey.task(job[0]).attempts[0]
+    assert first_attempt.HasField("finished_at")
+    assert 3_600_000 <= first_attempt.finished_at.epoch_ms - first_attempt.started_at.epoch_ms < 3_601_000
+
+    journey.clock.advance(9 * 3600)
+    journey.settle()
+    assert journey.task(job[0]).attempts[0].finished_at == first_attempt.finished_at
 
     journey.succeed_all(job)
     journey.settle()


### PR DESCRIPTION
Record a finish timestamp when the controller terminates a Kubernetes attempt through cancellation, preemption, timeout, or coscheduled failure. These attempts have no Iris worker to confirm termination, so their finish timestamps stayed empty. The dashboard continued to calculate their durations from the current time.

Terminal attempts with no finish time now show `-`. Active attempts continue to use the current time. For controller-terminated Kubernetes attempts, the finish timestamp records the controller decision time. It does not identify the exact process exit. Worker-bound attempts still wait for termination confirmation before the controller releases capacity. Historical missing timestamps remain unknown.

The controller requeued the reported attempt 58m26s after it started, but the displayed duration included nine hours after the retry. [Investigation](https://marina.oa.dev/echo/wiki/390).
