### PR TITLE
[iris] Check child capacity through public task behavior

### DIFF
--- a/lib/iris/src/iris/testing/journeys/worker.py
+++ b/lib/iris/src/iris/testing/journeys/worker.py
@@ -212,12 +212,14 @@ class WorkerJourney:
         cpu_millicores: int = 1000,
         priority_band: int = job_pb2.PRIORITY_BAND_BATCH,
         preemption_retries: int = 1,
+        parent: WorkerJob | None = None,
     ) -> WorkerJob:
+        job_name = JobName.from_wire(parent.job_id).child(name) if parent is not None else JobName.root("journey", name)
         entrypoint = job_pb2.RuntimeEntrypoint()
         entrypoint.run_command.argv[:] = ["python", "-c", "pass"]
         response = self.controller.launch_job(
             controller_pb2.Controller.LaunchJobRequest(
-                name=JobName.root("journey", name).to_wire(),
+                name=job_name.to_wire(),
                 entrypoint=entrypoint,
                 environment=job_pb2.EnvironmentConfig(),
                 resources=job_pb2.ResourceSpecProto(

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -2909,38 +2909,6 @@ def test_worker_death_cascades_children_terminal(state):
     assert child_job.state == job_pb2.JOB_STATE_KILLED
 
 
-def test_parent_failure_keeps_preempted_child_capacity_until_worker_confirmation(state):
-    parent_worker = register_worker(state, "parent-worker", "parent:8080", make_worker_metadata())
-    child_worker = register_worker(state, "child-worker", "child:8080", make_worker_metadata())
-    parent = submit_job(state, "parent", make_job_request("parent"))[0]
-    child_request = make_job_request("child")
-    child_request.max_retries_preemption = 1
-    child = submit_job(state, "/test-user/parent/child", child_request)[0]
-    dispatch_task(state, parent, parent_worker)
-    dispatch_task(state, child, child_worker)
-    child_usage = _usage_for_worker(state, child_worker)
-
-    with state._db.transaction() as cur:
-        finalize(cur, [TerminalDecision(TerminalKind.PREEMPT, child.task_id, "reclaim")], now=Timestamp.now())
-    assert _query_task(state, child.task_id).state == job_pb2.TASK_STATE_PENDING
-
-    transition_task(state, parent.task_id, job_pb2.TASK_STATE_FAILED)
-
-    assert _query_task(state, child.task_id).state == job_pb2.TASK_STATE_KILLED
-    assert _query_attempt(state, child.task_id, 0).finished_at_ms is None
-    assert _usage_for_worker(state, child_worker) == child_usage
-
-    with state._db.transaction() as cur:
-        apply_task_observations(
-            cur,
-            [WorkerTaskUpdates(child_worker, [TaskUpdate(child.task_id, 0, job_pb2.TASK_STATE_KILLED)])],
-            health=state._health,
-            now=Timestamp.now(),
-        )
-    assert _query_attempt(state, child.task_id, 0).finished_at_ms is not None
-    assert _usage_for_worker(state, child_worker) == _ZERO_USAGE
-
-
 def test_worker_death_preemption_policy_terminate(state):
     """Single-task parent retried after worker death -> children killed (default TERMINATE)."""
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())

--- a/lib/iris/tests/journeys/test_worker_lifecycle.py
+++ b/lib/iris/tests/journeys/test_worker_lifecycle.py
@@ -110,3 +110,30 @@ def test_preempted_attempt_holds_capacity_until_worker_reports_exact_terminal_st
 
     journey.run_until_task_state(high, job_pb2.TASK_STATE_RUNNING)
     assert journey.task(high).worker_id == "worker-a"
+
+
+def test_parent_failure_keeps_preempted_child_capacity_until_worker_confirmation(worker_journey):
+    journey = worker_journey
+    daemon = journey.add_worker("worker-a", "worker-a:8080", cpu_millicores=2000)
+    parent = journey.submit("parent")
+    journey.run_until_task_state(parent, job_pb2.TASK_STATE_RUNNING)
+    child = journey.submit("child", parent=parent)
+    journey.run_until_task_state(child, job_pb2.TASK_STATE_RUNNING)
+
+    daemon.acknowledge_stops = False
+    journey.preempt(child)
+    journey.run_until_task_state(child, job_pb2.TASK_STATE_PENDING)
+    daemon.queue_observation(journey.task(parent).attempts[0].attempt_uid, job_pb2.TASK_STATE_FAILED)
+    journey.run_until_task_state(parent, job_pb2.TASK_STATE_FAILED)
+
+    assert journey.task(child).state == job_pb2.TASK_STATE_KILLED
+    assert not journey.task(child).attempts[0].HasField("finished_at")
+
+    replacement = journey.submit("replacement", cpu_millicores=2000)
+    journey.step()
+    assert journey.task(replacement).state == job_pb2.TASK_STATE_PENDING
+
+    daemon.acknowledge_stops = True
+    journey.run_until_task_state(replacement, job_pb2.TASK_STATE_RUNNING)
+    assert journey.task(child).attempts[0].HasField("finished_at")
+    assert journey.task(replacement).worker_id == "worker-a"


### PR DESCRIPTION
Check that a child retains worker capacity when its parent fails after child preemption and before worker confirmation. The regression now uses public task status and proves that a replacement task stays pending until that confirmation, then runs. This addresses the test review on #9078.
