### PR TITLE
[grafana] Project a completion date for the training run

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -45,7 +45,7 @@ GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
 GET /wandb/report/{train-loss,paloma-macro-loss,mfu}
                                                     public report runset and sampled history
 GET /wandb/history?run=&metric=&project=          one run's whole logged history for one metric
-GET /wandb/activity?run=&project=                 one run's active, wall, and downtime seconds
+GET /wandb/activity?run=&project=                 one run's active, wall, and downtime seconds, and projected finish
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
@@ -113,8 +113,10 @@ download: `_runtime` is the seconds the training process was alive, which
 across every attempt. Wall time runs from the run's creation to its last heartbeat,
 which makes the remainder downtime. `_runtime` advances only when an attempt logs, so
 the total holds still while a restart initializes rather than counting the wait as
-work. Without an explicit `project` the bridge searches `RUN_HISTORY_PROJECTS` in
-order and fails with a 404 when no project holds the run.
+work. The same request's `_step` and `run_progress`, with the first point of a
+sampled history, give the projected finish (see the training dashboard below). Without
+an explicit `project` the bridge searches `RUN_HISTORY_PROJECTS` in order and fails
+with a 404 when no project holds the run.
 
 k8s: the bridge polls the three production CoreWeave clusters' public CKS API servers with plain
 httpx GETs (paginated LISTs, bounded timeouts, one 429 retry) and a single org-wide CW
@@ -328,6 +330,21 @@ a `renameByRegex` transformation cannot, because it reads the raw field name and
 prefix is added later. The strip stands ten grid rows tall because the stat layout
 picks its tile grid from the aspect ratio, and twelve tiles in a shorter panel land in
 one unreadable row.
+
+Projected finish comes from `/wandb/activity` as well, extrapolating the same run-own
+accounting to the stop step: this run's steps since its first sampled one, over the wall
+clock since that sample, carried forward to the step the run stops at, which `_step /
+run_progress` recovers because Levanter logs progress as the global step over the stop
+step. Measuring from the first sample means a run resumed from a checkpoint is not
+credited with the steps it inherited, while every restart, checkpoint, and eval since
+then slows the rate. The averaging window is the run's whole life under this id, the
+steadiest one there is, and also the one that lags a throughput change longest; hero ids
+rotate at each restore, so in practice it is the time since the last one. The wall clock
+ends at the last heartbeat, so an outage in progress moves the date only once the run
+resumes. On 2026-09-10 `hero-ragged_a2a-nccl2307-ep-step81k`, resumed at step 81,740 and
+at 85,956 twenty-three hours later against a stop step of 390,244, projected 2026-11-18;
+a finelog query over the same day agreed to within a day, and crediting the run with the
+inherited steps would have put the finish three days out.
 
 The Attempts table carries the recent detail behind that total: one row per Iris
 execution over a fixed seven-day window, newest first, running or not, so the top row

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -152,7 +152,7 @@
       "id": 1,
       "type": "stat",
       "title": "Run status",
-      "description": "Where the run is right now. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile from the semantic Levanter metrics table. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any metric from the run, so the two together separate a stalled trainer from a broken metrics path. Active execution and active share come from W&B, not from finelog: W&B counts the seconds each attempt was alive and carries that count across every restart, thus the total covers the whole run and no Finelog eviction truncates it. Active share divides that total by the time from the creation of the run to its last heartbeat, so the remainder is downtime. The total holds while an attempt restarts, because W&B advances it when the attempt logs its first step. Progress efficiency is stricter: it divides the tokens this run has produced, cumulative tokens less the count it started from, by what it would have reached had it held its mean token rate with no downtime, so it also counts the throughput lost to checkpoints, evals, and steps redone after a rollback, not only downtime. Subtracting the starting count keeps a run resumed under a fresh id from a mid-schedule checkpoint from being credited the tokens it inherited.",
+      "description": "Where the run is right now, and when it reaches the end of its schedule. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile from the semantic Levanter metrics table. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any metric from the run, so the two together separate a stalled trainer from a broken metrics path. Active execution and active share come from W&B, not from finelog: W&B counts the seconds each attempt was alive and carries that count across every restart, thus the total covers the whole run and no Finelog eviction truncates it. Active share divides that total by the time from the creation of the run to its last heartbeat, so the remainder is downtime. The total holds while an attempt restarts, because W&B advances it when the attempt logs its first step. Progress efficiency is stricter: it divides the tokens this run has produced, cumulative tokens less the count it started from, by what it would have reached had it held its mean token rate with no downtime, so it also counts the throughput lost to checkpoints, evals, and steps redone after a rollback, not only downtime. Subtracting the starting count keeps a run resumed under a fresh id from a mid-schedule checkpoint from being credited the tokens it inherited. Projected finish extrapolates the same run-own accounting to the stop step: this run's steps since its first logged one, over the wall clock since then, carried forward to the step the run stops at, which is step over run_progress. Measuring from the first logged step means a run resumed from a checkpoint is not credited with the steps it inherited, while every restart, checkpoint, and eval since then slows the rate. The rate spans the run's whole life under this id -- the steadiest average there is, and the one that lags a throughput change longest. The wall clock ends at the last heartbeat, so an outage in progress moves the date only once the run resumes. Blank until the run has advanced past its first sample, and only for a run configured with a total step count, which is what makes it report run_progress.",
       "datasource": {
         "type": "datasource",
         "uid": "-- Mixed --"
@@ -382,6 +382,18 @@
                 "value": 1
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "projected finish"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              }
+            ]
           }
         ]
       },
@@ -514,6 +526,11 @@
             {
               "selector": "progress_efficiency",
               "text": "progress efficiency",
+              "type": "number"
+            },
+            {
+              "selector": "projected_finish_ms",
+              "text": "projected finish",
               "type": "number"
             }
           ]

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -15,6 +15,7 @@ retains only a window of them.
 import json
 from collections.abc import Callable
 from datetime import datetime
+from typing import NamedTuple
 
 import httpx
 from errors import UpstreamError
@@ -41,6 +42,16 @@ _RUN_HISTORY_SAMPLES = 2000
 # W&B's own step counter. Levanter logs every training metric through
 # `wandb.log(..., step=<training step>)`, so this column is the Levanter step.
 _STEP_KEY = "_step"
+# W&B's own wall-clock stamp on every logged point, in epoch seconds.
+_TIMESTAMP_KEY = "_timestamp"
+# Schedule progress, logged with every step by `levanter.callbacks.log_step_info`. The
+# grug trainers log the global step over the step the run stops at, so `_step` over
+# it is the stop step exactly. Levanter's own trainer logs examples through step + 1
+# over the schedule's total, which with a constant batch is (step + 1) over the stop
+# step: the recovered stop step is then low by a part in `_step`, and a batch ramp
+# makes it the example-weighted equivalent, which a step-rate extrapolation reads as
+# an approximation either way.
+_PROGRESS_KEY = "run_progress"
 
 # Reference speed for progress efficiency. `summaryMetrics` carries only the last
 # step's `throughput/tokens_per_second`, which a checkpoint or eval step drives
@@ -82,6 +93,29 @@ query RunActivity($entity: String!, $project: String!, $run: String!) {
 def _epoch_seconds(stamp: str) -> float:
     """Epoch seconds for a W&B RFC-3339 stamp, whose zone is always `Z`."""
     return datetime.fromisoformat(stamp.replace("Z", "+00:00")).timestamp()
+
+
+class _HistoryBaseline(NamedTuple):
+    reference_tps: float
+    tokens_baseline: float
+    first_step: float
+    first_timestamp: float
+
+
+def _projected_finish_ms(
+    *, step: float, progress: float, baseline: _HistoryBaseline, heartbeat_seconds: float
+) -> int | None:
+    """Epoch milliseconds when the run reaches `step / progress` at its own step rate.
+
+    The rate is `step` less the first sampled step, over the heartbeat less the first
+    sample's stamp. None until the run has advanced past its first sample.
+    """
+    steps_since_first = step - baseline.first_step
+    seconds_since_first = heartbeat_seconds - baseline.first_timestamp
+    if progress <= 0 or steps_since_first <= 0 or seconds_since_first <= 0:
+        return None
+    steps_remaining = step / progress - step
+    return round((heartbeat_seconds + steps_remaining * seconds_since_first / steps_since_first) * 1000)
 
 
 class WandbSource:
@@ -208,33 +242,43 @@ class WandbSource:
 
         return self._search_projects(run, project, read)
 
-    def _reference_rate_and_token_baseline(self, *, project: str, run: str) -> tuple[float, float] | tuple[None, None]:
-        """Mean per-step token rate and the tokens this W&B run inherited before its first step.
+    def _history_baseline(self, *, project: str, run: str) -> _HistoryBaseline | None:
+        """The reference token rate and where this W&B run's own work begins.
 
-        Both come from one sampled history. The mean of the rate is the reference speed
+        All from one sampled history. The mean of the rate is the reference speed
         -- a mean over history, not the summary's last-step value, so a checkpoint or
         eval step cannot skew it (see `_TPS_KEY`).
 
-        The baseline is the cumulative token count before this run's first step, which a
-        run resumed under a fresh id from a mid-schedule checkpoint carries in from the
-        checkpoint (levanter derives `total_tokens` from the global step). It is
-        reconstructed rather than read off the earliest sample, because that sample is
-        logged *after* the first step and so already includes one batch: with a constant
-        batch, `total_tokens` is proportional to `step + 1`, so the pre-first-step count
-        is `first_tokens * first_step / (first_step + 1)` -- zero for a run started from
-        scratch, the inherited count for a resumed one. `(None, None)` before the first
-        logged step.
+        The token baseline is the cumulative token count before this run's first step,
+        which a run resumed under a fresh id from a mid-schedule checkpoint carries in
+        from the checkpoint (levanter derives `total_tokens` from the global step). It
+        is reconstructed rather than read off the earliest sample, because that sample
+        is logged *after* the first step and so already includes one batch: with a
+        constant batch, `total_tokens` is proportional to `step + 1`, so the
+        pre-first-step count is `first_tokens * first_step / (first_step + 1)` -- zero
+        for a run started from scratch, the inherited count for a resumed one.
+
+        The first sample's step and stamp anchor the step rate: measured from there,
+        the steps a resumed run inherited and the time before its first step both drop
+        out. None before the first logged step.
         """
         points = self._sampled_points(
-            project=project, run=run, keys=(_STEP_KEY, _TOTAL_TOKENS_KEY, _TPS_KEY), samples=_TPS_SAMPLES
+            project=project,
+            run=run,
+            keys=(_STEP_KEY, _TIMESTAMP_KEY, _TOTAL_TOKENS_KEY, _TPS_KEY),
+            samples=_TPS_SAMPLES,
         )
         if not points:
-            return None, None
+            return None
         reference_tps = sum(point[_TPS_KEY] for point in points) / len(points)
         first = min(points, key=lambda point: point[_STEP_KEY])
         step, tokens = first[_STEP_KEY], first[_TOTAL_TOKENS_KEY]
-        baseline = tokens * step / (step + 1)
-        return reference_tps, baseline
+        return _HistoryBaseline(
+            reference_tps=reference_tps,
+            tokens_baseline=tokens * step / (step + 1),
+            first_step=step,
+            first_timestamp=first[_TIMESTAMP_KEY],
+        )
 
     def run_activity(self, run: str, *, project: str | None = None) -> list[dict]:
         """Return one row of active time, wall-clock time, and progress efficiency for `run`.
@@ -254,6 +298,16 @@ class WandbSource:
         share, which sees only downtime: this also counts the throughput lost to
         checkpoints, evals, and steps redone after a rollback. A run that has logged
         nothing yet reports nulls rather than zeros.
+
+        `projected_finish_ms` is the epoch millisecond at which the run reaches its
+        stop step at its own step rate: the steps between the first sampled point and
+        the summary's `_step`, over the wall clock between that point and the last
+        heartbeat, carried forward over `_step / run_progress - _step` steps to go.
+        Measuring from the first sample means a run resumed from a checkpoint is not
+        credited with the steps it inherited, and every restart, checkpoint, and eval
+        since then slows the rate. The window is the run's whole life under this id.
+        Null until the run has advanced past its first sample, and for a run that
+        does not log `run_progress`.
         """
 
         def read(candidate: str) -> list[dict] | None:
@@ -269,16 +323,27 @@ class WandbSource:
             summary = json.loads(run_data.get("summaryMetrics") or "{}")
             active = summary.get("_runtime")
             active = float(active) if isinstance(active, int | float) else None
-            wall = _epoch_seconds(run_data["heartbeatAt"]) - _epoch_seconds(run_data["createdAt"])
+            heartbeat_seconds = _epoch_seconds(run_data["heartbeatAt"])
+            wall = heartbeat_seconds - _epoch_seconds(run_data["createdAt"])
             tokens_seen = summary.get(_TOTAL_TOKENS_KEY)
             tokens_seen = float(tokens_seen) if isinstance(tokens_seen, int | float) else None
-            reference_tps, tokens_baseline = self._reference_rate_and_token_baseline(project=candidate, run=run)
-            tokens_since_start = (
-                tokens_seen - tokens_baseline if tokens_seen is not None and tokens_baseline is not None else None
-            )
+            baseline = self._history_baseline(project=candidate, run=run)
+            reference_tps = baseline.reference_tps if baseline else None
+            tokens_since_start = tokens_seen - baseline.tokens_baseline if tokens_seen is not None and baseline else None
             efficiency = (
                 tokens_since_start / (reference_tps * wall)
                 if tokens_since_start is not None and tokens_since_start > 0 and reference_tps and wall > 0
+                else None
+            )
+            step, progress = summary.get(_STEP_KEY), summary.get(_PROGRESS_KEY)
+            projected_finish_ms = (
+                _projected_finish_ms(
+                    step=step,
+                    progress=progress,
+                    baseline=baseline,
+                    heartbeat_seconds=heartbeat_seconds,
+                )
+                if baseline and isinstance(step, int | float) and isinstance(progress, int | float)
                 else None
             )
             return [
@@ -293,6 +358,7 @@ class WandbSource:
                     "active_share": active / wall if active is not None and wall > 0 else None,
                     "reference_tps": reference_tps,
                     "progress_efficiency": efficiency,
+                    "projected_finish_ms": projected_finish_ms,
                 }
             ]
 

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -1074,6 +1074,14 @@ def test_training_status_reads_whole_run_active_time_from_wandb():
     # Four days of wall clock, ninety hours of them running.
     assert (row["active_seconds"], row["active_share"]) == (324_000.0, 0.9375)
     assert {column["selector"] for column in target["columns"]} <= set(row)
+    # The projected finish rides on the same target as epoch milliseconds, which only the
+    # date unit makes readable in a stat tile.
+    finish = next(
+        override
+        for override in panel["fieldConfig"]["overrides"]
+        if override["matcher"]["options"] == "projected finish"
+    )
+    assert {field["id"]: field["value"] for field in finish["properties"]} == {"unit": "dateTimeAsIso"}
 
 
 def test_training_attempts_table_links_the_newest_attempt_to_iris():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -423,8 +423,18 @@ def test_wandb_run_activity_separates_active_time_from_downtime():
         "summaryMetrics": json.dumps({"_runtime": 90 * 3_600, "throughput/total_tokens": 1_038_000_000_000}),
     }
     tps_points = [
-        {"_step": 39_000, "throughput/total_tokens": 390_010_000_000, "throughput/tokens_per_second": 2_000_000},
-        {"_step": 78_001, "throughput/total_tokens": 780_020_000_000, "throughput/tokens_per_second": 3_000_000},
+        {
+            "_step": 39_000,
+            "_timestamp": 1_787_364_000,
+            "throughput/total_tokens": 390_010_000_000,
+            "throughput/tokens_per_second": 2_000_000,
+        },
+        {
+            "_step": 78_001,
+            "_timestamp": 1_787_700_000,
+            "throughput/total_tokens": 780_020_000_000,
+            "throughput/tokens_per_second": 3_000_000,
+        },
     ]
 
     (row,) = _wandb(_activity_handler("marin_moe", run, asked, tps_points)).run_activity("hero-run")
@@ -441,6 +451,7 @@ def test_wandb_run_activity_separates_active_time_from_downtime():
         "active_share": 0.9375,
         "reference_tps": 2_500_000.0,
         "progress_efficiency": pytest.approx(0.75),
+        "projected_finish_ms": None,  # no `_step` or `run_progress` in this summary
     }
 
 
@@ -457,7 +468,14 @@ def test_wandb_run_activity_credits_a_from_scratch_run_its_first_step():
         "heartbeatAt": "2026-08-21T05:46:40Z",
         "summaryMetrics": json.dumps({"_runtime": 90_000, "throughput/total_tokens": 100_000_000_000}),
     }
-    tps_points = [{"_step": 0, "throughput/total_tokens": 100_000_000_000, "throughput/tokens_per_second": 2_000_000}]
+    tps_points = [
+        {
+            "_step": 0,
+            "_timestamp": 1_787_364_000,
+            "throughput/total_tokens": 100_000_000_000,
+            "throughput/tokens_per_second": 2_000_000,
+        }
+    ]
 
     (row,) = _wandb(_activity_handler("marin_moe", run, asked, tps_points)).run_activity("hero-run")
 
@@ -483,7 +501,48 @@ def test_wandb_run_activity_reports_no_active_time_before_the_first_log():
     assert asked == ["marin_moe", "marin"]
     assert (row["active_seconds"], row["downtime_seconds"], row["active_share"]) == (None, None, None)
     assert row["wall_seconds"] == 600.0
-    assert (row["reference_tps"], row["progress_efficiency"]) == (None, None)
+    assert (row["reference_tps"], row["progress_efficiency"], row["projected_finish_ms"]) == (None, None, None)
+
+
+def test_wandb_run_activity_projects_the_finish_from_this_runs_own_steps():
+    # A completion date extrapolates this run's own step rate, measured from its first
+    # sampled step to the summary's last over the wall clock between them, to the stop step
+    # that `_step / run_progress` recovers. This run is a fresh id resumed at step 81,000 that
+    # has done 4,320 steps in the 24 hours since its first sample: 20 s a step, and 304,680
+    # steps to go on a 390,000-step schedule is another 70.5 days. Crediting it with the
+    # 85,320 steps of the global counter over the same day would put the finish 3.6 days
+    # out. The half hour between creation and the first sample is startup, and does not
+    # count against the rate.
+    asked: list[str] = []
+    first_sample = datetime(2026, 9, 9, 22, 30, tzinfo=UTC)
+    heartbeat = datetime(2026, 9, 10, 22, 30, tzinfo=UTC)
+    run = {
+        "state": "running",
+        "createdAt": "2026-09-09T22:00:00Z",
+        "heartbeatAt": "2026-09-10T22:30:00Z",
+        "summaryMetrics": json.dumps(
+            {"_runtime": 86_000, "_step": 85_320, "run_progress": 85_320 / 390_000, "throughput/total_tokens": 1.0}
+        ),
+    }
+    tps_points = [
+        {
+            "_step": 81_000,
+            "_timestamp": first_sample.timestamp(),
+            "throughput/total_tokens": 1.0,
+            "throughput/tokens_per_second": 1.0,
+        }
+    ]
+
+    (row,) = _wandb(_activity_handler("marin_moe", run, asked, tps_points)).run_activity("hero-run")
+
+    projected = datetime.fromtimestamp(row["projected_finish_ms"] / 1000, UTC)
+    assert projected == heartbeat + timedelta(seconds=304_680 * 20)
+    assert projected == datetime(2026, 11, 20, 11, 10, tzinfo=UTC)
+
+    # Before the run advances past its first sample there is no rate, and so no date.
+    run["summaryMetrics"] = json.dumps({"_step": 81_000, "run_progress": 81_000 / 390_000})
+    (row,) = _wandb(_activity_handler("marin_moe", run, asked, tps_points)).run_activity("hero-run")
+    assert row["projected_finish_ms"] is None
 
 
 def test_wandb_run_activity_fails_loud_when_no_project_has_the_run():


### PR DESCRIPTION
Add a projected finish tile to the Run status strip, from the W&B activity endpoint that already serves its whole-run totals.

- The bridge extrapolates this run's own step rate — steps since its first sampled point, over the wall clock since then — to the stop step, `_step / run_progress`, since the grug trainers log progress as global step over stop step.
- Measuring from the first sample, a run resumed from a checkpoint is not credited with the steps it inherited; every restart, checkpoint, and eval since then slows the rate.
- The window is the run's whole life under its W&B id: the steadiest average available, and the one that lags a throughput change longest. Hero ids rotate at each restore, so that is time since the last.
- Wall clock ends at the last heartbeat, so an outage in progress moves the date once the run resumes.
- Null until the run advances past its first sample, or if it does not log `run_progress`.
- The hero, resumed at step 81,740 and at 85,956 a day later with a stop step of 390,244, projects 2026-11-18; crediting the inherited steps would put it three days out.