### PR TITLE
[iris] Inspect Zephyr stages with list and graph views

### DIFF
--- a/infra/grafana/dashboards/zephyr.json
+++ b/infra/grafana/dashboards/zephyr.json
@@ -1,0 +1,527 @@
+{
+  "uid": "marin-zephyr-shuffle",
+  "title": "Zephyr shuffle inputs",
+  "description": "Reducer input diagnostics with coordinator target announcements and incremental measurements. Null sizes are unreported; numeric zero means measured empty.",
+  "tags": [
+    "marin",
+    "zephyr"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "execution_id",
+        "label": "Execution",
+        "type": "query",
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "finelog-marin"
+        },
+        "query": {
+          "queryType": "infinity",
+          "refId": "variable-execution_id",
+          "infinityQuery": {
+            "refId": "variable-execution_id",
+            "type": "json",
+            "source": "url",
+            "format": "table",
+            "parser": "backend",
+            "url": "/query",
+            "url_options": {
+              "method": "GET",
+              "params": [
+                {
+                  "key": "sql",
+                  "value": "SELECT DISTINCT execution_id AS value FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} ORDER BY value LIMIT 1000"
+                },
+                {
+                  "key": "from",
+                  "value": "${__from}"
+                },
+                {
+                  "key": "to",
+                  "value": "${__to}"
+                }
+              ]
+            },
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "stage_name",
+        "label": "Reduce stage",
+        "type": "query",
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "finelog-marin"
+        },
+        "query": {
+          "queryType": "infinity",
+          "refId": "variable-stage_name",
+          "infinityQuery": {
+            "refId": "variable-stage_name",
+            "type": "json",
+            "source": "url",
+            "format": "table",
+            "parser": "backend",
+            "url": "/query",
+            "url_options": {
+              "method": "GET",
+              "params": [
+                {
+                  "key": "sql",
+                  "value": "SELECT DISTINCT stage_name AS value FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} AND execution_id = ${execution_id:sqlstring} ORDER BY value"
+                },
+                {
+                  "key": "from",
+                  "value": "${__from}"
+                },
+                {
+                  "key": "to",
+                  "value": "${__to}"
+                }
+              ]
+            },
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "Reading these charts",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 5
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Select one execution and its **reduce stage**. The coordinator announces each target with null sizes. Reducers fill in measurements after reading mapper metadata; transport can delay publication. **Coverage is measurement coverage, not task completion.** UNREPORTED targets may be queued, loading, or missing/delayed telemetry. The target table lists persisted announcements and measurements. Incomplete telemetry can temporarily omit IDs; the offline HTML report also infers missing IDs from the announced target count. Histograms and summaries exclude null sizes; numeric zero means measured empty. Queries prefer the greatest attempt, then a measurement over a placeholder, then timestamp and ingestion sequence. This does not establish which attempt succeeded. Encoded bytes exclude Parquet overhead and do not measure RAM or network traffic."
+      }
+    },
+    {
+      "id": 2,
+      "type": "barchart",
+      "title": "Observed input rows by target reducer",
+      "description": "Reported targets sorted largest first, including reported zeros. Unreported targets are excluded, never filled with zero.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 12,
+        "h": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "axisPlacement": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH snapshots AS (SELECT target_shard, num_targets, input_rows, payload_bytes, num_sources, attempt, ROW_NUMBER() OVER (PARTITION BY target_shard ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS sample_rank FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} AND execution_id = ${execution_id:sqlstring} AND stage_name = ${stage_name:sqlstring}) SELECT CAST(target_shard AS VARCHAR) AS target_reducer, input_rows FROM snapshots WHERE sample_rank = 1 AND input_rows IS NOT NULL ORDER BY input_rows DESC, target_shard"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "target_reducer",
+              "text": "target_reducer",
+              "type": "string"
+            },
+            {
+              "selector": "input_rows",
+              "text": "input_rows",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "barchart",
+      "title": "Observed encoded payload bytes by target reducer",
+      "description": "Reported targets sorted largest first, including reported zeros. Unreported targets are excluded, never filled with zero.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 9,
+        "w": 12,
+        "h": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "axisPlacement": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH snapshots AS (SELECT target_shard, num_targets, input_rows, payload_bytes, num_sources, attempt, ROW_NUMBER() OVER (PARTITION BY target_shard ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS sample_rank FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} AND execution_id = ${execution_id:sqlstring} AND stage_name = ${stage_name:sqlstring}) SELECT CAST(target_shard AS VARCHAR) AS target_reducer, payload_bytes FROM snapshots WHERE sample_rank = 1 AND input_rows IS NOT NULL ORDER BY payload_bytes DESC, target_shard"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "target_reducer",
+              "text": "target_reducer",
+              "type": "string"
+            },
+            {
+              "selector": "payload_bytes",
+              "text": "payload_bytes",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Telemetry coverage (not task completion)",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "noValue": "Unknown"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH snapshots AS (SELECT target_shard, num_targets, input_rows, payload_bytes, num_sources, attempt, ROW_NUMBER() OVER (PARTITION BY target_shard ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS sample_rank FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} AND execution_id = ${execution_id:sqlstring} AND stage_name = ${stage_name:sqlstring}) SELECT COUNT(input_rows) AS observed_targets, MAX(num_targets) AS expected_targets, MAX(num_targets) - COUNT(input_rows) AS unreported_targets, SUM(CASE WHEN input_rows = 0 THEN 1 ELSE 0 END) AS reported_empty_targets, SUM(input_rows) AS observed_input_rows FROM snapshots WHERE sample_rank = 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "observed_targets",
+              "text": "observed targets",
+              "type": "number"
+            },
+            {
+              "selector": "expected_targets",
+              "text": "expected targets",
+              "type": "number"
+            },
+            {
+              "selector": "unreported_targets",
+              "text": "unreported targets",
+              "type": "number"
+            },
+            {
+              "selector": "reported_empty_targets",
+              "text": "reported empty targets",
+              "type": "number"
+            },
+            {
+              "selector": "observed_input_rows",
+              "text": "observed input rows",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "description": "Counts numeric measurements only. Target announcements establish the expected count even before a reducer reports. No records at all leaves the expected count unknown."
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Target reducers: measured or UNREPORTED",
+      "description": "Shows persisted target announcements and measurements. UNREPORTED means null sizes. Missing announcements can temporarily omit IDs if telemetry delivery is incomplete. Attempt is shown only for measurements.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 24,
+        "h": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "UNREPORTED",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "UNREPORTED": {
+                        "text": "UNREPORTED",
+                        "color": "gray"
+                      },
+                      "EMPTY": {
+                        "text": "EMPTY",
+                        "color": "blue"
+                      },
+                      "REPORTED": {
+                        "text": "REPORTED",
+                        "color": "green"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH snapshots AS (SELECT target_shard, num_targets, input_rows, payload_bytes, num_sources, attempt, ROW_NUMBER() OVER (PARTITION BY target_shard ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS sample_rank FROM \"zephyr.shuffle\" WHERE ts >= {{from}} AND ts < {{to}} AND execution_id = ${execution_id:sqlstring} AND stage_name = ${stage_name:sqlstring}) SELECT target_shard, CASE WHEN input_rows IS NULL THEN 'UNREPORTED' WHEN input_rows = 0 THEN 'EMPTY' ELSE 'REPORTED' END AS status, CASE WHEN input_rows IS NOT NULL THEN attempt END AS attempt, input_rows, payload_bytes, num_sources FROM snapshots WHERE sample_rank = 1 ORDER BY target_shard"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "target_shard",
+              "text": "target shard",
+              "type": "number"
+            },
+            {
+              "selector": "status",
+              "text": "status",
+              "type": "string"
+            },
+            {
+              "selector": "attempt",
+              "text": "attempt",
+              "type": "number"
+            },
+            {
+              "selector": "input_rows",
+              "text": "input rows",
+              "type": "number"
+            },
+            {
+              "selector": "payload_bytes",
+              "text": "payload bytes",
+              "type": "number"
+            },
+            {
+              "selector": "num_sources",
+              "text": "num sources",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -328,6 +328,25 @@ iris --cluster=marin cluster dashboard --port 8080
 # Local clusters: dashboard is at the URL printed by `cluster start --local`
 ```
 
+For Zephyr jobs, the job detail page shows an execution selector and List/Graph
+tabs when a `zephyr.execution` plan record is available in Finelog. Join plans
+default to Graph; other plans default to List. A tab choice is saved in the
+browser and overrides that default. Switching tabs preserves the selected
+stage and its details. The list numbers the steps in each join's right-input
+chain; the graph shows their data dependencies.
+
+Select a stage to inspect its completion report and reducer input sizes.
+Reducer rows are ordered by payload size and paged in groups of 20.
+Null or absent measurements count as UNREPORTED; they do not indicate task
+state. Each reducer also shows its latest worker-task status and payload size
+relative to the stage median. Worker status has no attempt identifier, so it
+can describe a different attempt from the size measurement. Follow the
+coordinator task link for live progress.
+
+This requires both the updated Zephyr code in the job and an updated Iris
+dashboard build. Runs without a persisted plan record do not appear in the
+execution selector. Telemetry delivery is best-effort.
+
 ### Job Management
 
 ```bash

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -27,6 +27,7 @@ import MarkdownRenderer from '@/components/shared/MarkdownRenderer.vue'
 import EndpointLink from '@/components/shared/EndpointLink.vue'
 import ClusterLink from '@/components/shared/ClusterLink.vue'
 import { useMediaQuery } from '@/composables/useMediaQuery'
+import ZephyrExecutionPanel from './ZephyrExecutionPanel.vue'
 
 // Tailwind's `sm` breakpoint is 640px. Cards on mobile, table on desktop.
 // v-if-switched (not CSS-hidden) so only one variant is in the DOM.
@@ -1262,6 +1263,8 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
           </div>
         </div>
       </details>
+
+      <ZephyrExecutionPanel :key="props.jobId" :job-id="props.jobId" :start-ms="timestampMs(job.submittedAt)" />
 
       <!-- Child Jobs -->
       <div v-if="flattenedChildJobs.length > 0" class="mb-6">

--- a/lib/iris/dashboard/src/components/controller/ZephyrExecutionGraph.vue
+++ b/lib/iris/dashboard/src/components/controller/ZephyrExecutionGraph.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import { stageLayout, STAGE_NODE_WIDTH, STAGE_NODE_HEIGHT, type ExecutionStage } from '@/utils/zephyr'
+
+const props = defineProps<{
+  stages: ExecutionStage[]
+  selectedStage: string
+  statuses: Record<string, string>
+}>()
+const emit = defineEmits<{ select: [stage: ExecutionStage] }>()
+const markerId = useId()
+const graph = computed(() => {
+  try {
+    return { layout: stageLayout(props.stages), error: '' }
+  } catch (error) {
+    return { layout: stageLayout([]), error: `Cannot draw stage dependencies: ${String(error)}` }
+  }
+})
+</script>
+
+<template>
+  <p v-if="graph.error" role="alert" class="text-red-500">{{ graph.error }}</p>
+  <div v-else class="overflow-x-auto rounded bg-surface-sunken p-2" aria-label="Stage dependencies">
+    <div class="relative" :style="{ width: `${graph.layout.width}px`, height: `${graph.layout.height}px` }">
+      <svg class="pointer-events-none absolute inset-0 text-text-muted" :width="graph.layout.width" :height="graph.layout.height" aria-hidden="true">
+        <defs><marker :id="markerId" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0 L7 3.5 L0 7" fill="currentColor" /></marker></defs>
+        <path v-for="edge in graph.layout.edges" :key="edge.key"
+          :d="`M${edge.x1},${edge.y1} C${edge.x1 + 16},${edge.y1} ${edge.x2 - 16},${edge.y2} ${edge.x2},${edge.y2}`"
+          fill="none" stroke="currentColor" stroke-width="1.5" :marker-end="`url(#${markerId})`" />
+      </svg>
+      <button v-for="node in graph.layout.nodes" :key="node.stage_name" :title="node.stage_name"
+        :aria-pressed="selectedStage === node.stage_name" @click="emit('select', node)"
+        class="absolute flex flex-col justify-center gap-1 rounded-lg border bg-surface px-3 text-left focus-visible:outline-2 focus-visible:outline-accent"
+        :class="selectedStage === node.stage_name ? 'border-accent ring-1 ring-accent' : 'border-surface-border hover:border-text-muted'"
+        :style="{ left: `${node.x}px`, top: `${node.y}px`, width: `${STAGE_NODE_WIDTH}px`, height: `${STAGE_NODE_HEIGHT}px` }">
+        <span class="w-full truncate text-xs text-text-muted">{{ node.stage_name }}</span>
+        <span class="w-full truncate font-semibold text-text">{{ node.label }}</span>
+        <span class="text-xs" :class="statuses[node.stage_name] === 'Failed' ? 'text-red-500' : 'text-text-secondary'">{{ statuses[node.stage_name] }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/lib/iris/dashboard/src/components/controller/ZephyrExecutionPanel.vue
+++ b/lib/iris/dashboard/src/components/controller/ZephyrExecutionPanel.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useLogServerStatsRpc } from '@/composables/useRpc'
+import { DEFAULT_REFRESH_MS, useAutoRefresh } from '@/composables/useAutoRefresh'
+import { decodeArrowIpc } from '@/utils/arrow'
+import { executionPlansSql, EXECUTION_LIMIT, type ExecutionPlan } from '@/utils/zephyr'
+import ZephyrExecutionStages from './ZephyrExecutionStages.vue'
+
+const props = defineProps<{ jobId: string; startMs: number }>()
+const selectedExecution = ref('')
+const namespaces = useLogServerStatsRpc<{ namespaces?: { namespace: string }[] }>('ListNamespaces')
+const plans = useLogServerStatsRpc<{ arrowIpc?: string }>('Query', () => ({
+  sql: executionPlansSql(props.jobId, props.startMs),
+}))
+const available = computed(() => (namespaces.data.value?.namespaces ?? []).map(item => item.namespace))
+const executions = computed(() => decodeArrowIpc(plans.data.value?.arrowIpc).rows as unknown as ExecutionPlan[])
+const execution = computed(() => executions.value.find(item => item.execution_id === selectedExecution.value))
+const error = computed(() => namespaces.error.value ?? plans.error.value)
+
+async function refresh() {
+  if (!props.startMs || namespaces.loading.value || plans.loading.value) return
+  await namespaces.refresh()
+  if (!available.value.includes('zephyr.execution')) return
+  await plans.refresh()
+  if (!execution.value) selectedExecution.value = executions.value[0]?.execution_id ?? ''
+}
+
+onMounted(refresh)
+useAutoRefresh(refresh, DEFAULT_REFRESH_MS)
+</script>
+
+<template>
+  <section v-if="executions.length || error" class="mb-6 rounded-lg border border-surface-border bg-surface p-4" aria-label="Zephyr executions">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <h3 class="text-sm font-semibold uppercase tracking-wider text-text-secondary">Zephyr executions</h3>
+      <button class="text-sm text-accent hover:underline" :disabled="plans.loading.value" @click="refresh">Refresh executions</button>
+    </div>
+    <p v-if="error" role="alert" class="mt-3 text-sm text-red-500">Zephyr telemetry unavailable: {{ error }}</p>
+    <template v-if="executions.length">
+      <label class="mt-3 flex flex-wrap items-center gap-3 text-sm text-text-secondary">
+        Execution
+        <select v-model="selectedExecution" class="rounded border border-surface-border bg-surface-sunken px-2 py-1 font-mono text-text">
+          <option v-for="item in executions" :key="item.execution_id" :value="item.execution_id">{{ item.execution_id }}</option>
+        </select>
+        <span v-if="executions.length === EXECUTION_LIMIT">Newest {{ EXECUTION_LIMIT }} executions</span>
+      </label>
+      <ZephyrExecutionStages v-if="execution" :key="execution.execution_id" :execution="execution" :start-ms="startMs" :namespaces="available" />
+    </template>
+  </section>
+</template>

--- a/lib/iris/dashboard/src/components/controller/ZephyrExecutionStages.vue
+++ b/lib/iris/dashboard/src/components/controller/ZephyrExecutionStages.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useLogServerStatsRpc } from '@/composables/useRpc'
+import { DEFAULT_REFRESH_MS, useAutoRefresh } from '@/composables/useAutoRefresh'
+import { decodeArrowIpc } from '@/utils/arrow'
+import { formatBytes } from '@/utils/formatting'
+import ZephyrExecutionGraph from './ZephyrExecutionGraph.vue'
+import {
+  stageStatsSql, reducerStatsSql, reducerTaskStatsSql, shuffleSummarySql, relativePayload, REDUCER_PAGE_SIZE,
+  stageView, joinStep, STAGE_VIEWS, STAGE_VIEW_STORAGE_KEY, type StageView,
+  type ExecutionPlan, type ExecutionStage, type StageStat, type ReducerStat, type ShuffleSummary,
+} from '@/utils/zephyr'
+
+const props = defineProps<{ execution: ExecutionPlan; startMs: number; namespaces: string[] }>()
+const selectedStage = ref('')
+const page = ref(0)
+const savedView = ref<string | null>(null)
+try {
+  savedView.value = localStorage.getItem(STAGE_VIEW_STORAGE_KEY)
+} catch (error) {
+  console.warn('Cannot read the saved Zephyr stage view; using the plan default.', error)
+}
+const plan = computed(() => {
+  try {
+    const nodes = JSON.parse(props.execution.stages_json) as ExecutionStage[]
+    if (!Array.isArray(nodes)) throw new Error('Expected a stage list')
+    return { nodes, error: '' }
+  } catch (error) {
+    return { nodes: [] as ExecutionStage[], error: `Cannot read execution plan: ${String(error)}` }
+  }
+})
+const selected = computed(() => plan.value.nodes.find(node => node.stage_name === selectedStage.value))
+const view = computed(() => stageView(plan.value.nodes, savedView.value))
+const stageStatuses = computed(() => Object.fromEntries(plan.value.nodes.map(stage => [stage.stage_name, stageStatus(stage)])))
+const stages = useLogServerStatsRpc<{ arrowIpc?: string }>('Query', () => ({
+  sql: stageStatsSql(props.execution.execution_id, props.startMs),
+}))
+const reducers = useLogServerStatsRpc<{ arrowIpc?: string }>('Query', () => ({
+  sql: (props.namespaces.includes('zephyr.worker') ? reducerTaskStatsSql : reducerStatsSql)(
+    props.execution.execution_id, selectedStage.value, props.startMs, page.value,
+  ),
+}))
+const summary = useLogServerStatsRpc<{ arrowIpc?: string }>('Query', () => ({
+  sql: shuffleSummarySql(props.execution.execution_id, selectedStage.value, props.startMs),
+}))
+const stageStats = computed(() => decodeArrowIpc(stages.data.value?.arrowIpc).rows as unknown as StageStat[])
+const selectedStat = computed(() => stageStats.value.find(item => item.stage_name === selectedStage.value))
+const targets = computed(() => decodeArrowIpc(reducers.data.value?.arrowIpc).rows as unknown as ReducerStat[])
+const totals = computed(() => (decodeArrowIpc(summary.data.value?.arrowIpc).rows as unknown as ShuffleSummary[])[0])
+const error = computed(() => plan.value.error || stages.error.value || reducers.error.value || summary.error.value)
+const coordinatorLink = computed(() => `/job/${encodeURIComponent(props.execution.coordinator_job_id)}/task/${encodeURIComponent(props.execution.coordinator_job_id + '/0')}`)
+
+function stageStatus(stage: ExecutionStage): string {
+  if (stage.stage_type === 'reshard') return 'Reference-only · no worker task'
+  const stat = stageStats.value.find(item => item.stage_name === stage.stage_name)
+  if (stat?.status === 'END') return 'Completed'
+  if (stat?.status === 'FAILED') return 'Failed'
+  return 'No completion report'
+}
+
+function branchLabel(stage: ExecutionStage): string {
+  const branch = joinStep(stage, plan.value.nodes)
+  return branch ? `Right input of stage${branch.parentStage} · step ${branch.step} of ${branch.total}` : ''
+}
+
+function selectView(next: StageView) {
+  savedView.value = next
+  try {
+    localStorage.setItem(STAGE_VIEW_STORAGE_KEY, next)
+  } catch (error) {
+    console.warn('Cannot save the Zephyr stage view; keeping it for this execution.', error)
+  }
+}
+
+function handleTabKey(event: KeyboardEvent) {
+  if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+  event.preventDefault()
+  const next = event.key === 'Home' ? 'List' : event.key === 'End' ? 'Graph' : view.value === 'List' ? 'Graph' : 'List'
+  selectView(next)
+  document.getElementById(`${props.execution.execution_id}-${next}-tab`)?.focus()
+}
+
+async function refreshReducers() {
+  if (!selected.value?.has_reduce || !props.namespaces.includes('zephyr.shuffle')) return
+  await Promise.all([reducers.refresh(), summary.refresh()])
+}
+
+async function refresh() {
+  if (stages.loading.value || reducers.loading.value || summary.loading.value) return
+  await Promise.all([
+    props.namespaces.includes('zephyr.stage') ? stages.refresh() : Promise.resolve(),
+    refreshReducers(),
+  ])
+}
+
+watch([selectedStage, page], () => {
+  reducers.data.value = null
+  summary.data.value = null
+  reducers.error.value = null
+  summary.error.value = null
+  void refreshReducers()
+})
+
+function selectStage(stage: ExecutionStage) {
+  page.value = 0
+  selectedStage.value = stage.stage_name
+}
+
+selectedStage.value = plan.value.nodes.find(stage => stage.stage_type !== 'reshard')?.stage_name ?? ''
+onMounted(refresh)
+useAutoRefresh(refresh, DEFAULT_REFRESH_MS)
+</script>
+
+<template>
+  <div class="mt-3 text-sm">
+    <div role="tablist" aria-label="Stage view" class="mb-3 flex gap-1 border-b border-surface-border" @keydown="handleTabKey">
+      <button v-for="mode in STAGE_VIEWS" :key="mode" :id="`${execution.execution_id}-${mode}-tab`"
+        role="tab" :aria-selected="view === mode" :tabindex="view === mode ? 0 : -1"
+        :aria-controls="`${execution.execution_id}-stage-picker`" @click="selectView(mode)"
+        class="border-b-2 px-4 py-2 font-medium focus-visible:outline-2 focus-visible:outline-accent"
+        :class="view === mode ? 'border-accent text-accent' : 'border-transparent text-text-secondary hover:text-text'">
+        {{ mode }}
+      </button>
+    </div>
+    <div class="flex flex-wrap items-center justify-between gap-2 text-text-muted">
+      <p v-if="view === 'List'">Stages in dependency order. Each indented block is one chain feeding the right input of a join.</p>
+      <p v-else>Arrows show data dependencies. Reshard stages can change task counts; the graph does not show scheduling concurrency.</p>
+      <RouterLink v-if="execution.coordinator_job_id" :to="coordinatorLink" class="text-accent hover:underline">Coordinator task / live progress →</RouterLink>
+    </div>
+    <p v-if="error" role="alert" class="mt-3 text-red-500">{{ error }}</p>
+    <div class="mt-4 grid items-start gap-5" :class="view === 'List' ? 'xl:grid-cols-[260px_minmax(0,1fr)]' : ''">
+      <div role="tabpanel" :id="`${execution.execution_id}-stage-picker`" :aria-labelledby="`${execution.execution_id}-${view}-tab`" class="min-w-0">
+      <ZephyrExecutionGraph v-if="view === 'Graph'" :stages="plan.nodes" :selected-stage="selectedStage" :statuses="stageStatuses" @select="selectStage" />
+      <ol v-else class="space-y-2" aria-label="Execution stages">
+        <li v-for="node in plan.nodes" :key="node.stage_name" :class="branchLabel(node) ? 'ml-5 border-l-2 border-surface-border pl-3' : ''">
+          <div v-if="node.stage_type === 'reshard'" class="border-y border-dashed border-surface-border px-3 py-2 text-xs text-text-muted">
+            {{ node.stage_name }} · references only
+          </div>
+          <button v-else :title="node.stage_name" :aria-pressed="selectedStage === node.stage_name" @click="selectStage(node)"
+            class="flex w-full flex-col gap-1 rounded-lg border bg-surface px-3 py-3 text-left focus-visible:outline-2 focus-visible:outline-accent"
+            :class="selectedStage === node.stage_name ? 'border-accent bg-accent-subtle ring-1 ring-accent' : 'border-surface-border hover:border-text-muted'">
+            <span v-if="branchLabel(node)" class="text-xs text-text-secondary">{{ branchLabel(node) }}</span>
+            <span class="w-full truncate text-xs text-text-muted">{{ node.stage_name }}</span>
+            <span class="font-semibold text-text">{{ node.label }}</span>
+            <span class="text-xs" :class="stageStatus(node) === 'Failed' ? 'text-red-500' : 'text-text-secondary'">{{ stageStatus(node) }}</span>
+          </button>
+        </li>
+      </ol>
+      </div>
+      <p v-if="!plan.nodes.length" class="text-text-muted">This execution has no planned stages.</p>
+      <div v-if="selected" class="min-w-0">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h4 class="font-mono font-semibold text-text">{{ selected.stage_name }}</h4>
+          <button class="text-accent hover:underline" :disabled="stages.loading.value || reducers.loading.value" @click="refresh">Refresh stage</button>
+        </div>
+        <p v-if="selectedStat" class="mt-2 text-text-secondary">
+          {{ selectedStat.elapsed.toFixed(2) }} s · {{ selectedStat.total_shards }} tasks · {{ selectedStat.items.toLocaleString() }} output items · {{ formatBytes(selectedStat.mem_peak_bytes_max) }} peak task RAM
+        </p>
+        <p v-else class="mt-2 text-text-muted">{{ stageStatus(selected) }}. Completion telemetry can be delayed or unavailable.</p>
+        <template v-if="selected.has_reduce">
+          <p class="mt-3 text-text-muted">Task status is the latest worker report. Sizes arrive independently; UNREPORTED means no size measurement and zero means an observed empty target. Worker status has no retry-attempt identifier.</p>
+          <p v-if="summary.loading.value && !totals" class="mt-3 text-text-muted">Loading reducer measurements…</p>
+          <template v-if="totals && totals.expected_targets !== null">
+            <div class="my-3 flex flex-wrap gap-x-8 gap-y-2 text-text-secondary">
+              <span><strong class="text-text">{{ totals.observed_targets }} / {{ totals.expected_targets }}</strong> measured</span>
+              <span><strong class="text-text">{{ totals.expected_targets - totals.observed_targets }}</strong> UNREPORTED</span>
+              <span>Median / max rows: <strong class="text-text">{{ totals.median_rows?.toLocaleString() ?? '—' }} / {{ totals.max_rows?.toLocaleString() ?? '—' }}</strong></span>
+              <span>Median / max payload: <strong class="text-text">{{ totals.median_bytes === null ? '—' : formatBytes(totals.median_bytes) }} / {{ totals.max_bytes === null ? '—' : formatBytes(totals.max_bytes) }}</strong></span>
+            </div>
+            <p class="mb-2 text-xs text-text-muted">Largest encoded payloads first. Only persisted targets appear below; undelivered placeholders are included in UNREPORTED above.</p>
+            <div class="overflow-x-auto">
+              <table class="w-full text-left text-sm">
+                <thead class="sticky top-0 border-b border-surface-border bg-surface text-text-muted"><tr><th class="py-2 pr-3">Reducer</th><th class="pr-3">Task status</th><th class="pr-3">Input rows</th><th class="pr-3">Encoded payload</th><th class="pr-3">Payload / median</th><th class="pr-3">Mapper outputs</th><th>Size attempt</th></tr></thead>
+                <tbody>
+                  <tr v-for="target in targets" :key="target.target_shard" class="border-b border-surface-border text-text-secondary">
+                    <td class="py-2 font-mono">{{ target.target_shard }}</td>
+                    <td class="pr-3" :class="target.task_status === 'FAILED' ? 'text-red-500' : ''">{{ target.task_status ?? 'No report' }}</td>
+                    <td class="py-2 pr-4">{{ target.input_rows?.toLocaleString() ?? 'UNREPORTED' }}</td>
+                    <td class="py-2 pr-4">{{ target.payload_bytes === null ? 'UNREPORTED' : formatBytes(target.payload_bytes) }}</td>
+                    <td class="pr-3 font-mono font-semibold text-text">{{ relativePayload(target.payload_bytes, totals.median_bytes) }}</td>
+                    <td>{{ target.num_sources ?? '—' }}</td><td>{{ target.attempt }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="mt-3 flex items-center gap-4 text-text-secondary">
+              <button :disabled="page === 0 || reducers.loading.value" class="text-accent disabled:opacity-40" @click="page--">← Previous</button>
+              <span>{{ page * REDUCER_PAGE_SIZE + 1 }}–{{ Math.min((page + 1) * REDUCER_PAGE_SIZE, totals.persisted_targets) }} of {{ totals.persisted_targets }} persisted targets</span>
+              <button :disabled="(page + 1) * REDUCER_PAGE_SIZE >= totals.persisted_targets || reducers.loading.value" class="text-accent disabled:opacity-40" @click="page++">Next →</button>
+            </div>
+          </template>
+          <p v-else-if="!summary.loading.value" class="mt-3 text-text-muted">No reducer reports yet. Target count is unavailable until a placeholder or measurement arrives.</p>
+        </template>
+        <p v-else class="mt-3 text-text-muted">This stage has no reducer inputs.</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/lib/iris/dashboard/src/utils/taskStatus.ts
+++ b/lib/iris/dashboard/src/utils/taskStatus.ts
@@ -10,7 +10,7 @@ export const TASK_STATUS_NAMESPACE = 'iris.task_status'
 // Workers must re-emit faster than this window or their tasks will fall off the UI.
 export const TASK_STATUS_RETENTION_INTERVAL = "INTERVAL '10 minutes'"
 
-function sqlString(value: string): string {
+export function sqlString(value: string): string {
   return `'${value.replace(/'/g, "''")}'`
 }
 

--- a/lib/iris/dashboard/src/utils/zephyr.ts
+++ b/lib/iris/dashboard/src/utils/zephyr.ts
@@ -1,0 +1,173 @@
+import { sqlString } from './taskStatus.ts'
+
+export const REDUCER_PAGE_SIZE = 20
+export const EXECUTION_LIMIT = 100
+export const STAGE_NODE_WIDTH = 224
+export const STAGE_NODE_HEIGHT = 96
+const STAGE_COLUMN_GAP = 32
+const STAGE_ROW_GAP = 28
+const STAGE_PADDING = 8
+
+export const STAGE_VIEW_STORAGE_KEY = 'iris-zephyr-stage-view'
+export const STAGE_VIEWS = ['List', 'Graph'] as const
+export type StageView = typeof STAGE_VIEWS[number]
+
+export interface ExecutionStage {
+  stage_name: string
+  label: string
+  stage_type: string
+  has_reduce: boolean
+  dependencies: string[]
+}
+
+export function stageLayout(stages: ExecutionStage[]) {
+  const nodes: Array<ExecutionStage & { x: number; y: number }> = []
+  const columns = new Map<string, number>()
+  const lanes = new Map<string, number>()
+  let nextLane = 0
+  for (const stage of stages) {
+    const column = stage.dependencies.length
+      ? Math.max(...stage.dependencies.map(dependency => {
+        const parent = columns.get(dependency)
+        if (parent === undefined) throw new Error(`Missing or unordered stage dependency: ${dependency}`)
+        return parent + 1
+      })) : 0
+    const row = stage.dependencies.length ? lanes.get(stage.dependencies[0])! : nextLane++
+    columns.set(stage.stage_name, column)
+    lanes.set(stage.stage_name, row)
+    nodes.push({
+      ...stage,
+      x: column * (STAGE_NODE_WIDTH + STAGE_COLUMN_GAP) + STAGE_PADDING,
+      y: row * (STAGE_NODE_HEIGHT + STAGE_ROW_GAP) + STAGE_PADDING,
+    })
+  }
+  const byName = new Map(nodes.map(node => [node.stage_name, node]))
+  const edges = nodes.flatMap(node => node.dependencies.map(dependency => {
+    const parent = byName.get(dependency)!
+    return {
+      key: `${dependency}:${node.stage_name}`,
+      x1: parent.x + STAGE_NODE_WIDTH, y1: parent.y + STAGE_NODE_HEIGHT / 2,
+      x2: node.x, y2: node.y + STAGE_NODE_HEIGHT / 2,
+    }
+  }))
+  return {
+    nodes, edges,
+    width: Math.max(STAGE_NODE_WIDTH + STAGE_PADDING * 2, ...nodes.map(node => node.x + STAGE_NODE_WIDTH + STAGE_PADDING)),
+    height: Math.max(STAGE_NODE_HEIGHT + STAGE_PADDING * 2, ...nodes.map(node => node.y + STAGE_NODE_HEIGHT + STAGE_PADDING)),
+  }
+}
+
+export function stageView(stages: ExecutionStage[], saved: string | null): StageView {
+  if (saved === 'List' || saved === 'Graph') return saved
+  return stages.some(stage => stage.stage_name.startsWith('join-right-')) ? 'Graph' : 'List'
+}
+
+export function joinStep(stage: ExecutionStage, stages: ExecutionStage[]): { parentStage: number; step: number; total: number } | null {
+  const branch = stage.stage_name.match(/^join-right-(\d+)-(\d+)-stage\d+$/)
+  if (!branch) return null
+  const prefix = `join-right-${branch[1]}-${branch[2]}-stage`
+  const chain = stages.filter(item => item.stage_name.startsWith(prefix))
+  const step = chain.findIndex(item => item.stage_name === stage.stage_name) + 1
+  return { parentStage: Number(branch[1]), step, total: chain.length }
+}
+
+export interface ExecutionPlan {
+  execution_id: string
+  coordinator_job_id: string
+  ts: number
+  input_shards: number
+  stages_json: string
+}
+
+export interface StageStat {
+  stage_name: string
+  status: string
+  elapsed: number
+  items: number
+  total_shards: number
+  mem_peak_bytes_max: number
+}
+
+export interface ReducerStat {
+  target_shard: number
+  input_rows: number | null
+  payload_bytes: number | null
+  num_sources: number | null
+  attempt: number
+  task_status?: string | null
+}
+
+export interface ShuffleSummary {
+  persisted_targets: number
+  observed_targets: number
+  expected_targets: number | null
+  median_rows: number | null
+  max_rows: number | null
+  median_bytes: number | null
+  max_bytes: number | null
+}
+
+export function timePredicate(startMs: number): string {
+  return `ts >= TIMESTAMP ${sqlString(new Date(startMs).toISOString())} AND ts <= now()`
+}
+
+export function executionPlansSql(jobId: string, startMs: number): string {
+  const root = '/' + jobId.split('/').filter(Boolean).slice(0, 2).join('/')
+  return `SELECT execution_id, coordinator_job_id, ts, input_shards, stages_json
+FROM "zephyr.execution"
+WHERE root_job_id = ${sqlString(root)} AND ${timePredicate(startMs)}
+  AND (coordinator_job_id = ${sqlString(jobId)} OR starts_with(coordinator_job_id, ${sqlString(jobId + '/')}))
+QUALIFY ROW_NUMBER() OVER (PARTITION BY execution_id ORDER BY ts DESC, seq DESC) = 1
+ORDER BY ts DESC LIMIT ${EXECUTION_LIMIT}`
+}
+
+export function stageStatsSql(execution: string, startMs: number): string {
+  return `SELECT stage_name, status, elapsed, items, total_shards, mem_peak_bytes_max
+FROM "zephyr.stage" WHERE execution_id = ${sqlString(execution)} AND ${timePredicate(startMs)}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY stage_name ORDER BY ts DESC, seq DESC) = 1`
+}
+
+export function shuffleSnapshotsSql(execution: string, stage: string, startMs: number): string {
+  return `WITH snapshots AS (
+SELECT *, ROW_NUMBER() OVER (
+PARTITION BY target_shard ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC
+) AS sample_rank
+FROM "zephyr.shuffle" WHERE execution_id = ${sqlString(execution)}
+AND stage_name = ${sqlString(stage)} AND ${timePredicate(startMs)}
+)`
+}
+
+export function reducerStatsSql(execution: string, stage: string, startMs: number, page: number): string {
+  return `${shuffleSnapshotsSql(execution, stage, startMs)}
+SELECT target_shard, input_rows, payload_bytes, num_sources, attempt FROM snapshots
+WHERE sample_rank = 1 ORDER BY payload_bytes DESC NULLS LAST, target_shard
+LIMIT ${REDUCER_PAGE_SIZE} OFFSET ${page * REDUCER_PAGE_SIZE}`
+}
+
+export function reducerTaskStatsSql(execution: string, stage: string, startMs: number, page: number): string {
+  return `WITH targets AS (${reducerStatsSql(execution, stage, startMs, page)}),
+task_states AS (
+SELECT shard_idx, status FROM "zephyr.worker"
+WHERE execution_id = ${sqlString(execution)} AND stage_name = ${sqlString(stage)} AND ${timePredicate(startMs)}
+AND shard_idx IN (SELECT target_shard FROM targets)
+QUALIFY ROW_NUMBER() OVER (PARTITION BY shard_idx ORDER BY ts DESC, seq DESC) = 1
+)
+SELECT targets.*, task_states.status AS task_status FROM targets
+LEFT JOIN task_states ON targets.target_shard = task_states.shard_idx
+ORDER BY payload_bytes DESC NULLS LAST, target_shard`
+}
+
+export function relativePayload(value: number | null, median: number | null): string {
+  if (value === null || median === null) return '—'
+  if (median === 0) return 'median 0'
+  const ratio = value / median
+  return `${ratio.toLocaleString(undefined, { maximumFractionDigits: ratio >= 10 ? 0 : 1 })}×`
+}
+
+export function shuffleSummarySql(execution: string, stage: string, startMs: number): string {
+  return `${shuffleSnapshotsSql(execution, stage, startMs)}
+SELECT COUNT(*) AS persisted_targets, COUNT(input_rows) AS observed_targets,
+MAX(num_targets) AS expected_targets, MEDIAN(CAST(input_rows AS DOUBLE)) AS median_rows,
+MAX(input_rows) AS max_rows, MEDIAN(CAST(payload_bytes AS DOUBLE)) AS median_bytes,
+MAX(payload_bytes) AS max_bytes FROM snapshots WHERE sample_rank = 1`
+}

--- a/lib/iris/dashboard/tests/zephyr.test.ts
+++ b/lib/iris/dashboard/tests/zephyr.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { test } from 'node:test'
+import { relativePayload, shuffleSnapshotsSql, stageView, joinStep, stageLayout } from '../src/utils/zephyr.ts'
+
+const linear = [
+  { stage_name: 'stage0-Scatter', label: 'Scatter', stage_type: 'map_worker', has_reduce: false, dependencies: [] },
+  { stage_name: 'stage1-Reduce', label: 'Reduce', stage_type: 'reduce_worker', has_reduce: true, dependencies: ['stage0-Scatter'] },
+]
+const joined = [
+  linear[0],
+  { ...linear[0], stage_name: 'join-right-1-0-stage0' },
+  { ...linear[1], stage_name: 'join-right-1-0-stage1', dependencies: ['join-right-1-0-stage0'] },
+  { ...linear[1], stage_name: 'stage1-Reduce → Join', dependencies: ['stage0-Scatter', 'join-right-1-0-stage1'] },
+]
+
+test('join plans default to Graph and saved choices override either plan default', () => {
+  assert.equal(stageView(linear, null), 'List')
+  assert.equal(stageView(joined, null), 'Graph')
+  assert.equal(stageView(linear, 'Graph'), 'Graph')
+  assert.equal(stageView(joined, 'List'), 'List')
+  assert.equal(stageView(joined, 'obsolete'), 'Graph')
+})
+
+test('right-input labels identify steps within their own join operation', () => {
+  const anotherBranch = { ...linear[0], stage_name: 'join-right-1-1-stage0' }
+  const stages = [...joined, anotherBranch]
+  assert.deepEqual(joinStep(joined[1], stages), { parentStage: 1, step: 1, total: 2 })
+  assert.deepEqual(joinStep(joined[2], stages), { parentStage: 1, step: 2, total: 2 })
+  assert.deepEqual(joinStep(anotherBranch, stages), { parentStage: 1, step: 1, total: 1 })
+  assert.equal(joinStep(linear[0], stages), null)
+})
+
+test('graph shows a right-input chain feeding the join separately from the left input', () => {
+  const graph = stageLayout(joined)
+  const [left, rightStart, rightEnd, joinNode] = graph.nodes
+  assert.equal(left.y, joinNode.y)
+  assert.equal(rightStart.y, rightEnd.y)
+  assert.notEqual(left.y, rightStart.y)
+  assert.ok(rightStart.x < rightEnd.x && rightEnd.x < joinNode.x)
+  assert.deepEqual(graph.edges.map(edge => edge.key).sort(), [
+    'join-right-1-0-stage0:join-right-1-0-stage1',
+    'join-right-1-0-stage1:stage1-Reduce → Join',
+    'stage0-Scatter:stage1-Reduce → Join',
+  ])
+})
+
+test('payload ratios distinguish unreported, empty, and skewed reducers', () => {
+  assert.equal(relativePayload(null, 10), '—')
+  assert.equal(relativePayload(0, 10), '0×')
+  assert.equal(relativePayload(5500, 10), '550×')
+  assert.equal(relativePayload(5635, 10), '564×')
+  assert.equal(relativePayload(19, 10), '1.9×')
+  assert.equal(relativePayload(33, 16.5), '2×')
+  assert.equal(relativePayload(10, 0), 'median 0')
+  assert.equal(relativePayload(10, null), '—')
+})
+
+test('Iris and Grafana select measured retries over placeholders and preserve observed zeros', context => {
+  const dashboard = JSON.parse(readFileSync(new URL('../../../../infra/grafana/dashboards/zephyr.json', import.meta.url), 'utf8'))
+  const precedence = (sql: string) => sql.match(/PARTITION BY target_shard ORDER BY (.*?)\) AS sample_rank/s)![1].replace(/\s+/g, ' ').trim()
+  const iris = precedence(shuffleSnapshotsSql('execution', 'stage', 1))
+  const queries: string[] = []
+  function collect(value: unknown) {
+    if (typeof value === 'string' && value.includes('PARTITION BY target_shard')) queries.push(value)
+    else if (value && typeof value === 'object') Object.values(value).forEach(collect)
+  }
+  collect(dashboard)
+  assert.ok(queries.length > 0)
+  const database = new DatabaseSync(':memory:')
+  context.after(() => database.close())
+  database.exec(`CREATE TABLE samples (target_shard INTEGER, input_rows INTEGER, attempt INTEGER, ts INTEGER, seq INTEGER);
+INSERT INTO samples VALUES
+(0,7,0,1,1), (0,NULL,0,9,2),
+(1,3,0,9,3), (1,8,1,2,4),
+(2,0,0,1,5), (2,NULL,0,9,6),
+(3,NULL,0,1,7),
+(4,9,0,1,8), (4,11,0,1,9),
+(5,1,0,1,10), (5,2,0,2,11)`)
+  for (const order of [iris, ...queries.map(precedence)]) {
+    const result = database.prepare(`WITH ranked AS (
+SELECT *, ROW_NUMBER() OVER (PARTITION BY target_shard ORDER BY ${order}) AS sample_rank FROM samples
+) SELECT target_shard, input_rows, attempt FROM ranked WHERE sample_rank = 1 ORDER BY target_shard`).all()
+    assert.deepEqual(result.map(row => [row.target_shard, row.input_rows, row.attempt]), [
+      [0, 7, 0], [1, 8, 1], [2, 0, 0], [3, null, 0], [4, 11, 0], [5, 2, 0],
+    ])
+  }
+})

--- a/lib/zephyr/OPS.md
+++ b/lib/zephyr/OPS.md
@@ -4,6 +4,59 @@
 
 See `lib/iris/OPS.md` → "Cluster Lifecycle" for `iris cluster dashboard` and `dashboard-proxy`. The proxy serves a locally-built frontend against the remote controller — restart it after frontend changes.
 
+## Shuffle input reports
+
+Zephyr records the input size of every reducer in a `group_by` stage. Each
+reducer sets three counters after its existing sidecar read: input rows,
+encoded payload bytes, and contributing mappers. The worker publishes one
+row per reduce attempt to the Finelog table `zephyr.shuffle`. Before a
+reduce stage starts, the coordinator writes one placeholder row per target
+with null counts. Reporting is always on. It adds no sidecar or Parquet
+reads.
+
+Run the local demo. It starts an embedded Finelog server and writes an HTML
+report:
+
+```bash
+uv run python lib/zephyr/scripts/shuffle_diagnostics_demo.py --output /tmp/shuffle.html
+```
+
+Run the same demo against the hosted Finelog:
+
+```bash
+uv run python lib/zephyr/scripts/shuffle_diagnostics_demo.py \
+  --stats-url https://iris.oa.dev/proxy/system.log-server \
+  --auth-profile marin --output /tmp/shuffle-hosted.html
+```
+
+Query one run. Use `result.execution_id` from `ctx.execute`:
+
+```sql
+SELECT target_shard, input_rows, payload_bytes, num_sources
+FROM (
+  SELECT *, ROW_NUMBER() OVER (
+    PARTITION BY execution_id, stage_name, target_shard
+    ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS rn
+  FROM "zephyr.shuffle"
+  WHERE execution_id = '<id>' AND stage_name = '<reduce stage>'
+) WHERE rn = 1
+ORDER BY payload_bytes DESC NULLS LAST
+```
+
+The Grafana dashboard is `infra/grafana/dashboards/zephyr.json`. It must be
+deployed before its links work.
+
+How to read the rows:
+
+- A null count means unreported. The reducer can be queued, reading, or its
+  row can be delayed or lost. Null is not a task state.
+- A measured zero means an empty target.
+- A row appears some time after the sidecar read. There is no fixed delay.
+- Set the query time range to include the run start. A narrow range drops
+  rows of reducers that still run.
+- The report shows target sizes only. It cannot tell one large key from
+  many keys.
+
 ## Architecture
 
 Pull-based coordinator/worker model. Coordinator queues tasks per stage; workers poll `pull_task()`, execute shards, report results. Stages are sequential barriers — all shards in a stage must complete before the next starts (`_wait_for_stage`).

--- a/lib/zephyr/scripts/shuffle_diagnostics_demo.py
+++ b/lib/zephyr/scripts/shuffle_diagnostics_demo.py
@@ -22,6 +22,8 @@ from zephyr.dataset import Dataset
 from zephyr.shuffle_report import render_shuffle_report
 from zephyr.stats import StatsConfig, ZephyrShuffleStat
 
+NUM_OUTPUT_SHARDS = 16
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -58,7 +60,7 @@ def main() -> None:
                     .group_by(
                         key=lambda row: row["key"],
                         reducer=lambda key, items: (key, sum(row["count"] for row in items)),
-                        num_output_shards=16,
+                        num_output_shards=NUM_OUTPUT_SHARDS,
                     )
                 )
                 result = context.execute(dataset)
@@ -81,8 +83,10 @@ def main() -> None:
                 "AND ts >= now() - INTERVAL '1 hour' AND ts <= now()) "
                 "SELECT * FROM reports WHERE report_rank = 1 ORDER BY target_shard"
             ).to_pylist()
-            assert len(result_rows) == 16, f"Expected 16 persisted targets, got {len(result_rows)}"
-            assert {row["num_targets"] for row in result_rows} == {16}
+            assert (
+                len(result_rows) == NUM_OUTPUT_SHARDS
+            ), f"Expected {NUM_OUTPUT_SHARDS} persisted targets, got {len(result_rows)}"
+            assert {row["num_targets"] for row in result_rows} == {NUM_OUTPUT_SHARDS}
             assert all(row["input_rows"] is not None for row in result_rows), "Some targets remain unreported"
             assert sum(row["input_rows"] for row in result_rows) == 10_000
             records.extend(

--- a/lib/zephyr/scripts/shuffle_diagnostics_demo.py
+++ b/lib/zephyr/scripts/shuffle_diagnostics_demo.py
@@ -1,0 +1,98 @@
+"""Run local shuffles, persist diagnostics in Finelog, and render their histograms."""
+
+import argparse
+from collections import Counter
+from contextlib import ExitStack
+from dataclasses import fields
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlencode
+
+from finelog.client import LogClient
+from finelog.embedded import EmbeddedServer
+from fray.local_backend import LocalClient
+from fray.types import ResourceConfig
+from rigging.connect import IapAuth
+from rigging.credentials import iap_provider_for
+from zephyr.context import ZephyrContext
+from zephyr.dataset import Dataset
+from zephyr.shuffle_report import render_shuffle_report
+from zephyr.stats import StatsConfig, ZephyrShuffleStat
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stats-url", help="Explicit Finelog URL; otherwise start an embedded local server.")
+    parser.add_argument("--auth-profile", help="Marin IAP credential profile, e.g. marin.")
+    parser.add_argument("--output", type=Path, default=Path("/tmp/zephyr-shuffle-report.html"))
+    args = parser.parse_args()
+    if args.auth_profile and not args.stats_url:
+        parser.error("--auth-profile requires --stats-url")
+
+    with ExitStack() as stack:
+        scratch = Path(stack.enter_context(TemporaryDirectory(prefix="zephyr-shuffle-demo-")))
+        url = args.stats_url
+        if url is None:
+            server = EmbeddedServer(log_dir=str(scratch / "finelog"))
+            stack.callback(server.stop)
+            url = f"http://127.0.0.1:{server.port}"
+        client = LocalClient()
+        stack.callback(client.shutdown)
+        executions = []
+        with ZephyrContext(
+            client=client,
+            max_workers=2,
+            resources=ResourceConfig(cpu=1, ram="1g"),
+            chunk_storage_prefix=str(scratch / "chunks"),
+            stats_config=StatsConfig(url, args.auth_profile),
+        ) as context:
+            for scenario in ("uniform", "hot-key"):
+                keys = [0 if scenario == "hot-key" and index < 9000 else index % 128 for index in range(10_000)]
+                rows = [{"key": key, "count": 1} for key in keys]
+                dataset = (
+                    Dataset.from_list(rows)
+                    .reshard(8)
+                    .group_by(
+                        key=lambda row: row["key"],
+                        reducer=lambda key, items: (key, sum(row["count"] for row in items)),
+                        num_output_shards=16,
+                    )
+                )
+                result = context.execute(dataset)
+                assert dict(result.results) == dict(Counter(keys))
+                executions.append(result.execution_id)
+                print(f"{scenario}: {result.execution_id}")
+
+        interceptors = IapAuth(iap_provider_for(args.auth_profile)).interceptors() if args.auth_profile else ()
+        query_client = LogClient.connect(url, interceptors=interceptors)
+        stack.callback(query_client.close)
+        allowed_fields = {field.name for field in fields(ZephyrShuffleStat)}
+        records = []
+        for execution_id in executions:
+            quoted_id = execution_id.replace("'", "''")
+            result_rows = query_client.query(
+                "WITH reports AS (SELECT *, ROW_NUMBER() OVER ("
+                "PARTITION BY execution_id, stage_name, target_shard "
+                "ORDER BY attempt DESC, (input_rows IS NOT NULL) DESC, ts DESC, seq DESC) AS report_rank "
+                f"FROM \"zephyr.shuffle\" WHERE execution_id = '{quoted_id}' "
+                "AND ts >= now() - INTERVAL '1 hour' AND ts <= now()) "
+                "SELECT * FROM reports WHERE report_rank = 1 ORDER BY target_shard"
+            ).to_pylist()
+            assert len(result_rows) == 16, f"Expected 16 persisted targets, got {len(result_rows)}"
+            assert {row["num_targets"] for row in result_rows} == {16}
+            assert all(row["input_rows"] is not None for row in result_rows), "Some targets remain unreported"
+            assert sum(row["input_rows"] for row in result_rows) == 10_000
+            records.extend(
+                ZephyrShuffleStat(**{key: value for key, value in row.items() if key in allowed_fields})
+                for row in result_rows
+            )
+            parameters = urlencode({"var-execution_id": execution_id, "from": "now-1h", "to": "now"})
+            print(f"Grafana (after dashboard deployment): https://grafana.oa.dev/d/marin-zephyr-shuffle?{parameters}")
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        render_shuffle_report(records, args.output)
+        print(f"Visual report from {len(records)} persisted rows: {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/zephyr/scripts/shuffle_diagnostics_demo.py
+++ b/lib/zephyr/scripts/shuffle_diagnostics_demo.py
@@ -1,3 +1,6 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Run local shuffles, persist diagnostics in Finelog, and render their histograms."""
 
 import argparse

--- a/lib/zephyr/src/zephyr/context.py
+++ b/lib/zephyr/src/zephyr/context.py
@@ -59,6 +59,7 @@ from zephyr.stage_io import (
     ZephyrWorkerError,
     _shared_data_path,
 )
+from zephyr.stats import StatsConfig
 from zephyr.worker import ZephyrWorker
 from zephyr.writers import ensure_parent_dir
 
@@ -256,6 +257,8 @@ class ZephyrContext:
         max_concurrent_pipelines: Maximum pipelines one pool runs at the same
             time. A pipeline past the limit is rejected, not queued. Raise it
             for a driver that fans many pipelines onto one shared pool.
+        stats_config: Explicit Finelog endpoint and authentication for local reporting.
+            When absent, discover Finelog through the Iris context.
     """
 
     client: Client | None = None
@@ -273,6 +276,7 @@ class ZephyrContext:
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
     max_concurrent_pipelines: int = MAX_CONCURRENT_PIPELINES
+    stats_config: StatsConfig | None = None
 
     _shared_data: ContextVar[dict[str, Any] | None] = field(init=False, repr=False)
     _state: _ContextState = field(init=False, default=_ContextState.NEW, repr=False)
@@ -511,6 +515,7 @@ class ZephyrContext:
             max_shard_infra_failures=self.max_shard_infra_failures,
             drain_idle_workers=idle_policy is _IdleWorkerPolicy.DRAIN,
             max_concurrent_pipelines=self.max_concurrent_pipelines,
+            stats_config=self.stats_config,
             name=coordinator_name,
             count=1,
             resources=self.coordinator_resources,

--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -4,6 +4,7 @@
 """Coordinator actor and pull protocol for Zephyr pipelines."""
 
 import enum
+import json
 import logging
 import re
 import sys
@@ -13,7 +14,7 @@ from collections import Counter, defaultdict, deque
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -28,7 +29,19 @@ from rigging.filesystem.storage_path import StoragePath
 from rigging.timing import Duration, ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.memory_store import MemoryTableRegistration
-from zephyr.plan import Join, PhysicalOp, PhysicalPlan, PhysicalStage, Reduce, Scatter, SourceItem, StageType
+from zephyr.plan import (
+    Join,
+    PhysicalOp,
+    PhysicalPlan,
+    PhysicalStage,
+    Reduce,
+    Scatter,
+    SourceItem,
+    StageType,
+    execution_stage_name,
+    execution_stages,
+    join_stage_name,
+)
 from zephyr.shuffle import ListShard, MemChunk
 from zephyr.stage_io import (
     ShardTask,
@@ -39,7 +52,14 @@ from zephyr.stage_io import (
     _ensure_picklable_exception,
     _stage_throughput,
 )
-from zephyr.stats import StatsConfig, StatsWriter, ZephyrShuffleStat, ZephyrWorkerStatStatus, _push_iris_task_status
+from zephyr.stats import (
+    StatsConfig,
+    StatsWriter,
+    ZephyrExecutionStat,
+    ZephyrShuffleStat,
+    ZephyrWorkerStatStatus,
+    _push_iris_task_status,
+)
 from zephyr.worker_context import Aggregation, CounterEntry, CounterSnapshot, merge_counter_entries
 from zephyr.writers import ensure_parent_dir
 
@@ -363,6 +383,7 @@ class ZephyrCoordinator:
         self._stats_writer = StatsWriter.connect(stats_config)
         job_info = get_job_info()
         self._job_id = str(job_info.job_id) if job_info is not None else ""
+        self._root_job_id = str(job_info.job_id.root_job) if job_info is not None else ""
         self._result_executor = ThreadPoolExecutor(
             max_workers=MAX_CONCURRENT_RESULT_READS, thread_name_prefix="zephyr-result"
         )
@@ -1209,6 +1230,16 @@ class ZephyrCoordinator:
         result_path = _execution_result_path(self._chunk_prefix, execution_id)
         try:
             shards = _build_source_shards(plan.source_items)
+            self._stats_writer.emit_execution_stat(
+                ZephyrExecutionStat(
+                    execution_id=execution_id,
+                    root_job_id=self._root_job_id,
+                    coordinator_job_id=self._job_id,
+                    ts=datetime.now(UTC).replace(tzinfo=None),
+                    input_shards=len(shards),
+                    stages_json=json.dumps([asdict(stage) for stage in execution_stages(plan)]),
+                )
+            )
             if not shards:
                 self._persist_result(
                     result_path, ZephyrExecutionResult(results=[], counters={}, execution_id=execution_id)
@@ -1233,7 +1264,7 @@ class ZephyrCoordinator:
                     run,
                     stage,
                     shards,
-                    stage_label=f"stage{stage_idx}-{stage.stage_name(max_length=40)}",
+                    stage_label=execution_stage_name(stage, stage_idx),
                     stage_index_for_state=stage_idx,
                     aux_per_shard=aux_per_shard,
                     is_last_stage=(stage_idx == last_worker_stage_idx),
@@ -1419,7 +1450,7 @@ class ZephyrCoordinator:
                     run,
                     right_stage,
                     right_refs,
-                    stage_label=f"join-right-{parent_stage_idx}-{i}-stage{stage_idx}",
+                    stage_label=join_stage_name(parent_stage_idx, i, stage_idx),
                     stage_index_for_state=parent_stage_idx,
                 )
 

--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 import cloudpickle
@@ -21,12 +22,13 @@ from fray.actor import ActorGroup, ActorHandle, current_actor
 from fray.current_client import current_client
 from fray.local_backend import LocalClient
 from fray.types import ActorConfig, ResourceConfig
+from iris.cluster.client.job_info import get_job_info
 from rigging import telemetry
 from rigging.filesystem.storage_path import StoragePath
 from rigging.timing import Duration, ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.memory_store import MemoryTableRegistration
-from zephyr.plan import Join, PhysicalOp, PhysicalPlan, PhysicalStage, Scatter, SourceItem, StageType
+from zephyr.plan import Join, PhysicalOp, PhysicalPlan, PhysicalStage, Reduce, Scatter, SourceItem, StageType
 from zephyr.shuffle import ListShard, MemChunk
 from zephyr.stage_io import (
     ShardTask,
@@ -37,7 +39,7 @@ from zephyr.stage_io import (
     _ensure_picklable_exception,
     _stage_throughput,
 )
-from zephyr.stats import StatsWriter, ZephyrWorkerStatStatus, _push_iris_task_status
+from zephyr.stats import StatsConfig, StatsWriter, ZephyrShuffleStat, ZephyrWorkerStatStatus, _push_iris_task_status
 from zephyr.worker_context import Aggregation, CounterEntry, CounterSnapshot, merge_counter_entries
 from zephyr.writers import ensure_parent_dir
 
@@ -309,6 +311,7 @@ class ZephyrCoordinator:
         max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES,
         drain_idle_workers: bool = False,
         max_concurrent_pipelines: int = MAX_CONCURRENT_PIPELINES,
+        stats_config: StatsConfig | None = None,
     ) -> None:
         # Pipeline executions keyed by execution_id, insertion-ordered. All
         # per-pipeline state lives in the _PipelineExecution values.
@@ -334,6 +337,7 @@ class ZephyrCoordinator:
         self._max_shard_failures = max_shard_failures
         self._max_shard_infra_failures = max_shard_infra_failures
         self._max_concurrent_pipelines = max_concurrent_pipelines
+        self._stats_config = stats_config
         # Per-worker in-flight counter snapshots. Each snapshot carries a
         # monotonic generation so the coordinator can discard stale or
         # out-of-order heartbeats.
@@ -356,7 +360,9 @@ class ZephyrCoordinator:
         self._host_shutdown_event = actor_ctx.shutdown_event
         self._self_handle = actor_ctx.handle
 
-        self._stats_writer = StatsWriter.connect()
+        self._stats_writer = StatsWriter.connect(stats_config)
+        job_info = get_job_info()
+        self._job_id = str(job_info.job_id) if job_info is not None else ""
         self._result_executor = ThreadPoolExecutor(
             max_workers=MAX_CONCURRENT_RESULT_READS, thread_name_prefix="zephyr-result"
         )
@@ -394,6 +400,7 @@ class ZephyrCoordinator:
             self._self_handle,
             stage_runner_factory,
             task_resources,
+            stats_config=self._stats_config,
             name=f"{self._name}-workers",
             count=worker_count,
             resources=worker_resources,
@@ -1203,7 +1210,9 @@ class ZephyrCoordinator:
         try:
             shards = _build_source_shards(plan.source_items)
             if not shards:
-                self._persist_result(result_path, ZephyrExecutionResult(results=[], counters={}))
+                self._persist_result(
+                    result_path, ZephyrExecutionResult(results=[], counters={}, execution_id=execution_id)
+                )
                 return None
 
             last_worker_stage_idx = max(
@@ -1238,7 +1247,9 @@ class ZephyrCoordinator:
 
             with self._lock:
                 counters = {name: entry.value for name, entry in run.merged_counters().items()}
-            self._persist_result(result_path, ZephyrExecutionResult(results=flat_result, counters=counters))
+            self._persist_result(
+                result_path, ZephyrExecutionResult(results=flat_result, counters=counters, execution_id=execution_id)
+            )
             return None
         except Exception as e:
             # Persist the normalized exception so the driver can recover the
@@ -1350,6 +1361,25 @@ class ZephyrCoordinator:
         logger.info(
             "[%s] Starting stage %s (%s) with %d tasks", run.execution_id, stage_label, stage.stage_type, len(tasks)
         )
+        if tasks and any(isinstance(op, Reduce) for op in stage.operations):
+            timestamp = datetime.now(UTC).replace(tzinfo=None)
+            self._stats_writer.emit_shuffle_stats(
+                [
+                    ZephyrShuffleStat(
+                        execution_id=run.execution_id,
+                        stage_name=stage_label,
+                        target_shard=task.shard_idx,
+                        num_targets=task.total_shards,
+                        attempt=0,
+                        input_rows=None,
+                        payload_bytes=None,
+                        num_sources=None,
+                        ts=timestamp,
+                        job_id=self._job_id,
+                    )
+                    for task in tasks
+                ]
+            )
         self._start_stage(run, stage_label, stage_index_for_state, tasks, is_last_stage=is_last_stage)
         try:
             self._wait_for_stage(run)
@@ -1543,6 +1573,7 @@ class ZephyrExecutionResult:
 
     results: list
     counters: dict[str, int | float]
+    execution_id: str = ""
 
 
 def _read_coordinator_result(result_path: str) -> Any:

--- a/lib/zephyr/src/zephyr/counters.py
+++ b/lib/zephyr/src/zephyr/counters.py
@@ -56,6 +56,9 @@ RECORDS_OUT = "zephyr/records_out"
 """Records written by the output writers (jsonl/parquet/vortex/binary)."""
 PARTITIONS_SKIPPED = "zephyr/partitions_skipped"
 """Output partitions skipped because the target already existed (``skip_existing``)."""
+SHUFFLE_INPUT_ROWS = "zephyr/shuffle/input_rows"
+SHUFFLE_PAYLOAD_BYTES = "zephyr/shuffle/payload_bytes"
+SHUFFLE_NUM_SOURCES = "zephyr/shuffle/num_sources"
 
 
 class ScopedCounters:

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -793,6 +793,10 @@ def run_stage(
             # reads all per-mapper sidecars in parallel, filters for its own
             # target shard, then merges the sorted chunks and reduces per key.
             reader = ScatterReader.from_sidecars(list(ctx.shard), ctx.shard_idx)
+            stage_counters = counters.current_stage()
+            stage_counters.set_counter(counters.SHUFFLE_INPUT_ROWS, reader.shard_payload_rows)
+            stage_counters.set_counter(counters.SHUFFLE_PAYLOAD_BYTES, reader.shard_payload_bytes)
+            stage_counters.set_counter(counters.SHUFFLE_NUM_SOURCES, reader.contributing_sidecars)
             stream = _reduce_gen(reader, op.key_fn, op.reducer_fn, external_sort_dir)
             op_index += 1
 

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -330,6 +330,64 @@ class PhysicalPlan:
 
 
 @dataclass
+class ExecutionStage:
+    stage_name: str
+    label: str
+    stage_type: str
+    has_reduce: bool
+    dependencies: list[str] = field(default_factory=list)
+
+
+def execution_stage_name(stage: PhysicalStage, index: int) -> str:
+    return f"stage{index}-{stage.stage_name(max_length=40)}"
+
+
+def join_stage_name(parent_index: int, operation_index: int, stage_index: int) -> str:
+    return f"join-right-{parent_index}-{operation_index}-stage{stage_index}"
+
+
+def execution_stages(plan: PhysicalPlan) -> list[ExecutionStage]:
+    """Describe stage data dependencies using the labels emitted by the coordinator.
+
+    Arrows describe data flow, not concurrent scheduling. Join right-hand stages
+    feed the join separately from the preceding left-hand stage.
+    """
+    stages = []
+    previous = []
+    for stage_index, stage in enumerate(plan.stages):
+        dependencies = list(previous)
+        for operation_index, operation in enumerate(stage.operations):
+            if not isinstance(operation, Join) or operation.right_plan is None:
+                continue
+            right_previous = []
+            for right_index, right_stage in enumerate(operation.right_plan.stages):
+                name = join_stage_name(stage_index, operation_index, right_index)
+                stages.append(
+                    ExecutionStage(
+                        name,
+                        right_stage.stage_name(),
+                        str(right_stage.stage_type),
+                        any(isinstance(operation, Reduce) for operation in right_stage.operations),
+                        right_previous,
+                    )
+                )
+                right_previous = [name]
+            dependencies.extend(right_previous)
+        name = execution_stage_name(stage, stage_index)
+        stages.append(
+            ExecutionStage(
+                name,
+                stage.stage_name(),
+                str(stage.stage_type),
+                any(isinstance(operation, Reduce) for operation in stage.operations),
+                dependencies,
+            )
+        )
+        previous = [name]
+    return stages
+
+
+@dataclass
 class FusionState:
     """Incremental state for fusing logical operations into physical stages."""
 

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -468,11 +468,15 @@ class ScatterReader:
         target_shard: int,
         avg_item_bytes: float,
         shard_payload_bytes: float = 0.0,
+        shard_payload_rows: int = 0,
+        contributing_sidecars: int = 0,
     ) -> None:
         self._chunk_files = chunk_files
         self._target_shard = target_shard
         self.avg_item_bytes = avg_item_bytes
         self.shard_payload_bytes = shard_payload_bytes
+        self.shard_payload_rows = shard_payload_rows
+        self.contributing_sidecars = contributing_sidecars
 
     @classmethod
     def from_sidecars(cls, scatter_paths: list[str], target_shard: int) -> "ScatterReader":
@@ -484,7 +488,7 @@ class ScatterReader:
         thousands of mappers.
         """
         chunk_files: list[_ChunkFile] = []
-        shard_payload_bytes = 0.0
+        shard_payload_bytes = 0
         shard_payload_rows = 0
 
         with log_time(
@@ -525,6 +529,8 @@ class ScatterReader:
             target_shard=target_shard,
             avg_item_bytes=avg_item_bytes,
             shard_payload_bytes=shard_payload_bytes,
+            shard_payload_rows=shard_payload_rows,
+            contributing_sidecars=contributing_sidecars,
         )
 
     def get_frames(self) -> list[pl.LazyFrame]:

--- a/lib/zephyr/src/zephyr/shuffle_report.py
+++ b/lib/zephyr/src/zephyr/shuffle_report.py
@@ -1,0 +1,178 @@
+"""Offline charts of reducer input sizes read from Finelog."""
+
+from collections import defaultdict
+from collections.abc import Sequence
+from html import escape
+from pathlib import Path
+from statistics import median
+
+from zephyr.stats import ZephyrShuffleStat
+
+_HISTOGRAM_BINS = 10
+_STYLE = """
+body { font: 16px system-ui, sans-serif; color: #183043; background: #f4f6f8; margin: 0; }
+main { max-width: 1100px; margin: auto; padding: 24px; }
+section { background: white; padding: 24px; margin: 24px 0; border: 1px solid #d5dfe6; border-radius: 8px; }
+h1, h2, h3 { line-height: 1.2; } h2, p { overflow-wrap: anywhere; }
+.charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr)); gap: 24px; }
+.scroll { max-height: 480px; overflow: auto; }
+table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+th { text-align: left; } th, td { padding: 6px; border-bottom: 1px solid #e7edf1; }
+td:last-child { text-align: right; white-space: nowrap; }
+.track { min-width: 80px; background: #edf1f5; height: 16px; }
+.bar { background: #157b86; height: 100%; }
+.histogram .bar { background: #7357ac; }
+.coverage { margin: 12px 0; height: 12px; background: #d5dfe6; }
+.coverage .bar { background: #157b86; }
+.unreported { color: #687581; background: #edf1f5; }
+.note { color: #4c6071; } code { font-size: 0.9em; }
+"""
+
+
+def _rank_chart(values: list[tuple[int, int | None]], label: str, metric: str) -> str:
+    maximum = max((value for _, value in values if value is not None), default=0)
+    rows = []
+    for target, value in sorted(values, key=lambda item: (item[1] is None, -(item[1] or 0), item[0])):
+        if value is None:
+            rows.append(
+                f'<tr class="unreported" data-target="{target}" data-status="UNREPORTED">'
+                f'<td>{target}</td><td colspan="2">UNREPORTED</td></tr>'
+            )
+            continue
+        width = 100 * value / maximum if maximum else 0
+        rows.append(
+            f'<tr data-target="{target}" data-value="{value}"><td>{target}</td>'
+            f'<td><div class="track"><div class="bar" style="width:{width:.4f}%"></div></div></td>'
+            f"<td>{value:,}</td></tr>"
+        )
+    return (
+        f'<div><h3>{label} by target reducer</h3><div class="scroll"><table data-metric="{metric}">'
+        f"<thead><tr><th>Target</th><th>Relative size</th><th>{label}</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div></div>"
+    )
+
+
+def _histogram(values: list[int], label: str, metric: str) -> str:
+    if not values:
+        return f'<div data-distribution="{metric}"><h3>{label} distribution</h3><p>No measurements yet.</p></div>'
+    maximum = max(values)
+    bin_width = max(1, (maximum + _HISTOGRAM_BINS) // _HISTOGRAM_BINS)
+    counts = [0] * (maximum // bin_width + 1)
+    for value in values:
+        counts[value // bin_width] += 1
+    largest_count = max(counts)
+    rows = []
+    for index, count in enumerate(counts):
+        lower = index * bin_width
+        upper = min(maximum, lower + bin_width - 1)
+        width = 100 * count / largest_count
+        rows.append(
+            f'<tr data-lower="{lower}" data-upper="{upper}" data-count="{count}">'
+            f'<td>{lower:,}-{upper:,}</td><td><div class="track">'
+            f'<div class="bar" style="width:{width:.4f}%"></div></div></td><td>{count}</td></tr>'
+        )
+    return (
+        f'<div class="histogram"><h3>{label} distribution</h3><table data-metric="{metric}">'
+        f"<thead><tr><th>{label} (inclusive)</th><th>Frequency</th><th>Reducers</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
+    )
+
+
+def _summary(values: list[int], label: str) -> str:
+    if not values:
+        return f"{label}: unknown (no measurements)."
+    middle = median(values)
+    maximum = max(values)
+    ratio = f"{maximum / middle:,.2f}x" if middle else "undefined (median is zero)"
+    return f"{label}: median {middle:,.1f}; max {maximum:,}; max/median {ratio}."
+
+
+def render_shuffle_report(records: Sequence[ZephyrShuffleStat], output_path: Path) -> None:
+    """Write observed input-size charts grouped by execution and reduce stage.
+
+    Args:
+        records: Placeholders and observations. Keep the greatest attempt, then
+            prefer a measurement over a placeholder, then the latest timestamp.
+            Resolve timestamp ties by Finelog sequence in the query; otherwise
+            the last supplied tied row wins. Infer unreported IDs from num_targets.
+        output_path: Destination HTML file in an existing directory.
+    """
+    groups: dict[tuple[str, str], list[ZephyrShuffleStat]] = defaultdict(list)
+    latest_targets: dict[tuple[str, str, int], ZephyrShuffleStat] = {}
+    for record in records:
+        identity = (record.execution_id, record.stage_name, record.target_shard)
+        if not 0 <= record.target_shard < record.num_targets:
+            raise ValueError(f"Shuffle target outside expected range: {identity}")
+        sizes = (record.input_rows, record.payload_bytes, record.num_sources)
+        if any(value is None for value in sizes) and not all(value is None for value in sizes):
+            raise ValueError(f"Incomplete shuffle measurement: {identity}")
+        if record.attempt < 0 or any(value < 0 for value in sizes if value is not None):
+            raise ValueError(f"Negative shuffle observation: {identity}")
+        previous = latest_targets.get(identity)
+        priority = (record.attempt, record.input_rows is not None, record.ts)
+        if previous is None or priority >= (previous.attempt, previous.input_rows is not None, previous.ts):
+            latest_targets[identity] = record
+    for identity, record in latest_targets.items():
+        groups[identity[:2]].append(record)
+
+    sections = []
+    for (execution_id, stage_name), group in sorted(groups.items()):
+        expected = group[0].num_targets
+        if any(record.num_targets != expected for record in group):
+            raise ValueError(f"Conflicting target counts for {execution_id}, {stage_name}")
+        input_rows = [record.input_rows for record in group if record.input_rows is not None]
+        payload_bytes = [record.payload_bytes for record in group if record.payload_bytes is not None]
+        observed = len(input_rows)
+        unreported = expected - observed
+        coverage = "partial" if unreported else "complete"
+        rows_by_target = {record.target_shard: record.input_rows for record in group}
+        bytes_by_target = {record.target_shard: record.payload_bytes for record in group}
+        empty_count = sum(value == 0 for value in input_rows)
+        jobs = ", ".join(sorted({record.job_id for record in group if record.job_id})) or "local / unspecified"
+        latest = max(record.ts for record in group).isoformat()
+        sections.append(
+            f'<section data-execution="{escape(execution_id)}" data-stage="{escape(stage_name)}">'
+            f"<h2>Reduce stage: {escape(stage_name)}</h2>"
+            f"<p>Execution: <code>{escape(execution_id)}</code><br>Job: <code>{escape(jobs)}</code>"
+            f"<br>Latest record timestamp: {escape(latest)}</p>"
+            f'<p data-targets="{observed}" data-expected-targets="{expected}" '
+            f'data-unreported-targets="{unreported}" data-empty-targets="{empty_count}" data-coverage="{coverage}">'
+            f"{observed:,} / {expected:,} targets reported ({100 * observed / expected:.1f}% coverage); "
+            f"{unreported:,} UNREPORTED; {empty_count:,} reported empty. "
+            "Coverage describes available telemetry, not task completion.</p>"
+            f'<div class="coverage"><div class="bar" style="width:{100 * observed / expected:.4f}%"></div></div>'
+            "<p>Observed targets only:<br>"
+            f"{_summary(input_rows, 'Input rows')}<br>{_summary(payload_bytes, 'Encoded payload bytes')}</p>"
+            '<div class="charts">'
+            + _rank_chart(
+                [(target, rows_by_target.get(target)) for target in range(expected)], "Input rows", "input_rows"
+            )
+            + _rank_chart(
+                [(target, bytes_by_target.get(target)) for target in range(expected)], "Encoded bytes", "payload_bytes"
+            )
+            + _histogram(input_rows, "Input rows", "input_rows_histogram")
+            + _histogram(payload_bytes, "Encoded bytes", "payload_bytes_histogram")
+            + "</div></section>"
+        )
+    content = "".join(sections) or (
+        '<p data-coverage="unknown">No shuffle observations were returned. Expected target count and coverage '
+        "are unknown. No distribution can be shown.</p>"
+    )
+    output_path.write_text(
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>Zephyr shuffle inputs</title><style>{_STYLE}</style></head><body><main>"
+        '<h1>Zephyr shuffle inputs</h1><p class="note">Each reducer reports its input sizes after reading mapper '
+        "metadata. Transport can delay publication. Encoded bytes exclude Parquet overhead and do not measure "
+        "RAM or network traffic. "
+        "Partition totals cannot identify a single hot key or explain runtime on their own.</p>"
+        '<p class="note">Charts use linear scales. Rank charts sort each metric independently. '
+        "Histograms and summaries include reported targets only, including explicitly reported empty targets. "
+        "UNREPORTED targets are unknown, never zero: they may be queued, loading, or missing telemetry. "
+        "The coordinator announces targets with null sizes before they run; missing announcements are inferred "
+        "from the expected target count. Time filters can omit records. Each target uses its greatest attempt, "
+        "preferring a measurement over a placeholder before comparing timestamps. "
+        "This does not establish which attempt succeeded.</p>"
+        f"{content}</main></body></html>",
+        encoding="utf-8",
+    )

--- a/lib/zephyr/src/zephyr/shuffle_report.py
+++ b/lib/zephyr/src/zephyr/shuffle_report.py
@@ -1,3 +1,6 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Offline charts of reducer input sizes read from Finelog."""
 
 from collections import defaultdict

--- a/lib/zephyr/src/zephyr/stats.py
+++ b/lib/zephyr/src/zephyr/stats.py
@@ -3,12 +3,13 @@
 
 """Finelog stats schemas and counter-key constants for Zephyr pipelines.
 
-Two namespaces are written:
+Three namespaces are written:
 
 - ``zephyr.stage`` — one row per stage at completion, emitted by the
   coordinator. Contains throughput and aggregated resource usage.
 - ``zephyr.worker`` — one row per shard at START, each sample interval
   (RUNNING), and END, emitted by the long-lived worker actor.
+- ``zephyr.shuffle`` — optional target placeholders and reducer input sizes.
 
 Runners sample CPU and memory counters. Worker heartbeats write per-shard rows
 and send aggregated counters to the coordinator for stage stats.
@@ -27,12 +28,15 @@ from finelog.client import LogClient, Table
 from iris.client.client import get_iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
+from rigging.connect import IapAuth
+from rigging.credentials import iap_provider_for
 from rigging.timing import RateLimiter
 
 logger = logging.getLogger(__name__)
 
 ZEPHYR_STAGE_STATS_NAMESPACE = "zephyr.stage"
 ZEPHYR_WORKER_STATS_NAMESPACE = "zephyr.worker"
+ZEPHYR_SHUFFLE_STATS_NAMESPACE = "zephyr.shuffle"
 WORKER_STATS_INTERVAL = 5.0
 
 ZEPHYR_STAGE_ITEM_COUNT_KEY = "zephyr/item_count"
@@ -134,10 +138,41 @@ class ZephyrWorkerStat:
     mem_peak_bytes: int
 
 
+@dataclass(frozen=True)
+class StatsConfig:
+    """Explicit Finelog URL and optional Marin cluster name for IAP credentials."""
+
+    url: str
+    auth_profile: str | None = None
+
+
+@dataclass
+class ZephyrShuffleStat:
+    """Initial target placeholder or input size observed by a reducer.
+
+    Payload bytes measure encoded records, not compressed storage or RAM.
+    All three counts are null until measured. Stage names identify the reduce
+    stage; job IDs identify the producer. Local runs have no job ID.
+    """
+
+    key_column: ClassVar[str] = "execution_id"
+
+    execution_id: str
+    stage_name: str
+    target_shard: int
+    num_targets: int
+    attempt: int
+    input_rows: int | None
+    payload_bytes: int | None
+    num_sources: int | None
+    ts: datetime
+    job_id: str
+
+
 class StatsWriter:
     """Manages finelog connections and emits Zephyr stat rows.
 
-    Call ``connect()`` to get a live instance; pass a pre-resolved URL when
+    Call ``connect()`` to get a live instance; pass explicit ``StatsConfig`` when
     an Iris context is not available. All emit methods are no-ops when the
     log client is unavailable.
     """
@@ -146,6 +181,7 @@ class StatsWriter:
         self._log_client = log_client
         self._stage_table: Table | None = None
         self._worker_table: Table | None = None
+        self._shuffle_table: Table | None = None
         if log_client is not None:
             with suppress(Exception):
                 self._stage_table = log_client.get_table(ZEPHYR_STAGE_STATS_NAMESPACE, ZephyrStageStat)
@@ -153,17 +189,22 @@ class StatsWriter:
                 self._worker_table = log_client.get_table(ZEPHYR_WORKER_STATS_NAMESPACE, ZephyrWorkerStat)
 
     @classmethod
-    def connect(cls, url: str | None = None) -> "StatsWriter":
-        """Connect to finelog; resolves the URL via Iris if not provided.
+    def connect(cls, config: StatsConfig | None = None) -> "StatsWriter":
+        """Connect to Finelog using explicit configuration or Iris discovery.
 
         Returns a no-op instance if the URL cannot be determined or the
         connection fails.
         """
-        resolved = url or cls.resolve_url()
+        resolved = config.url if config is not None else cls.resolve_url()
         if resolved is None:
             return cls(None)
         try:
-            return cls(LogClient.connect(resolved))
+            interceptors = (
+                IapAuth(iap_provider_for(config.auth_profile)).interceptors()
+                if config is not None and config.auth_profile is not None
+                else ()
+            )
+            return cls(LogClient.connect(resolved, interceptors=interceptors))
         except Exception:
             logger.warning("Could not connect to finelog at %s; stats disabled", resolved, exc_info=True)
             return cls(None)
@@ -262,6 +303,17 @@ class StatsWriter:
             self._worker_table.write([stat])
         except Exception:
             logger.warning("Failed to write worker stat to finelog", exc_info=True)
+
+    def emit_shuffle_stats(self, records: list[ZephyrShuffleStat]) -> None:
+        """Append target placeholders or measurements; create the table on demand."""
+        if self._log_client is None:
+            return
+        try:
+            if self._shuffle_table is None:
+                self._shuffle_table = self._log_client.get_table(ZEPHYR_SHUFFLE_STATS_NAMESPACE, ZephyrShuffleStat)
+            self._shuffle_table.write(records)
+        except Exception:
+            logger.warning("Failed to write shuffle stats to finelog", exc_info=True)
 
     def close(self) -> None:
         if self._log_client is not None:

--- a/lib/zephyr/src/zephyr/stats.py
+++ b/lib/zephyr/src/zephyr/stats.py
@@ -3,13 +3,14 @@
 
 """Finelog stats schemas and counter-key constants for Zephyr pipelines.
 
-Three namespaces are written:
+Four namespaces are written:
 
 - ``zephyr.stage`` — one row per stage at completion, emitted by the
   coordinator. Contains throughput and aggregated resource usage.
 - ``zephyr.worker`` — one row per shard at START, each sample interval
   (RUNNING), and END, emitted by the long-lived worker actor.
-- ``zephyr.shuffle`` — optional target placeholders and reducer input sizes.
+- ``zephyr.shuffle`` — target placeholders and reducer input sizes.
+- ``zephyr.execution`` — one physical plan per execution, linked to its Iris job.
 
 Runners sample CPU and memory counters. Worker heartbeats write per-shard rows
 and send aggregated counters to the coordinator for stage stats.
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 ZEPHYR_STAGE_STATS_NAMESPACE = "zephyr.stage"
 ZEPHYR_WORKER_STATS_NAMESPACE = "zephyr.worker"
 ZEPHYR_SHUFFLE_STATS_NAMESPACE = "zephyr.shuffle"
+ZEPHYR_EXECUTION_STATS_NAMESPACE = "zephyr.execution"
 WORKER_STATS_INTERVAL = 5.0
 
 ZEPHYR_STAGE_ITEM_COUNT_KEY = "zephyr/item_count"
@@ -169,6 +171,20 @@ class ZephyrShuffleStat:
     job_id: str
 
 
+@dataclass
+class ZephyrExecutionStat:
+    """A physical plan used to discover and navigate an Iris job's executions."""
+
+    key_column: ClassVar[str] = "root_job_id"
+
+    execution_id: str
+    root_job_id: str
+    coordinator_job_id: str
+    ts: datetime
+    input_shards: int
+    stages_json: str
+
+
 class StatsWriter:
     """Manages finelog connections and emits Zephyr stat rows.
 
@@ -182,6 +198,7 @@ class StatsWriter:
         self._stage_table: Table | None = None
         self._worker_table: Table | None = None
         self._shuffle_table: Table | None = None
+        self._execution_table: Table | None = None
         if log_client is not None:
             with suppress(Exception):
                 self._stage_table = log_client.get_table(ZEPHYR_STAGE_STATS_NAMESPACE, ZephyrStageStat)
@@ -303,6 +320,17 @@ class StatsWriter:
             self._worker_table.write([stat])
         except Exception:
             logger.warning("Failed to write worker stat to finelog", exc_info=True)
+
+    def emit_execution_stat(self, record: ZephyrExecutionStat) -> None:
+        """Persist the execution plan once without delaying for a flush."""
+        if self._log_client is None:
+            return
+        try:
+            if self._execution_table is None:
+                self._execution_table = self._log_client.get_table(ZEPHYR_EXECUTION_STATS_NAMESPACE, ZephyrExecutionStat)
+            self._execution_table.write([record])
+        except Exception:
+            logger.warning("Failed to write execution plan to finelog", exc_info=True)
 
     def emit_shuffle_stats(self, records: list[ZephyrShuffleStat]) -> None:
         """Append target placeholders or measurements; create the table on demand."""

--- a/lib/zephyr/src/zephyr/worker.py
+++ b/lib/zephyr/src/zephyr/worker.py
@@ -10,10 +10,13 @@ import traceback
 from collections.abc import Callable, Hashable
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 from fray.actor import ActorFuture, ActorHandle, current_actor
+from iris.cluster.client.job_info import get_job_info
 from rigging.timing import ExponentialBackoff, RateLimiter
 
+from zephyr import counters as stage_counters
 from zephyr.coordinator import CoordinatorUnreachable, PullStatus, PullTask
 from zephyr.memory_store import (
     MemoryStoreActorStats,
@@ -26,7 +29,9 @@ from zephyr.stage_io import ShardTask, StageRunner, TaskResult, ZephyrTaskResour
 from zephyr.stats import (
     WORKER_STATS_INTERVAL,
     ZEPHYR_WORKER_MEM_CURRENT_KEY,
+    StatsConfig,
     StatsWriter,
+    ZephyrShuffleStat,
     ZephyrWorkerStatStatus,
     _push_iris_task_status,
 )
@@ -48,6 +53,8 @@ class _ActiveShard:
     task: ShardTask
     execution_id: str
     start_time: float
+    attempt: int
+    shuffle_reported: bool = False
     last_counters: dict[str, CounterEntry] = field(default_factory=dict)
 
 
@@ -79,6 +86,7 @@ class ZephyrWorker:
         coordinator_handle: ActorHandle,
         stage_runner_factory: Callable[[], StageRunner],
         total_resources: ZephyrTaskResources,
+        stats_config: StatsConfig | None = None,
     ):
         self._coordinator = coordinator_handle
         self._stage_runner_factory = stage_runner_factory
@@ -106,7 +114,9 @@ class ZephyrWorker:
         self._worker_id = f"{self._actor_ctx.group_name}-{self._actor_ctx.index}"
         self._actor_handle = self._actor_ctx.handle
         self._memory_store = MemoryStoreService(self._actor_ctx.index)
-        self._stats_writer = StatsWriter.connect()
+        self._stats_writer = StatsWriter.connect(stats_config)
+        job_info = get_job_info()
+        self._job_id = str(job_info.job_id) if job_info is not None else ""
 
         self._heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
@@ -249,6 +259,7 @@ class ZephyrWorker:
                 task=work.task,
                 execution_id=work.execution_id,
                 start_time=time.monotonic(),
+                attempt=work.attempt,
             )
             with self._resources_lock:
                 self._available = self._available - work.task.cost
@@ -364,6 +375,7 @@ class ZephyrWorker:
         with self._resources_lock:
             if not counters:
                 counters = active_shard.last_counters
+            self._report_shuffle_sizes(active_shard, counters)
             self._stats_writer.emit_worker_stat(
                 active_shard.task.stage_name,
                 active_shard.task.shard_idx,
@@ -385,6 +397,43 @@ class ZephyrWorker:
         stage = active[-1].task.stage_name if active else ""
         return _format_worker_status_md(len(active), stage)
 
+    def _report_shuffle_sizes(self, active: _ActiveShard, counters: dict[str, CounterEntry]) -> None:
+        if active.shuffle_reported:
+            return
+        keys = (
+            stage_counters.SHUFFLE_INPUT_ROWS,
+            stage_counters.SHUFFLE_PAYLOAD_BYTES,
+            stage_counters.SHUFFLE_NUM_SOURCES,
+        )
+        if not all(key in counters for key in keys):
+            return
+        input_rows, payload_bytes, num_sources = (int(counters[key].value) for key in keys)
+        record = ZephyrShuffleStat(
+            execution_id=active.execution_id,
+            stage_name=active.task.stage_name,
+            target_shard=active.task.shard_idx,
+            num_targets=active.task.total_shards,
+            attempt=active.attempt,
+            input_rows=input_rows,
+            payload_bytes=payload_bytes,
+            num_sources=num_sources,
+            ts=datetime.now(UTC).replace(tzinfo=None),
+            job_id=self._job_id,
+        )
+        logger.info(
+            "[%s] Shuffle %s target=%d/%d attempt=%d: input_rows=%d payload_bytes=%d num_sources=%d",
+            record.execution_id,
+            record.stage_name,
+            record.target_shard,
+            record.num_targets,
+            record.attempt,
+            record.input_rows,
+            record.payload_bytes,
+            record.num_sources,
+        )
+        self._stats_writer.emit_shuffle_stats([record])
+        active.shuffle_reported = True
+
     def _heartbeat_counter_snapshot(self) -> CounterSnapshot | None:
         """Aggregate live counters from all active runners; return None if unchanged."""
         with self._resources_lock:
@@ -392,6 +441,7 @@ class ZephyrWorker:
             for active_shard in self._active_shards:
                 counters = active_shard.runner.live_counters()
                 active_shard.last_counters = dict(counters)
+                self._report_shuffle_sizes(active_shard, counters)
                 if ZEPHYR_WORKER_MEM_CURRENT_KEY in counters:
                     self._stats_writer.emit_worker_stat(
                         active_shard.task.stage_name,

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -3,10 +3,11 @@
 
 """Tests for the pluggable StageRunner strategies (zephyr.runners)."""
 
+import json
 import os
 import time
 import uuid
-from contextlib import suppress
+from contextlib import closing, suppress
 from threading import Lock
 
 import polars as pl
@@ -238,11 +239,16 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     try:
         stage_rows = query_client.query(f'SELECT * FROM "{ZEPHYR_STAGE_STATS_NAMESPACE}"')
         worker_rows = query_client.query(f'SELECT * FROM "{ZEPHYR_WORKER_STATS_NAMESPACE}"')
+        executions = query_client.query('SELECT * FROM "zephyr.execution"').to_pylist()
         assert "zephyr.shuffle" not in {info.namespace for info in query_client.list_namespaces()}
     finally:
         query_client.close()
 
     assert stage_rows.num_rows >= 1, "Expected stage stat rows, got none"
+    assert len(executions) == 1
+    assert {stage["stage_name"] for stage in json.loads(executions[0]["stages_json"])} == {
+        stage["stage_name"] for stage in stage_rows.to_pylist()
+    }
     assert worker_rows.num_rows >= 1, "Expected worker stat rows, got none"
 
     stage_names = stage_rows.column("stage_name").to_pylist()
@@ -382,9 +388,21 @@ def test_shuffle_diagnostics_persist_target_sizes(local_client, tmp_path, finelo
         stage_rows = query_client.query('SELECT * FROM "zephyr.stage"').to_pylist()
         assert len({row["execution_id"] for row in stage_rows}) == 2
         reports = query_client.query('SELECT * FROM "zephyr.shuffle"').to_pylist()
+        executions = query_client.query('SELECT * FROM "zephyr.execution"').to_pylist()
     finally:
         query_client.close()
     assert len(reports) == 32
+    assert {execution["execution_id"] for execution in executions} == {first.execution_id, second.execution_id}
+    assert len(executions) == 2
+    for execution in executions:
+        graph = json.loads(execution["stages_json"])
+        assert {stage["stage_name"] for stage in graph if stage["stage_type"] != "reshard"} == {
+            stage["stage_name"] for stage in stage_rows if stage["execution_id"] == execution["execution_id"]
+        }
+        assert [stage["dependencies"] for stage in graph] == [[]] + [[stage["stage_name"]] for stage in graph[:-1]]
+        assert {stage["stage_name"] for stage in graph if stage["has_reduce"]} == {
+            report["stage_name"] for report in reports if report["execution_id"] == execution["execution_id"]
+        }
     assert {row["execution_id"] for row in reports} == {first.execution_id, second.execution_id}
     for execution_id in {row["execution_id"] for row in reports}:
         placeholders = [row for row in reports if row["execution_id"] == execution_id and row["input_rows"] is None]
@@ -404,6 +422,44 @@ def test_shuffle_diagnostics_persist_target_sizes(local_client, tmp_path, finelo
         assert {row["stage_name"] for row in targets} == {
             row["stage_name"] for row in stage_rows if "Reduce" in row["stage_name"]
         }
+
+
+def test_execution_plan_preserves_join_dependencies(local_client, tmp_path, finelog_server):
+    left = Dataset.from_list([{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}]).group_by(
+        key=lambda row: row["id"], reducer=lambda key, rows: next(rows), num_output_shards=2
+    )
+    right = Dataset.from_list([{"id": 1, "score": 7}]).group_by(
+        key=lambda row: row["id"], reducer=lambda key, rows: next(rows), num_output_shards=2
+    )
+    joined = left.sorted_merge_join(right, left_key=lambda row: row["id"], right_key=lambda row: row["id"])
+    with ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stats_config=StatsConfig(finelog_server),
+        stage_runner_factory=lambda: InlineRunner(),
+    ) as context:
+        result = context.execute(joined)
+
+    assert result.results == [{"id": 1, "text": "hello", "score": 7}]
+    with closing(LogClient.connect(finelog_server)) as client:
+        executions = client.query('SELECT * FROM "zephyr.execution"').to_pylist()
+        reported = client.query('SELECT stage_name FROM "zephyr.stage"').to_pylist()
+    assert len(executions) == 1
+    execution = next(row for row in executions if row["execution_id"] == result.execution_id)
+    graph = json.loads(execution["stages_json"])
+    assert {stage["stage_name"] for stage in graph if stage["stage_type"] != "reshard"} == {
+        row["stage_name"] for row in reported
+    }
+    joins = [stage for stage in graph if len(stage["dependencies"]) == 2]
+    assert len(joins) == 1
+    left_input, right_input = joins[0]["dependencies"]
+    assert not left_input.startswith("join-right-")
+    assert right_input.startswith("join-right-")
+    right_sources = [stage for stage in graph if stage["stage_name"].startswith("join-right-")]
+    assert right_sources[0]["dependencies"] == []
+    assert right_sources[-1]["stage_name"] == right_input
 
 
 def test_shuffle_diagnostics_visible_before_reducer_completes(local_client, tmp_path, finelog_server, runner_factory):

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -7,20 +7,26 @@ import os
 import time
 import uuid
 from contextlib import suppress
+from threading import Lock
 
 import polars as pl
 import pytest
 from finelog.client import LogClient
 from finelog.embedded import EmbeddedServer
 from fray.types import ResourceConfig
+from fsspec.implementations.local import LocalFileSystem
+from rigging.filesystem.storage_path import StoragePath
+from rigging.timing import Duration, ExponentialBackoff
 from zephyr import counters, runners, worker
 from zephyr.context import ZephyrContext
 from zephyr.dataset import Dataset
 from zephyr.runners import InlineRunner, SubprocessRunner
+from zephyr.shard_keys import deterministic_hash
 from zephyr.stage_io import ZephyrWorkerError
 from zephyr.stats import (
     ZEPHYR_STAGE_STATS_NAMESPACE,
     ZEPHYR_WORKER_STATS_NAMESPACE,
+    StatsConfig,
     StatsWriter,
 )
 
@@ -232,6 +238,7 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     try:
         stage_rows = query_client.query(f'SELECT * FROM "{ZEPHYR_STAGE_STATS_NAMESPACE}"')
         worker_rows = query_client.query(f'SELECT * FROM "{ZEPHYR_WORKER_STATS_NAMESPACE}"')
+        assert "zephyr.shuffle" not in {info.namespace for info in query_client.list_namespaces()}
     finally:
         query_client.close()
 
@@ -336,3 +343,215 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     # aggregate must therefore lie within the final per-shard averages.
     assert min(end_cpu_avg_pct) <= stage["cpu_pct_avg"] <= max(end_cpu_avg_pct)
     assert min(end_mem_avg_bytes) <= stage["mem_bytes_avg"] <= max(end_mem_avg_bytes)
+
+
+def test_shuffle_diagnostics_persist_target_sizes(local_client, tmp_path, finelog_server, monkeypatch, runner_factory):
+    read_bytes = StoragePath.read_bytes
+
+    def reject_extra_metadata_read(path, **kwargs):
+        if str(path).endswith("metadata.msgpack"):
+            raise AssertionError("Diagnostics must not reread metadata")
+        return read_bytes(path, **kwargs)
+
+    monkeypatch.setattr(StoragePath, "read_bytes", reject_extra_metadata_read)
+    rows = [{"key": "hot", "value": 1}] * 90 + [{"key": "cold", "value": 1}] * 10
+    dataset = (
+        Dataset.from_list(rows)
+        .reshard(2)
+        .group_by(
+            key=lambda row: row["key"],
+            reducer=lambda key, items: (key, sum(row["value"] for row in items)),
+            num_output_shards=8,
+        )
+    )
+    with ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stats_config=StatsConfig(finelog_server),
+        stage_runner_factory=runner_factory,
+    ) as context:
+        first = context.execute(dataset)
+        second = context.execute(dataset)
+
+    assert sorted(first.results) == [("cold", 10), ("hot", 90)]
+    assert sorted(second.results) == sorted(first.results)
+    query_client = LogClient.connect(finelog_server)
+    try:
+        stage_rows = query_client.query('SELECT * FROM "zephyr.stage"').to_pylist()
+        assert len({row["execution_id"] for row in stage_rows}) == 2
+        reports = query_client.query('SELECT * FROM "zephyr.shuffle"').to_pylist()
+    finally:
+        query_client.close()
+    assert len(reports) == 32
+    assert {row["execution_id"] for row in reports} == {first.execution_id, second.execution_id}
+    for execution_id in {row["execution_id"] for row in reports}:
+        placeholders = [row for row in reports if row["execution_id"] == execution_id and row["input_rows"] is None]
+        assert sorted(row["target_shard"] for row in placeholders) == list(range(8))
+        assert all(row["payload_bytes"] is None and row["num_sources"] is None for row in placeholders)
+        targets = [row for row in reports if row["execution_id"] == execution_id and row["input_rows"] is not None]
+        assert sorted(row["target_shard"] for row in targets) == list(range(8))
+        assert sum(row["input_rows"] for row in targets) == 100
+        assert max(row["input_rows"] for row in targets) >= 90
+        assert sum(row["input_rows"] == 0 for row in targets) >= 6
+        assert all((row["payload_bytes"] > 0) == (row["input_rows"] > 0) for row in targets)
+        assert {row["job_id"] for row in targets} == {""}
+        assert {row["num_targets"] for row in targets} == {8}
+        assert {row["attempt"] for row in targets} == {0}
+        assert all(0 <= row["num_sources"] <= 2 for row in targets)
+        assert all((row["num_sources"] == 0) == (row["input_rows"] == 0) for row in targets)
+        assert {row["stage_name"] for row in targets} == {
+            row["stage_name"] for row in stage_rows if "Reduce" in row["stage_name"]
+        }
+
+
+def test_shuffle_diagnostics_visible_before_reducer_completes(local_client, tmp_path, finelog_server, runner_factory):
+    key = next(value for value in range(100) if deterministic_hash(value) % 8 == 0)
+
+    def reduce_after_observation(key, items):
+        query_client = LogClient.connect(finelog_server)
+        reports = []
+
+        def input_size_visible():
+            nonlocal reports
+            if "zephyr.shuffle" not in {info.namespace for info in query_client.list_namespaces()}:
+                return False
+            reports = query_client.query('SELECT * FROM "zephyr.shuffle"').to_pylist()
+            return any(row["target_shard"] == 0 and row["input_rows"] is not None for row in reports)
+
+        try:
+            assert ExponentialBackoff().wait_until(input_size_visible, timeout=Duration.from_seconds(25))
+            placeholders = [row for row in reports if row["input_rows"] is None]
+            measured = [row for row in reports if row["input_rows"] is not None]
+            assert sorted(row["target_shard"] for row in placeholders) == list(range(8))
+            assert all(row["payload_bytes"] is None and row["num_sources"] is None for row in placeholders)
+            assert len(measured) == 1
+            assert measured[0]["input_rows"] == 10
+            assert measured[0]["num_targets"] == 8
+            assert measured[0]["num_sources"] == 2
+            return key, sum(row["value"] for row in items)
+        finally:
+            query_client.close()
+
+    dataset = (
+        Dataset.from_list([{"key": key, "value": 1}] * 10)
+        .reshard(2)
+        .group_by(key=lambda row: row["key"], reducer=reduce_after_observation, num_output_shards=8)
+    )
+    with ZephyrContext(
+        client=local_client,
+        max_workers=1,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stats_config=StatsConfig(finelog_server),
+        stage_runner_factory=runner_factory,
+    ) as context:
+        result = context.execute(dataset)
+    assert result.results == [(key, 10)]
+
+
+def test_shuffle_diagnostics_do_not_add_storage_reads(local_client, tmp_path, monkeypatch):
+    metadata_reads = []
+    read_file = LocalFileSystem.cat_file
+
+    def count_metadata_reads(filesystem, path, *args, **kwargs):
+        if str(path).endswith("metadata.msgpack"):
+            metadata_reads.append(str(path))
+        return read_file(filesystem, path, *args, **kwargs)
+
+    monkeypatch.setattr(LocalFileSystem, "cat_file", count_metadata_reads)
+    dataset = (
+        Dataset.from_list(list(range(20)))
+        .reshard(2)
+        .group_by(key=lambda value: value % 3, reducer=lambda key, values: (key, sum(values)), num_output_shards=8)
+    )
+    with ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stage_runner_factory=InlineRunner,
+    ) as context:
+        result = context.execute(dataset)
+    assert sorted(result.results) == [(0, 63), (1, 70), (2, 57)]
+    assert len(metadata_reads) == 2 * 8
+
+
+def test_shuffle_diagnostics_preserve_retry_attempts(local_client, tmp_path, finelog_server, runner_factory):
+    retry_marker = tmp_path / "retried"
+
+    def reduce_with_retry(key, values):
+        if not retry_marker.exists():
+            retry_marker.touch()
+            raise OSError("Retry the reducer after its metadata is ready")
+        return key, sum(values)
+
+    dataset = Dataset.from_list([1, 2, 3]).group_by(key=lambda value: 0, reducer=reduce_with_retry, num_output_shards=1)
+    with ZephyrContext(
+        client=local_client,
+        max_workers=1,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stats_config=StatsConfig(finelog_server),
+        stage_runner_factory=runner_factory,
+    ) as context:
+        result = context.execute(dataset)
+    assert result.results == [(0, 6)]
+    query_client = LogClient.connect(finelog_server)
+    try:
+        observations = query_client.query(
+            'SELECT * FROM "zephyr.shuffle" WHERE input_rows IS NOT NULL ORDER BY attempt'
+        ).to_pylist()
+    finally:
+        query_client.close()
+    assert [row["attempt"] for row in observations] == [0, 1]
+    assert {row["execution_id"] for row in observations} == {result.execution_id}
+    assert {row["target_shard"] for row in observations} == {0}
+    assert {row["input_rows"] for row in observations} == {3}
+
+
+def test_shuffle_placeholders_visible_before_metadata_read(local_client, tmp_path, finelog_server, monkeypatch):
+    initial_reports = []
+    metadata_lock = Lock()
+    read_file = LocalFileSystem.cat_file
+
+    def read_after_placeholders(filesystem, path, *args, **kwargs):
+        nonlocal initial_reports
+        if str(path).endswith("metadata.msgpack"):
+            with metadata_lock:
+                if not initial_reports:
+                    query_client = LogClient.connect(finelog_server)
+
+                    def placeholders_visible():
+                        nonlocal initial_reports
+                        if "zephyr.shuffle" not in {info.namespace for info in query_client.list_namespaces()}:
+                            return False
+                        initial_reports = query_client.query('SELECT * FROM "zephyr.shuffle"').to_pylist()
+                        return len(initial_reports) == 8
+
+                    try:
+                        assert ExponentialBackoff().wait_until(placeholders_visible, timeout=Duration.from_seconds(10))
+                        assert all(row["input_rows"] is None for row in initial_reports)
+                    finally:
+                        query_client.close()
+        return read_file(filesystem, path, *args, **kwargs)
+
+    monkeypatch.setattr(LocalFileSystem, "cat_file", read_after_placeholders)
+    dataset = Dataset.from_list([1, 2, 3]).group_by(
+        key=lambda value: 0, reducer=lambda key, values: sum(values), num_output_shards=8
+    )
+    with ZephyrContext(
+        client=local_client,
+        max_workers=1,
+        max_shard_failures=1,
+        resources=ResourceConfig(cpu=1, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        stats_config=StatsConfig(finelog_server),
+        stage_runner_factory=InlineRunner,
+    ) as context:
+        result = context.execute(dataset)
+    assert result.results == [6]
+    assert sorted(row["target_shard"] for row in initial_reports) == list(range(8))
+    assert {row["execution_id"] for row in initial_reports} == {result.execution_id}
+    assert all(row["input_rows"] is row["payload_bytes"] is row["num_sources"] is None for row in initial_reports)

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -852,3 +852,25 @@ def test_sidecar_reads_build_one_client(tmp_path):
 
     assert [sidecar.path for sidecar in sidecars] == paths
     assert _CountingFileSystem.clients_built == 1
+
+
+def test_scatter_reader_reports_input_totals_including_empty_targets(tmp_path):
+    rows = [{"k": 1, "v": value} for value in range(9)] + [{"k": 3, "v": 100}]
+    paths = [str(tmp_path / f"mapper-{index}") + "/" for index in range(3)]
+    for index, chunk in enumerate((rows[:5], rows[5:], [])):
+        _write_scatter(iter(chunk), index, paths[index], key_fn=lambda row: row["k"], num_output_shards=8)
+
+    expected_rows = [0] * 8
+    for row in rows:
+        expected_rows[deterministic_hash(row["k"]) % 8] += 1
+    for target, count in enumerate(expected_rows):
+        reader = ScatterReader.from_sidecars(paths, target)
+        assert reader.shard_payload_rows == count == len(_read_shard(reader))
+        assert reader.shard_payload_bytes == sum(
+            len(cloudpickle.dumps(row)) for row in rows if deterministic_hash(row["k"]) % 8 == target
+        )
+        assert reader.contributing_sidecars == sum(
+            any(deterministic_hash(row["k"]) % 8 == target for row in chunk) for chunk in (rows[:5], rows[5:], [])
+        )
+    empty_reader = ScatterReader.from_sidecars([], 0)
+    assert empty_reader.shard_payload_rows == empty_reader.shard_payload_bytes == empty_reader.contributing_sidecars == 0

--- a/lib/zephyr/tests/test_shuffle_report.py
+++ b/lib/zephyr/tests/test_shuffle_report.py
@@ -1,0 +1,197 @@
+"""Checks for reducer chart values, grouping, and untrusted labels."""
+
+from dataclasses import replace
+from datetime import datetime, timedelta
+from html.parser import HTMLParser
+from pathlib import Path
+
+import pytest
+from zephyr.shuffle_report import render_shuffle_report
+from zephyr.stats import ZephyrShuffleStat
+
+
+class ReportParser(HTMLParser):
+    def __init__(self, source: str):
+        super().__init__()
+        self.elements: list[tuple[str, dict[str, str]]] = []
+        self.feed(source)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.elements.append((tag, {key: value for key, value in attrs if value is not None}))
+
+
+@pytest.mark.parametrize("sizes,expected_bins", [([0, 1, 9, 90], [3, 0, 0, 0, 0, 0, 0, 0, 0, 1]), ([0, 0, 0, 0], [4])])
+def test_report_preserves_target_values_and_histogram_counts(tmp_path: Path, sizes: list[int], expected_bins: list[int]):
+    records = [
+        ZephyrShuffleStat(
+            execution_id="execution",
+            stage_name="reduce",
+            target_shard=target,
+            num_targets=len(sizes),
+            attempt=0,
+            input_rows=size,
+            payload_bytes=size * 10,
+            num_sources=2,
+            ts=datetime(2026, 9, 9),
+            job_id="",
+        )
+        for target, size in enumerate(sizes)
+    ]
+    output = tmp_path / "report.html"
+    render_shuffle_report(records, output)
+    parsed = ReportParser(output.read_text())
+    ranked = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-target" in attrs]
+    assert [int(attrs["data-value"]) for attrs in ranked] == sorted(sizes, reverse=True) + sorted(
+        [size * 10 for size in sizes], reverse=True
+    )
+    bins = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-count" in attrs]
+    assert [int(attrs["data-count"]) for attrs in bins] == expected_bins * 2
+    assert max(int(attrs["data-upper"]) for attrs in bins) == max(sizes) * 10
+    summaries = [attrs for _, attrs in parsed.elements if "data-empty-targets" in attrs]
+    assert int(summaries[0]["data-empty-targets"]) == sizes.count(0)
+
+
+def test_report_separates_stages_and_escapes_labels(tmp_path: Path):
+    label = '<script>alert("unsafe")</script>'
+    records = [
+        ZephyrShuffleStat(
+            execution_id=label,
+            stage_name=stage,
+            target_shard=0,
+            num_targets=1,
+            attempt=0,
+            input_rows=1,
+            payload_bytes=10,
+            num_sources=2,
+            ts=datetime(2026, 9, 9),
+            job_id=label,
+        )
+        for stage in ["reduce-a", "reduce-b"]
+    ]
+    output = tmp_path / "report.html"
+    render_shuffle_report(records, output)
+    parsed = ReportParser(output.read_text())
+    sections = [attrs for tag, attrs in parsed.elements if tag == "section"]
+    assert [attrs["data-stage"] for attrs in sections] == ["reduce-a", "reduce-b"]
+    assert [attrs["data-execution"] for attrs in sections] == [label, label]
+    assert not any(tag == "script" for tag, _ in parsed.elements)
+
+
+def test_report_retry_observations_prefer_attempt_then_timestamp(tmp_path: Path):
+    record = ZephyrShuffleStat(
+        execution_id="execution",
+        stage_name="reduce",
+        target_shard=0,
+        num_targets=1,
+        attempt=1,
+        input_rows=1,
+        payload_bytes=10,
+        num_sources=2,
+        ts=datetime(2026, 9, 9),
+        job_id="",
+    )
+    newer_attempt = replace(record, attempt=2, input_rows=2, payload_bytes=20)
+    newer_timestamp = replace(newer_attempt, input_rows=3, payload_bytes=30, ts=record.ts + timedelta(seconds=1))
+    delayed_old_attempt = replace(record, input_rows=99, payload_bytes=990, ts=record.ts + timedelta(seconds=2))
+    output = tmp_path / "report.html"
+    render_shuffle_report([newer_timestamp, newer_attempt, record, record, delayed_old_attempt], output)
+    parsed = ReportParser(output.read_text())
+    ranked = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-target" in attrs]
+    assert [int(attrs["data-value"]) for attrs in ranked] == [3, 30]
+    summary = next(attrs for _, attrs in parsed.elements if "data-targets" in attrs)
+    assert summary["data-targets"] == "1"
+
+
+def test_report_partial_coverage_keeps_unreported_targets_out_of_histograms(tmp_path: Path):
+    empty = ZephyrShuffleStat(
+        execution_id="execution",
+        stage_name="reduce",
+        target_shard=1,
+        num_targets=4,
+        attempt=0,
+        input_rows=0,
+        payload_bytes=0,
+        num_sources=2,
+        ts=datetime(2026, 9, 9),
+        job_id="",
+    )
+    populated = replace(empty, target_shard=3, input_rows=25, payload_bytes=250)
+    output = tmp_path / "report.html"
+    render_shuffle_report([empty, populated], output)
+    parsed = ReportParser(output.read_text())
+    summary = next(attrs for _, attrs in parsed.elements if "data-targets" in attrs)
+    assert summary["data-targets"] == "2"
+    assert summary["data-expected-targets"] == "4"
+    assert summary["data-unreported-targets"] == "2"
+    assert summary["data-empty-targets"] == "1"
+    assert summary["data-coverage"] == "partial"
+    ranked = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-target" in attrs]
+    assert [int(attrs["data-target"]) for attrs in ranked if "data-value" in attrs] == [3, 1, 3, 1]
+    assert [int(attrs["data-target"]) for attrs in ranked if attrs.get("data-status") == "UNREPORTED"] == [0, 2, 0, 2]
+    assert all("data-value" not in attrs for attrs in ranked if attrs.get("data-status") == "UNREPORTED")
+    bins = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-count" in attrs]
+    assert sum(int(attrs["data-count"]) for attrs in bins) == 4
+
+
+def test_report_without_observations_has_unknown_coverage(tmp_path: Path):
+    output = tmp_path / "report.html"
+    render_shuffle_report([], output)
+    parsed = ReportParser(output.read_text())
+    assert any(attrs.get("data-coverage") == "unknown" for _, attrs in parsed.elements)
+    assert not any("data-targets" in attrs or "data-metric" in attrs for _, attrs in parsed.elements)
+
+
+def test_report_placeholder_only_stage_shows_all_ids_without_zero_measurements(tmp_path: Path):
+    placeholder = ZephyrShuffleStat(
+        execution_id="execution",
+        stage_name="reduce",
+        target_shard=1,
+        num_targets=3,
+        attempt=0,
+        input_rows=None,
+        payload_bytes=None,
+        num_sources=None,
+        ts=datetime(2026, 9, 9),
+        job_id="",
+    )
+    output = tmp_path / "report.html"
+    render_shuffle_report([placeholder], output)
+    parsed = ReportParser(output.read_text())
+    summary = next(attrs for _, attrs in parsed.elements if "data-targets" in attrs)
+    assert summary["data-targets"] == "0"
+    assert summary["data-expected-targets"] == "3"
+    assert summary["data-unreported-targets"] == "3"
+    assert summary["data-empty-targets"] == "0"
+    assert summary["data-coverage"] == "partial"
+    ranked = [attrs for tag, attrs in parsed.elements if tag == "tr" and "data-target" in attrs]
+    assert [int(attrs["data-target"]) for attrs in ranked] == [0, 1, 2, 0, 1, 2]
+    assert all(attrs["data-status"] == "UNREPORTED" and "data-value" not in attrs for attrs in ranked)
+    assert not any("data-count" in attrs for _, attrs in parsed.elements)
+
+
+@pytest.mark.parametrize("input_rows", [0, 25])
+def test_report_delayed_placeholder_cannot_replace_measurement(tmp_path: Path, input_rows: int):
+    measurement = ZephyrShuffleStat(
+        execution_id="execution",
+        stage_name="reduce",
+        target_shard=0,
+        num_targets=2,
+        attempt=0,
+        input_rows=input_rows,
+        payload_bytes=input_rows * 10,
+        num_sources=1 if input_rows else 0,
+        ts=datetime(2026, 9, 9),
+        job_id="",
+    )
+    delayed_placeholder = replace(
+        measurement, input_rows=None, payload_bytes=None, num_sources=None, ts=measurement.ts + timedelta(seconds=1)
+    )
+    output = tmp_path / "report.html"
+    render_shuffle_report([measurement, delayed_placeholder, replace(delayed_placeholder, target_shard=1)], output)
+    parsed = ReportParser(output.read_text())
+    summary = next(attrs for _, attrs in parsed.elements if "data-targets" in attrs)
+    assert summary["data-targets"] == "1"
+    assert summary["data-unreported-targets"] == "1"
+    assert int(summary["data-empty-targets"]) == int(input_rows == 0)
+    values = [int(attrs["data-value"]) for tag, attrs in parsed.elements if tag == "tr" and "data-value" in attrs]
+    assert values == [input_rows, input_rows * 10]

--- a/lib/zephyr/tests/test_shuffle_report.py
+++ b/lib/zephyr/tests/test_shuffle_report.py
@@ -1,3 +1,6 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
 """Checks for reducer chart values, grouping, and untrusted labels."""
 
 from dataclasses import replace


### PR DESCRIPTION
Requested by @ravwojdyla:

Add execution and stage navigation to the Iris job page. Join plans open as a dependency graph; other plans open as a stage list. A browser preference overrides that default. Both views share the selected stage, its completion report, and each reducer's input sizes and latest worker-task status.

Persist one physical plan per execution, linked to its root Iris job. Query reducer data in Finelog with 20-row pages and payload sizes relative to the stage median. Null placeholders remain visible; missing measurements count toward unreported coverage. Worker status has no retry-attempt identifier. Older executions without a persisted plan do not appear in the selector.

Builds on #9087.

Here's what it actually looks like:
<img width="1271" height="647" alt="image" src="https://github.com/user-attachments/assets/5d6ae71c-8eb6-4166-a81f-03ab9401bfe9" />
<img width="1245" height="798" alt="image" src="https://github.com/user-attachments/assets/df01d40d-92ca-4f2b-a5f6-536a8f60cce9" />

