### PR TITLE
[evaldash] Add sort direction and last-updated column

### DIFF
--- a/infra/marina/apps/evaldash/README.md
+++ b/infra/marina/apps/evaldash/README.md
@@ -103,7 +103,8 @@ behind it, the per-cause counts of items it attempted and never graded, and a 95
 reports an attempted count, the interval covers the ungraded items by Manski bounds with an
 Imbens-Manski critical value rather than imputing them; when it reports none, the interval is labelled
 `sampling_only`, because completeness is then unknown. Rankings sort on the interval's lower bound, so
-losing items cannot buy rank.
+losing items cannot buy rank. Each row carries `last_updated`, the newest `created_at` among the cells
+it contributed, so a row's freshness is readable even though its cells can come from different launches.
 
 Both runners establish that attempted count. Harbor reports the trials it dispatched; lm-eval publishes
 no such count in its aggregate results, so the evalchemy path derives it from the document indices in

--- a/infra/marina/apps/evaldash/README.md
+++ b/infra/marina/apps/evaldash/README.md
@@ -103,8 +103,7 @@ behind it, the per-cause counts of items it attempted and never graded, and a 95
 reports an attempted count, the interval covers the ungraded items by Manski bounds with an
 Imbens-Manski critical value rather than imputing them; when it reports none, the interval is labelled
 `sampling_only`, because completeness is then unknown. Rankings sort on the interval's lower bound, so
-losing items cannot buy rank. Each row carries `last_updated`, the newest `created_at` among the cells
-it contributed, so a row's freshness is readable even though its cells can come from different launches.
+losing items cannot buy rank. Each row's `last_updated` is the maximum `created_at` among its cells.
 
 Both runners establish that attempted count. Harbor reports the trials it dispatched; lm-eval publishes
 no such count in its aggregate results, so the evalchemy path derives it from the document indices in

--- a/infra/marina/apps/evaldash/app.py
+++ b/infra/marina/apps/evaldash/app.py
@@ -167,6 +167,7 @@ class PanelRowResponse(BaseModel):
     missing: dict[str, MissingCellResponse]
     aggregate: PanelAggregateResponse | None
     covered: int
+    last_updated: str | None
 
 
 class PanelRequestResponse(BaseModel):

--- a/infra/marina/apps/evaldash/metrics.py
+++ b/infra/marina/apps/evaldash/metrics.py
@@ -231,6 +231,9 @@ def build_panel(
                 "archived": model in archived_models,
                 "cells": {name: cell_payload(measurement) for name, measurement in cells.items()},
                 "missing": missing.get(model, {}),
+                # The newest run behind any of the row's cells. Cells come from different launches,
+                # so this is the freshest result on the row, not the age of every number in it.
+                "last_updated": max((measurement.created_at for measurement in cells.values()), default=None),
                 "aggregate": _aggregate_payload(panel_aggregate(cells, protocol)) if protocol else None,
                 "covered": sum(1 for name in panel if name in cells),
             }

--- a/infra/marina/apps/evaldash/metrics.py
+++ b/infra/marina/apps/evaldash/metrics.py
@@ -231,8 +231,6 @@ def build_panel(
                 "archived": model in archived_models,
                 "cells": {name: cell_payload(measurement) for name, measurement in cells.items()},
                 "missing": missing.get(model, {}),
-                # The newest run behind any of the row's cells. Cells come from different launches,
-                # so this is the freshest result on the row, not the age of every number in it.
                 "last_updated": max((measurement.created_at for measurement in cells.values()), default=None),
                 "aggregate": _aggregate_payload(panel_aggregate(cells, protocol)) if protocol else None,
                 "covered": sum(1 for name in panel if name in cells),

--- a/infra/marina/apps/evaldash/tests/test_kernel_app.py
+++ b/infra/marina/apps/evaldash/tests/test_kernel_app.py
@@ -77,7 +77,6 @@ def test_the_mounted_api_serves_what_the_reconciler_committed(engine, records, d
         assert client.get("/runs/snowball-2026.07.20-mmlu").json()["status"] == "succeeded"
         assert client.get("/status").json()["store"]["catalog_generation"] > 0
 
-        # The row timestamp has to survive the response model, not just build_panel.
         snowball = next(row for row in client.get("/panel").json()["rows"] if row["model"] == "snowball")
         assert snowball["last_updated"] == max(cell["created_at"] for cell in snowball["cells"].values())
 

--- a/infra/marina/apps/evaldash/tests/test_kernel_app.py
+++ b/infra/marina/apps/evaldash/tests/test_kernel_app.py
@@ -77,6 +77,10 @@ def test_the_mounted_api_serves_what_the_reconciler_committed(engine, records, d
         assert client.get("/runs/snowball-2026.07.20-mmlu").json()["status"] == "succeeded"
         assert client.get("/status").json()["store"]["catalog_generation"] > 0
 
+        # The row timestamp has to survive the response model, not just build_panel.
+        snowball = next(row for row in client.get("/panel").json()["rows"] if row["model"] == "snowball")
+        assert snowball["last_updated"] == max(cell["created_at"] for cell in snowball["cells"].values())
+
 
 def test_a_second_instance_serves_the_generation_the_first_committed(engine, records):
     evaldash_app.migrate(engine)

--- a/infra/marina/apps/evaldash/tests/test_metrics.py
+++ b/infra/marina/apps/evaldash/tests/test_metrics.py
@@ -70,6 +70,34 @@ def test_panel_takes_the_latest_valid_result_for_each_benchmark_across_cohorts()
     assert row["cells"]["gsm8k-0shot"]["version"] == "v1"
 
 
+def test_a_row_is_dated_by_its_newest_contributing_cell():
+    """``last_updated`` answers how fresh a row's numbers are, so a newer run that contributed no
+    cell does not date the row: here the failed ``drop`` run is the newest run on the model."""
+    records = [
+        _record("m", "gsm8k-0shot", "v1", "2026-01-01T00:00:00+00:00", 0.30),
+        _record("m", "mmlu", "v2", "2026-02-01T00:00:00+00:00", 0.70),
+        _record("m", "drop", "v3", "2026-03-01T00:00:00+00:00", None),
+    ]
+
+    (row,) = build_panel(records, panel_request())["rows"]
+
+    assert row["last_updated"] == "2026-02-01T00:00:00+00:00"
+
+
+def test_a_single_cohort_row_is_dated_by_the_last_eval_of_that_launch():
+    """One launch's evals finish at different times, and the row reports the last of them rather
+    than the launch's first result."""
+    records = [
+        _record("m", "mmlu", "v1", "2026-01-01T00:00:00+00:00", 0.50),
+        _record("m", "gsm8k-0shot", "v1", "2026-01-01T06:00:00+00:00", 0.30),
+    ]
+
+    (row,) = build_panel(records, panel_request())["rows"]
+
+    assert {cell["version"] for cell in row["cells"].values()} == {"v1"}
+    assert row["last_updated"] == "2026-01-01T06:00:00+00:00"
+
+
 def test_panel_can_be_pinned_to_one_cohort():
     records = [
         _record("m", "mmlu", "v1", "2026-01-01T00:00:00+00:00", 0.50),

--- a/infra/marina/apps/evaldash/tests/test_metrics.py
+++ b/infra/marina/apps/evaldash/tests/test_metrics.py
@@ -71,8 +71,6 @@ def test_panel_takes_the_latest_valid_result_for_each_benchmark_across_cohorts()
 
 
 def test_a_row_is_dated_by_its_newest_contributing_cell():
-    """``last_updated`` answers how fresh a row's numbers are, so a newer run that contributed no
-    cell does not date the row: here the failed ``drop`` run is the newest run on the model."""
     records = [
         _record("m", "gsm8k-0shot", "v1", "2026-01-01T00:00:00+00:00", 0.30),
         _record("m", "mmlu", "v2", "2026-02-01T00:00:00+00:00", 0.70),
@@ -82,20 +80,6 @@ def test_a_row_is_dated_by_its_newest_contributing_cell():
     (row,) = build_panel(records, panel_request())["rows"]
 
     assert row["last_updated"] == "2026-02-01T00:00:00+00:00"
-
-
-def test_a_single_cohort_row_is_dated_by_the_last_eval_of_that_launch():
-    """One launch's evals finish at different times, and the row reports the last of them rather
-    than the launch's first result."""
-    records = [
-        _record("m", "mmlu", "v1", "2026-01-01T00:00:00+00:00", 0.50),
-        _record("m", "gsm8k-0shot", "v1", "2026-01-01T06:00:00+00:00", 0.30),
-    ]
-
-    (row,) = build_panel(records, panel_request())["rows"]
-
-    assert {cell["version"] for cell in row["cells"].values()} == {"v1"}
-    assert row["last_updated"] == "2026-01-01T06:00:00+00:00"
 
 
 def test_panel_can_be_pinned_to_one_cohort():

--- a/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
+++ b/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
@@ -244,6 +244,10 @@ function sortGlyph(key: string): string {
   if (sortKey.value !== key) return ''
   return sortDirection.value === 'asc' ? '▲' : '▼'
 }
+// Every sortable header marks the active column in the accent colour.
+function headerClass(key: string): string {
+  return sortKey.value === key ? 'text-accent' : 'text-text-secondary'
+}
 
 // What the active column ranks a row on. null means the row has nothing to rank there: no cell on
 // that benchmark, or no result at all behind its timestamp.
@@ -521,7 +525,7 @@ function goToModel(model: string) {
                 <th class="px-3 py-2 text-left w-8"></th>
                 <th
                   class="px-3 py-2 text-left cursor-pointer"
-                  :class="sortKey === MODEL_SORT ? 'text-accent' : 'text-text-secondary'"
+                  :class="headerClass(MODEL_SORT)"
                   title="Sort by model name"
                   @click="sortBy(MODEL_SORT)"
                 >
@@ -529,7 +533,7 @@ function goToModel(model: string) {
                 </th>
                 <th
                   class="px-3 py-2 text-left cursor-pointer"
-                  :class="sortKey === COVERAGE_SORT ? 'text-accent' : 'text-text-secondary'"
+                  :class="headerClass(COVERAGE_SORT)"
                   title="Sort by panel coverage"
                   @click="sortBy(COVERAGE_SORT)"
                 >
@@ -649,7 +653,7 @@ function goToModel(model: string) {
               <tr class="border-b border-surface-border bg-surface-raised">
                 <th
                   class="sticky left-0 z-10 bg-surface-raised px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider cursor-pointer"
-                  :class="sortKey === MODEL_SORT ? 'text-accent' : 'text-text-secondary'"
+                  :class="headerClass(MODEL_SORT)"
                   title="Sort by model name"
                   @click="sortBy(MODEL_SORT)"
                 >
@@ -659,7 +663,7 @@ function goToModel(model: string) {
                   v-for="task in visibleTasks"
                   :key="task"
                   class="px-3 py-2 text-center text-xs font-semibold uppercase tracking-wider whitespace-nowrap cursor-pointer"
-                  :class="sortKey === task ? 'text-accent' : 'text-text-secondary'"
+                  :class="headerClass(task)"
                   @click="sortBy(task)"
                 >
                   {{ task }} {{ sortGlyph(task) }}
@@ -672,7 +676,7 @@ function goToModel(model: string) {
                 </th>
                 <th
                   class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider whitespace-nowrap cursor-pointer"
-                  :class="sortKey === UPDATED_SORT ? 'text-accent' : 'text-text-secondary'"
+                  :class="headerClass(UPDATED_SORT)"
                   title="Newest contributing benchmark result; individual cells may be older"
                   @click="sortBy(UPDATED_SORT)"
                 >

--- a/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
+++ b/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
@@ -217,9 +217,7 @@ const visibleTasks = computed(() => data.value?.panel ?? [])
 // --- Fleet best per benchmark (the rail caret and the column marker) ---
 const best = computed(() => fleetBest(data.value?.rows ?? [], visibleTasks.value))
 
-// --- Ordering: by model name, panel coverage, last update, or a benchmark column's interval lower
-// bound. Sorting a benchmark on the lower bound is the point — a partly-graded run cannot buy rank
-// with the items it kept. Every column sorts both ways; clicking the active column flips it. ---
+// --- Ordering. Benchmark columns use the interval lower bound. ---
 const MODEL_SORT = 'model'
 const COVERAGE_SORT = 'coverage'
 const UPDATED_SORT = 'last_updated'
@@ -228,7 +226,6 @@ type SortDirection = 'asc' | 'desc'
 const sortKey = ref<string>(COVERAGE_SORT)
 const sortDirection = ref<SortDirection>('desc')
 
-// Names read A→Z; scores, coverage and recency read best-first.
 function defaultDirection(key: string): SortDirection {
   return key === MODEL_SORT ? 'asc' : 'desc'
 }
@@ -244,13 +241,10 @@ function sortGlyph(key: string): string {
   if (sortKey.value !== key) return ''
   return sortDirection.value === 'asc' ? '▲' : '▼'
 }
-// Every sortable header marks the active column in the accent colour.
 function headerClass(key: string): string {
   return sortKey.value === key ? 'text-accent' : 'text-text-secondary'
 }
 
-// What the active column ranks a row on. null means the row has nothing to rank there: no cell on
-// that benchmark, or no result at all behind its timestamp.
 function sortValue(row: PanelRow): string | number | null {
   if (sortKey.value === MODEL_SORT) return row.model
   if (sortKey.value === COVERAGE_SORT) return row.covered
@@ -265,8 +259,7 @@ const rows = computed<PanelRow[]>(() => {
     if (a.archived !== b.archived) return Number(a.archived) - Number(b.archived)
     const av = sortValue(a)
     const bv = sortValue(b)
-    // Rows with nothing to rank stay at the bottom in both directions: reversing the order asks a
-    // question about the ranked rows, and answering it should not float the unranked ones to the top.
+    // Missing values sort last in both directions.
     if (av === null || bv === null) {
       if (av !== bv) return av === null ? 1 : -1
       return a.model.localeCompare(b.model)
@@ -642,8 +635,8 @@ function goToModel(model: string) {
           <h3 class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
             Per-benchmark
             <span class="font-normal normal-case text-text-muted">
-              ({{ rows.length }} models × {{ visibleTasks.length }} benchmarks · click a header to sort, again to
-              reverse; a benchmark sorts on its interval's lower bound · a cell for history)
+              ({{ rows.length }} models × {{ visibleTasks.length }} benchmarks · benchmarks sort on interval lower
+              bound · click a cell for history)
             </span>
           </h3>
         </div>
@@ -677,7 +670,7 @@ function goToModel(model: string) {
                 <th
                   class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider whitespace-nowrap cursor-pointer"
                   :class="headerClass(UPDATED_SORT)"
-                  title="Newest contributing benchmark result; individual cells may be older"
+                  title="Latest result included in this row"
                   @click="sortBy(UPDATED_SORT)"
                 >
                   Last updated {{ sortGlyph(UPDATED_SORT) }}
@@ -738,7 +731,7 @@ function goToModel(model: string) {
                 </td>
                 <td
                   class="px-3 py-2 text-right whitespace-nowrap font-mono text-[11px] tabular-nums text-text-muted"
-                  title="Newest contributing benchmark result; individual cells may be older"
+                  title="Latest result included in this row"
                 >
                   {{ formatTimestamp(row.last_updated) }}
                 </td>
@@ -752,8 +745,7 @@ function goToModel(model: string) {
           — means the model never ran that benchmark. A result the engine flags as suspect is held out of the
           panel as <span class="text-status-warning">flagged</span> rather than standing as a model's newest score;
           "Show flagged results" admits it, marked with a <span class="text-status-warning">*</span>. Last updated is
-          the newest contributing benchmark result; individual cells may be older, and each cell's own timestamp is in
-          its tooltip.
+          the maximum timestamp among the row's displayed cells. Each cell's timestamp appears in its tooltip.
         </p>
       </div>
     </div>

--- a/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
+++ b/infra/marina/apps/evaldash/web/src/pages/PanelPage.vue
@@ -12,7 +12,7 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiPost, useApi } from '@/composables/useApi'
 import { onViewRefresh } from '@/composables/useRefresh'
-import { formatCoverage, formatDelta, formatInterval, formatScore } from '@/utils/formatting'
+import { formatCoverage, formatDelta, formatInterval, formatScore, formatTimestamp } from '@/utils/formatting'
 import { scoreTint } from '@/utils/score'
 import { cellsByModel, fleetBest, isPartialCoverage } from '@/utils/panel'
 import { MAX_COMPARE, isSmokeEval } from '@/constants'
@@ -217,27 +217,58 @@ const visibleTasks = computed(() => data.value?.panel ?? [])
 // --- Fleet best per benchmark (the rail caret and the column marker) ---
 const best = computed(() => fleetBest(data.value?.rows ?? [], visibleTasks.value))
 
-// --- Ordering: by a benchmark column's interval lower bound, else by panel coverage. Sorting on the
-// lower bound is the point — a partly-graded run cannot buy rank with the items it kept. ---
+// --- Ordering: by model name, panel coverage, last update, or a benchmark column's interval lower
+// bound. Sorting a benchmark on the lower bound is the point — a partly-graded run cannot buy rank
+// with the items it kept. Every column sorts both ways; clicking the active column flips it. ---
+const MODEL_SORT = 'model'
 const COVERAGE_SORT = 'coverage'
+const UPDATED_SORT = 'last_updated'
+type SortDirection = 'asc' | 'desc'
+
 const sortKey = ref<string>(COVERAGE_SORT)
-function sortBy(key: string) {
-  sortKey.value = sortKey.value === key ? COVERAGE_SORT : key
+const sortDirection = ref<SortDirection>('desc')
+
+// Names read A→Z; scores, coverage and recency read best-first.
+function defaultDirection(key: string): SortDirection {
+  return key === MODEL_SORT ? 'asc' : 'desc'
 }
+function sortBy(key: string) {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    return
+  }
+  sortKey.value = key
+  sortDirection.value = defaultDirection(key)
+}
+function sortGlyph(key: string): string {
+  if (sortKey.value !== key) return ''
+  return sortDirection.value === 'asc' ? '▲' : '▼'
+}
+
+// What the active column ranks a row on. null means the row has nothing to rank there: no cell on
+// that benchmark, or no result at all behind its timestamp.
+function sortValue(row: PanelRow): string | number | null {
+  if (sortKey.value === MODEL_SORT) return row.model
+  if (sortKey.value === COVERAGE_SORT) return row.covered
+  if (sortKey.value === UPDATED_SORT) return row.last_updated
+  return row.cells[sortKey.value]?.low ?? null
+}
+
 const rows = computed<PanelRow[]>(() => {
   const all = [...(data.value?.rows ?? [])]
+  const direction = sortDirection.value === 'asc' ? 1 : -1
   return all.sort((a, b) => {
     if (a.archived !== b.archived) return Number(a.archived) - Number(b.archived)
-    if (sortKey.value === COVERAGE_SORT) {
-      if (a.covered !== b.covered) return b.covered - a.covered
+    const av = sortValue(a)
+    const bv = sortValue(b)
+    // Rows with nothing to rank stay at the bottom in both directions: reversing the order asks a
+    // question about the ranked rows, and answering it should not float the unranked ones to the top.
+    if (av === null || bv === null) {
+      if (av !== bv) return av === null ? 1 : -1
       return a.model.localeCompare(b.model)
     }
-    const av = a.cells[sortKey.value]?.low ?? null
-    const bv = b.cells[sortKey.value]?.low ?? null
-    if (av === null && bv === null) return a.model.localeCompare(b.model)
-    if (av === null) return 1
-    if (bv === null) return -1
-    return bv - av
+    const ordered = typeof av === 'string' ? av.localeCompare(bv as string) : av - (bv as number)
+    return ordered * direction || a.model.localeCompare(b.model)
   })
 })
 
@@ -295,7 +326,7 @@ function cellTitle(cell: PanelCell): string {
     `${cell.metric} · ${cell.n_scored} items graded`,
     `95% ${formatInterval(cell.low, cell.high)} · ${scope}`,
     ...cell.flags.filter((flag) => flag in FLAG_NOTES).map((flag) => FLAG_NOTES[flag]),
-    `run ${cell.run_id}`,
+    `run ${cell.run_id} · ${formatTimestamp(cell.created_at)}`,
     `cohort ${cell.version ?? 'unversioned'} · ${cell.eval_runtime}`,
     'click for history',
   ].join('\n')
@@ -488,8 +519,22 @@ function goToModel(model: string) {
                 class="border-b border-surface-border bg-surface-raised text-xs font-semibold uppercase tracking-wider text-text-secondary"
               >
                 <th class="px-3 py-2 text-left w-8"></th>
-                <th class="px-3 py-2 text-left">Model</th>
-                <th class="px-3 py-2 text-left">Coverage</th>
+                <th
+                  class="px-3 py-2 text-left cursor-pointer"
+                  :class="sortKey === MODEL_SORT ? 'text-accent' : 'text-text-secondary'"
+                  title="Sort by model name"
+                  @click="sortBy(MODEL_SORT)"
+                >
+                  Model {{ sortGlyph(MODEL_SORT) }}
+                </th>
+                <th
+                  class="px-3 py-2 text-left cursor-pointer"
+                  :class="sortKey === COVERAGE_SORT ? 'text-accent' : 'text-text-secondary'"
+                  title="Sort by panel coverage"
+                  @click="sortBy(COVERAGE_SORT)"
+                >
+                  Coverage {{ sortGlyph(COVERAGE_SORT) }}
+                </th>
                 <th v-if="aggregatePolicy" class="px-3 py-2 text-right">Panel aggregate</th>
                 <th class="px-3 py-2 text-left">Profile</th>
                 <th class="px-3 py-2 text-right"></th>
@@ -593,8 +638,8 @@ function goToModel(model: string) {
           <h3 class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
             Per-benchmark
             <span class="font-normal normal-case text-text-muted">
-              ({{ rows.length }} models × {{ visibleTasks.length }} benchmarks · click a header to sort by its lower
-              bound · a cell for history)
+              ({{ rows.length }} models × {{ visibleTasks.length }} benchmarks · click a header to sort, again to
+              reverse; a benchmark sorts on its interval's lower bound · a cell for history)
             </span>
           </h3>
         </div>
@@ -604,11 +649,11 @@ function goToModel(model: string) {
               <tr class="border-b border-surface-border bg-surface-raised">
                 <th
                   class="sticky left-0 z-10 bg-surface-raised px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider cursor-pointer"
-                  :class="sortKey === COVERAGE_SORT ? 'text-accent' : 'text-text-secondary'"
-                  title="Sort by panel coverage"
-                  @click="sortBy(COVERAGE_SORT)"
+                  :class="sortKey === MODEL_SORT ? 'text-accent' : 'text-text-secondary'"
+                  title="Sort by model name"
+                  @click="sortBy(MODEL_SORT)"
                 >
-                  Model
+                  Model {{ sortGlyph(MODEL_SORT) }}
                 </th>
                 <th
                   v-for="task in visibleTasks"
@@ -617,13 +662,21 @@ function goToModel(model: string) {
                   :class="sortKey === task ? 'text-accent' : 'text-text-secondary'"
                   @click="sortBy(task)"
                 >
-                  {{ task }}
+                  {{ task }} {{ sortGlyph(task) }}
                   <span
                     v-if="best[task]"
                     class="block font-normal normal-case font-mono text-[10px]"
                     style="color: var(--c-best)"
                     >▲ {{ formatScore(best[task].value) }}</span
                   >
+                </th>
+                <th
+                  class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider whitespace-nowrap cursor-pointer"
+                  :class="sortKey === UPDATED_SORT ? 'text-accent' : 'text-text-secondary'"
+                  title="Newest contributing benchmark result; individual cells may be older"
+                  @click="sortBy(UPDATED_SORT)"
+                >
+                  Last updated {{ sortGlyph(UPDATED_SORT) }}
                 </th>
               </tr>
             </thead>
@@ -679,6 +732,12 @@ function goToModel(model: string) {
                   </button>
                   <span v-else class="text-text-muted" title="Never run on this benchmark">—</span>
                 </td>
+                <td
+                  class="px-3 py-2 text-right whitespace-nowrap font-mono text-[11px] tabular-nums text-text-muted"
+                  title="Newest contributing benchmark result; individual cells may be older"
+                >
+                  {{ formatTimestamp(row.last_updated) }}
+                </td>
               </tr>
             </tbody>
           </table>
@@ -688,7 +747,9 @@ function goToModel(model: string) {
           <span class="text-status-warning">no result</span> links the run that failed the panel's admission rule, and
           — means the model never ran that benchmark. A result the engine flags as suspect is held out of the
           panel as <span class="text-status-warning">flagged</span> rather than standing as a model's newest score;
-          "Show flagged results" admits it, marked with a <span class="text-status-warning">*</span>.
+          "Show flagged results" admits it, marked with a <span class="text-status-warning">*</span>. Last updated is
+          the newest contributing benchmark result; individual cells may be older, and each cell's own timestamp is in
+          its tooltip.
         </p>
       </div>
     </div>

--- a/infra/marina/apps/evaldash/web/src/types/api.ts
+++ b/infra/marina/apps/evaldash/web/src/types/api.ts
@@ -115,7 +115,7 @@ export interface PanelRow {
   missing: Record<string, MissingCell>
   aggregate: PanelAggregate | null
   covered: number
-  // The newest created_at among the row's cells: its freshest result, not the age of every cell.
+  // Maximum created_at among the row's cells.
   last_updated: string | null
 }
 

--- a/infra/marina/apps/evaldash/web/src/types/api.ts
+++ b/infra/marina/apps/evaldash/web/src/types/api.ts
@@ -115,6 +115,8 @@ export interface PanelRow {
   missing: Record<string, MissingCell>
   aggregate: PanelAggregate | null
   covered: number
+  // The newest created_at among the row's cells: its freshest result, not the age of every cell.
+  last_updated: string | null
 }
 
 export interface PanelRequest {


### PR DESCRIPTION
Panel headers sort in both directions. Benchmark columns rank by interval lower bound, and missing values stay at the bottom. Model names default to ascending order; coverage, benchmark, and timestamp columns default to descending order.

The panel response includes `last_updated`, the maximum `created_at` among the cells included in each row. The table displays it, and cell tooltips show each result's timestamp.

Fixes #8145
Fixes #8142
