### PR TITLE
[eval] Derive Harbor agent context limits from the served model

### DIFF
--- a/docs/harbor-integration.md
+++ b/docs/harbor-integration.md
@@ -139,11 +139,12 @@ Temporary policy and overlay files are owner-readable and removed after each iso
 
 The agent's `model_info.max_input_tokens` comes from the model's `serve.max_model_len` and its
 `model_info.max_output_tokens` from `generation.max_gen_toks`, so the agent compacts against the
-window the server actually offers. A policy that states a limit the model contradicts fails
-preflight, before Iris opens, with both values named; repeating the served limit in the policy is
-allowed. A limit neither the model nor the policy states falls back to Harbor's own default, 32768
-input and 8192 output tokens. `--dry-run` prints the resolved pair per Harbor eval and `record.json`
-keeps it under `eval.harbor`.
+window the server actually offers. A policy may state a lower limit to keep headroom under that
+window, and the lower limit wins: `grug-opencode-id.yaml` asks for 64512 input tokens against a
+model serving 65536. A policy limit above the served one fails preflight, before Iris opens, with
+both values named. A limit neither the model nor the policy states falls back to Harbor's own
+default, 32768 input and 8192 output tokens. `--dry-run` prints the resolved pair per Harbor eval
+and `record.json` keeps it under `eval.harbor`.
 
 ## Results
 

--- a/docs/harbor-integration.md
+++ b/docs/harbor-integration.md
@@ -135,6 +135,16 @@ Runtime values do not change the source-policy digest. Policy kwargs override mo
 the served endpoint/model, output paths, materialized source, and explicit `--limit` override both.
 Temporary policy and overlay files are owner-readable and removed after each isolated call.
 
+## Agent context limits
+
+The agent's `model_info.max_input_tokens` comes from the model's `serve.max_model_len` and its
+`model_info.max_output_tokens` from `generation.max_gen_toks`, so the agent compacts against the
+window the server actually offers. A policy that states a limit the model contradicts fails
+preflight, before Iris opens, with both values named; repeating the served limit in the policy is
+allowed. A limit neither the model nor the policy states falls back to Harbor's own default, 32768
+input and 8192 output tokens. `--dry-run` prints the resolved pair per Harbor eval and `record.json`
+keeps it under `eval.harbor`.
+
 ## Results
 
 Each Harbor evaluation writes:

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -70,12 +70,18 @@ def _print_plan(spec: LaunchSpec, batch: EvaluationBatch) -> None:
         f"priority={priority_band_name(batch.priority_band)}"
     )
     for evaluation in batch.evaluations:
-        tasks = [task.name for task in evaluation.identity.eval_ref.tasks]
+        eval_ref = evaluation.identity.eval_ref
+        tasks = [task.name for task in eval_ref.tasks]
+        harbor = eval_ref.harbor
+        agent_context = ""
+        if harbor is not None:
+            agent_context = f"max_input_tokens={harbor.max_input_tokens}  max_output_tokens={harbor.max_output_tokens}  "
         click.echo(
-            f"  eval={evaluation.identity.eval_ref.name}  location={batch.model.location}  "
+            f"  eval={eval_ref.name}  location={batch.model.location}  "
             f"backend={batch.model.serve.backend.value}  accel={batch.accelerator.label}  "
             f"region_or_cluster={batch.accelerator.target_cluster or batch.accelerator.region}  "
             f"tasks={tasks}  "
+            f"{agent_context}"
             f"records={batch.records_prefix}"
         )
 

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -156,11 +156,7 @@ class HarborDefinition:
 
 
 def harbor_model_agent_kwargs(model: ModelConfig) -> dict[str, object]:
-    """Harbor agent kwargs for one model, with ``model_info`` set to its serving context limits.
-
-    A limit the model catalog leaves unset is absent from ``model_info``, which leaves it to the
-    policy and then to Harbor's own default.
-    """
+    """Omit unset catalog limits so the policy or Harbor defaults can supply them."""
     return {
         **model.agent.agent_kwargs,
         MODEL_INFO_KEY: served_model_info(model.serve.max_model_len, model.generation.max_gen_toks),

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -19,6 +19,7 @@ from marin.evaluation.evalchemy.runner import (
     EvalchemyRuntimeConfig,
 )
 from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.evaluation.harbor.agent_context import MODEL_INFO_KEY, served_model_info
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, ValidatedHarborConfig
 from marin.evaluation.harbor.runner import HarborExecutor
 from marin.evaluation.model_config import ModelConfig
@@ -130,6 +131,8 @@ class HarborDefinition:
                 env=config.environment,
                 task_limit=runtime_task_limit,
                 config_digest=config.digest,
+                max_input_tokens=config.max_input_tokens,
+                max_output_tokens=config.max_output_tokens,
             ),
         )
 
@@ -147,9 +150,22 @@ class HarborDefinition:
         return HarborExecutor(
             config=config,
             task_limit=runtime_task_limit,
-            model_agent_kwargs=model.agent.agent_kwargs,
+            model_agent_kwargs=harbor_model_agent_kwargs(model),
             secret_env_keys=tuple(secret_env),
         )
+
+
+def harbor_model_agent_kwargs(model: ModelConfig) -> dict[str, object]:
+    """Harbor agent kwargs for one model, carrying the context limits it is served with.
+
+    The agent's ``model_info`` is derived from ``serve.max_model_len`` and ``generation.max_gen_toks``
+    so the agent summarizes and truncates against the window the server actually offers. The isolated
+    driver rejects a policy whose own ``model_info`` contradicts these values.
+    """
+    return {
+        **model.agent.agent_kwargs,
+        MODEL_INFO_KEY: served_model_info(model.serve.max_model_len, model.generation.max_gen_toks),
+    }
 
 
 def harbor_definition(

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -156,11 +156,10 @@ class HarborDefinition:
 
 
 def harbor_model_agent_kwargs(model: ModelConfig) -> dict[str, object]:
-    """Harbor agent kwargs for one model, carrying the context limits it is served with.
+    """Harbor agent kwargs for one model, with ``model_info`` set to its serving context limits.
 
-    The agent's ``model_info`` is derived from ``serve.max_model_len`` and ``generation.max_gen_toks``
-    so the agent summarizes and truncates against the window the server actually offers. The isolated
-    driver rejects a policy whose own ``model_info`` contradicts these values.
+    A limit the model catalog leaves unset is absent from ``model_info``, which leaves it to the
+    policy and then to Harbor's own default.
     """
     return {
         **model.agent.agent_kwargs,

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -49,6 +49,7 @@ from experiments.evaluation.evals import (
     EvalchemyDefinition,
     EvaluationDefinition,
     HarborDefinition,
+    harbor_model_agent_kwargs,
 )
 from experiments.evaluation.fleet import MARIN_EVAL_HARDWARE
 
@@ -150,7 +151,8 @@ def _resolve_definitions(
     evalchemy_definitions = [definition for _, definition in definitions if isinstance(definition, EvalchemyDefinition)]
     evalchemy_sources = iter(load_evalchemy_config(definition.config_path) for definition in evalchemy_definitions)
     harbor_definitions = [definition for _, definition in definitions if isinstance(definition, HarborDefinition)]
-    requests = [(definition.config_path, dict(model.agent.agent_kwargs)) for definition in harbor_definitions]
+    model_agent_kwargs = harbor_model_agent_kwargs(model)
+    requests = [(definition.config_path, model_agent_kwargs) for definition in harbor_definitions]
     validated_configs = iter(preflight_harbor_configs(requests))
 
     resolved: list[tuple[str, _ResolvedDefinition]] = []

--- a/experiments/evaluation/serve/models/README.md
+++ b/experiments/evaluation/serve/models/README.md
@@ -50,9 +50,9 @@ serve:                          # ServeConfig -> model-server behavior
   chat_template: null           # jinja served in place of the tokenizer's own
   auto_overrides: true          # derive remaining flags + clamp max_model_len from config.json
 
-generation:                     # GenerationConfig -> evalchemy --gen_kwargs
-  max_gen_toks: null            # per-model generation budget override
-  extra_gen_kwargs:             # forwarded verbatim, e.g. for a thinking model
+generation:                     # per-model generation behavior
+  max_gen_toks: null            # Evalchemy generation limit and Harbor agent output budget
+  extra_gen_kwargs:             # forwarded to Evalchemy, e.g. for a thinking model
     skip_special_tokens: "false"
 
 agent:                          # AgentConfig -> the Harbor/agentic agent

--- a/lib/marin/src/marin/evaluation/harbor/agent_context.py
+++ b/lib/marin/src/marin/evaluation/harbor/agent_context.py
@@ -1,11 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The context budget a Harbor agent runs under, derived from how the model is served.
-
-Both the Marin launcher and the isolated Harbor driver import this module, so it depends on the
-standard library alone.
-"""
+"""Resolve Harbor context limits without dependencies outside the standard library."""
 
 from collections.abc import Mapping
 from types import MappingProxyType
@@ -25,7 +21,7 @@ DEFAULT_MODEL_INFO: Mapping[str, Any] = MappingProxyType(
     }
 )
 
-# The model-catalog field behind each agent limit, named when a policy contradicts it.
+# Model-catalog fields named in policy-limit errors.
 _MODEL_CONFIG_FIELD: Mapping[str, str] = MappingProxyType(
     {
         MAX_INPUT_TOKENS_KEY: "serve.max_model_len",
@@ -35,11 +31,7 @@ _MODEL_CONFIG_FIELD: Mapping[str, str] = MappingProxyType(
 
 
 def served_model_info(max_model_len: int | None, max_gen_toks: int | None) -> dict[str, int]:
-    """The Harbor ``model_info`` limits implied by how a model is served.
-
-    A limit the model catalog leaves unset is omitted, so the policy and then Harbor's own default
-    still decide it.
-    """
+    """Omit unset catalog limits so the policy or Harbor defaults can supply them."""
     model_info: dict[str, int] = {}
     if max_model_len is not None:
         model_info[MAX_INPUT_TOKENS_KEY] = max_model_len
@@ -57,14 +49,12 @@ def _model_info_mapping(value: object, source: str) -> Mapping[str, Any]:
 
 
 def reconciled_model_info(served: object, policy: object) -> dict[str, Any]:
-    """The agent ``model_info`` for one run: served-model limits, policy kwargs, Harbor defaults.
+    """Reconcile policy limits with the model catalog and Harbor defaults.
 
-    A policy limit at or below the served one wins, which is how a policy keeps headroom under the
-    served window. A policy limit above the served one would let the agent run past what the server
-    accepts.
+    Policy limits may reserve headroom below served limits but cannot exceed them.
 
     Raises:
-        ValueError: a policy context limit exceeds the served model's, or is not an integer.
+        ValueError: A policy context limit exceeds the corresponding served limit.
     """
     served_info = _model_info_mapping(served, "model")
     policy_info = _model_info_mapping(policy, "agent")

--- a/lib/marin/src/marin/evaluation/harbor/agent_context.py
+++ b/lib/marin/src/marin/evaluation/harbor/agent_context.py
@@ -59,16 +59,25 @@ def _model_info_mapping(value: object, source: str) -> Mapping[str, Any]:
 def reconciled_model_info(served: object, policy: object) -> dict[str, Any]:
     """The agent ``model_info`` for one run: served-model limits, policy kwargs, Harbor defaults.
 
+    A policy limit at or below the served one wins, which is how a policy keeps headroom under the
+    served window. A policy limit above the served one would let the agent run past what the server
+    accepts.
+
     Raises:
-        ValueError: the policy states a context limit the served model contradicts.
+        ValueError: a policy context limit exceeds the served model's, or is not an integer.
     """
     served_info = _model_info_mapping(served, "model")
     policy_info = _model_info_mapping(policy, "agent")
     for key, served_value in served_info.items():
-        if key in policy_info and policy_info[key] != served_value:
+        if key not in policy_info:
+            continue
+        policy_value = policy_info[key]
+        model_field = _MODEL_CONFIG_FIELD[key]
+        if not isinstance(policy_value, int):
+            raise ValueError(f"Harbor agent model_info.{key} must be an integer, got {policy_value!r}")
+        if policy_value > served_value:
             raise ValueError(
-                f"Harbor agent model_info.{key} is {policy_info[key]!r} but the served model's "
-                f"{_MODEL_CONFIG_FIELD.get(key, key)} is {served_value!r}; align the policy with the "
-                f"model configuration or drop the agent kwarg"
+                f"Harbor agent model_info.{key} is {policy_value} but the served model's "
+                f"{model_field} is only {served_value}; lower the policy limit or raise {model_field}"
             )
     return {**DEFAULT_MODEL_INFO, **served_info, **policy_info}

--- a/lib/marin/src/marin/evaluation/harbor/agent_context.py
+++ b/lib/marin/src/marin/evaluation/harbor/agent_context.py
@@ -1,0 +1,74 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The context budget a Harbor agent runs under, derived from how the model is served.
+
+Both the Marin launcher and the isolated Harbor driver import this module, so it depends on the
+standard library alone.
+"""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+MODEL_INFO_KEY = "model_info"
+MAX_INPUT_TOKENS_KEY = "max_input_tokens"
+MAX_OUTPUT_TOKENS_KEY = "max_output_tokens"
+
+# Harbor's own budgets, applied when neither the model catalog nor the policy states a limit.
+DEFAULT_MODEL_INFO: Mapping[str, Any] = MappingProxyType(
+    {
+        MAX_INPUT_TOKENS_KEY: 32768,
+        MAX_OUTPUT_TOKENS_KEY: 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+    }
+)
+
+# The model-catalog field behind each agent limit, named when a policy contradicts it.
+_MODEL_CONFIG_FIELD: Mapping[str, str] = MappingProxyType(
+    {
+        MAX_INPUT_TOKENS_KEY: "serve.max_model_len",
+        MAX_OUTPUT_TOKENS_KEY: "generation.max_gen_toks",
+    }
+)
+
+
+def served_model_info(max_model_len: int | None, max_gen_toks: int | None) -> dict[str, int]:
+    """The Harbor ``model_info`` limits implied by how a model is served.
+
+    A limit the model catalog leaves unset is omitted, so the policy and then Harbor's own default
+    still decide it.
+    """
+    model_info: dict[str, int] = {}
+    if max_model_len is not None:
+        model_info[MAX_INPUT_TOKENS_KEY] = max_model_len
+    if max_gen_toks is not None:
+        model_info[MAX_OUTPUT_TOKENS_KEY] = max_gen_toks
+    return model_info
+
+
+def _model_info_mapping(value: object, source: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Harbor {source} model_info must be a mapping")
+    return value
+
+
+def reconciled_model_info(served: object, policy: object) -> dict[str, Any]:
+    """The agent ``model_info`` for one run: served-model limits, policy kwargs, Harbor defaults.
+
+    Raises:
+        ValueError: the policy states a context limit the served model contradicts.
+    """
+    served_info = _model_info_mapping(served, "model")
+    policy_info = _model_info_mapping(policy, "agent")
+    for key, served_value in served_info.items():
+        if key in policy_info and policy_info[key] != served_value:
+            raise ValueError(
+                f"Harbor agent model_info.{key} is {policy_info[key]!r} but the served model's "
+                f"{_MODEL_CONFIG_FIELD.get(key, key)} is {served_value!r}; align the policy with the "
+                f"model configuration or drop the agent kwarg"
+            )
+    return {**DEFAULT_MODEL_INFO, **served_info, **policy_info}

--- a/lib/marin/src/marin/evaluation/harbor/driver_config.py
+++ b/lib/marin/src/marin/evaluation/harbor/driver_config.py
@@ -105,6 +105,10 @@ class ValidatedHarborConfig:
     workspace_dataset_path: Path | None
     agent: str
     environment: str
+    max_input_tokens: int
+    max_output_tokens: int
+    """The agent's resolved context budget: the served model's limits, the policy's explicit
+    ``model_info``, then Harbor's own defaults."""
 
     @property
     def record_dataset(self) -> str:
@@ -217,6 +221,12 @@ def _validated_config(payload: object, path: Path) -> ValidatedHarborConfig:
             raise ValueError(f"Harbor preflight returned invalid {name!r} metadata for {path}")
         return value
 
+    def required_int(name: str) -> int:
+        value = payload.get(name)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"Harbor preflight returned invalid {name!r} metadata for {path}")
+        return value
+
     revision = payload.get("dataset_revision")
     if revision is not None and not isinstance(revision, str):
         raise ValueError(f"Harbor preflight returned invalid dataset revision metadata for {path}")
@@ -247,6 +257,8 @@ def _validated_config(payload: object, path: Path) -> ValidatedHarborConfig:
         workspace_dataset_path=workspace_dataset_path,
         agent=required_string("agent"),
         environment=required_string("environment"),
+        max_input_tokens=required_int("max_input_tokens"),
+        max_output_tokens=required_int("max_output_tokens"),
     )
 
 

--- a/lib/marin/src/marin/evaluation/harbor/driver_config.py
+++ b/lib/marin/src/marin/evaluation/harbor/driver_config.py
@@ -107,8 +107,6 @@ class ValidatedHarborConfig:
     environment: str
     max_input_tokens: int
     max_output_tokens: int
-    """The agent's resolved context budget: the served model's limits, the policy's explicit
-    ``model_info``, then Harbor's own defaults."""
 
     @property
     def record_dataset(self) -> str:

--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -14,7 +14,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum, StrEnum
 from pathlib import Path
-from types import MappingProxyType
 from typing import Any
 
 import yaml
@@ -28,6 +27,13 @@ from harbor_config.models.trial.config import AgentConfig  # pyrefly: ignore[mis
 from pydantic import BaseModel, ConfigDict, ValidationError
 from upath import UPath  # pyrefly: ignore[missing-import]  # installed by external driver
 
+from marin.evaluation.harbor.agent_context import (
+    MAX_INPUT_TOKENS_KEY,
+    MAX_OUTPUT_TOKENS_KEY,
+    MODEL_INFO_KEY,
+    reconciled_model_info,
+)
+
 _HOSTED_VLLM_PROVIDER = "hosted_vllm"
 _HOSTED_VLLM_DISPLAY_NAME = "Hosted vLLM"
 _OPENAI_COMPATIBLE_PACKAGE = "@ai-sdk/openai-compatible"
@@ -38,14 +44,6 @@ _STABLE_MODEL = "__marin_model__"
 _STABLE_ENDPOINT = "http://marin.invalid/v1"
 _PLACEHOLDER_DATASET_PATH = "/__marin_dataset__"
 _HF_DATASET_PREFIX = "hf://"
-_DEFAULT_MODEL_INFO = MappingProxyType(
-    {
-        "max_input_tokens": 32768,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 0.0,
-        "output_cost_per_token": 0.0,
-    }
-)
 
 
 class RuntimeOverlay(BaseModel):
@@ -182,13 +180,6 @@ def _dataset_metadata(
     return _DatasetMetadata(_DatasetKind.HARBOR_REGISTRY, dataset.name, revision)
 
 
-def _model_info(value: object) -> dict[str, Any]:
-    configured = {} if value is None else value
-    if not isinstance(configured, Mapping):
-        raise ValueError("Harbor agent model_info must be a mapping")
-    return {**_DEFAULT_MODEL_INFO, **configured}
-
-
 def _opencode_config(config: object, endpoint_url: str) -> dict[str, Any]:
     if not isinstance(config, Mapping):
         raise ValueError("Harbor agent opencode_config must be a mapping")
@@ -237,7 +228,10 @@ def _agent_config(
 
 def _effective_agent(agent: AgentConfig, overlay: RuntimeOverlay) -> AgentConfig:
     kwargs = {**overlay.model_agent_kwargs, **agent.kwargs}
-    kwargs["model_info"] = _model_info(kwargs.get("model_info"))
+    kwargs[MODEL_INFO_KEY] = reconciled_model_info(
+        overlay.model_agent_kwargs.get(MODEL_INFO_KEY),
+        agent.kwargs.get(MODEL_INFO_KEY),
+    )
     return _agent_config(
         agent,
         endpoint_url=overlay.endpoint_url,
@@ -247,8 +241,7 @@ def _effective_agent(agent: AgentConfig, overlay: RuntimeOverlay) -> AgentConfig
 
 
 def _stable_agent(agent: AgentConfig) -> AgentConfig:
-    if "model_info" in agent.kwargs:
-        _model_info(agent.kwargs["model_info"])
+    reconciled_model_info(None, agent.kwargs.get(MODEL_INFO_KEY))
     return _agent_config(
         agent,
         endpoint_url=_STABLE_ENDPOINT,
@@ -345,7 +338,7 @@ def _preflight_one(path: Path, model_agent_kwargs: Mapping[str, object]) -> dict
     placeholder_dataset_path = (
         None if dataset_metadata.kind == _DatasetKind.HARBOR_REGISTRY else _PLACEHOLDER_DATASET_PATH
     )
-    _effective_config(
+    effective = _effective_config(
         stable_config,
         RuntimeOverlay(
             job_name=_STABLE_JOB_NAME,
@@ -357,6 +350,7 @@ def _preflight_one(path: Path, model_agent_kwargs: Mapping[str, object]) -> dict
             model_agent_kwargs=dict(model_agent_kwargs),
         ),
     )
+    model_info = effective.agents[0].kwargs[MODEL_INFO_KEY]
     return {
         "stable_policy_json": stable_policy_json,
         "digest": f"sha256:{hashlib.sha256(stable_policy_json.encode()).hexdigest()}",
@@ -365,6 +359,8 @@ def _preflight_one(path: Path, model_agent_kwargs: Mapping[str, object]) -> dict
         "dataset_revision": dataset_metadata.revision,
         "agent": agent_name,
         "environment": environment_name,
+        "max_input_tokens": model_info[MAX_INPUT_TOKENS_KEY],
+        "max_output_tokens": model_info[MAX_OUTPUT_TOKENS_KEY],
     }
 
 

--- a/lib/marin/src/marin/evaluation/model_config.py
+++ b/lib/marin/src/marin/evaluation/model_config.py
@@ -93,7 +93,11 @@ class ServeConfig:
 
 @dataclass(frozen=True)
 class GenerationConfig:
-    """Generation overrides applied when an experiment resolves an Evalchemy definition."""
+    """Per-model generation settings for evaluation clients.
+
+    ``max_gen_toks`` sets the Evalchemy generation limit and Harbor agent output budget.
+    ``extra_gen_kwargs`` apply only to Evalchemy.
+    """
 
     max_gen_toks: int | None = None
     extra_gen_kwargs: Mapping[str, str] = field(default_factory=dict)

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -193,6 +193,16 @@ class HarborRef(BaseModel):
         pattern=r"^sha256:[0-9a-f]{64}$",
         exclude_if=lambda value: value is None,
     )
+    max_input_tokens: int | None = Field(
+        default=None,
+        description="Agent context budget resolved from the served model, the policy, and Harbor's defaults",
+        exclude_if=lambda value: value is None,
+    )
+    max_output_tokens: int | None = Field(
+        default=None,
+        description="Agent generation budget resolved from the served model, the policy, and Harbor's defaults",
+        exclude_if=lambda value: value is None,
+    )
 
 
 class EvalRef(BaseModel):

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -18,7 +18,6 @@ from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, Constra
 from iris.rpc import job_pb2
 from marin.evaluation.evalchemy.runner import EvalchemyExecutor, EvalchemyRunConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig
-from marin.evaluation.harbor.agent_context import reconciled_model_info
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, HarborDatasetKind, ValidatedHarborConfig
 from marin.evaluation.hardware import AcceleratorChoice, Platform
 from marin.evaluation.model_config import GenerationConfig, ModelConfig, ResourceHint, ServeConfig
@@ -46,15 +45,21 @@ from experiments.evaluation.launch import (
 )
 from experiments.evaluation.models import models
 
+# Stand-in agent limits the fake driver reports back. They match neither Harbor's defaults nor any
+# model in these tests, so an assertion on them can only be satisfied by the preflight result.
+_PREFLIGHT_MAX_INPUT_TOKENS = 262144
+_PREFLIGHT_MAX_OUTPUT_TOKENS = 65536
 
-def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stand in for the isolated driver subprocess, resolving agent limits the way it does."""
+
+def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> list[Mapping[str, object]]:
+    """Stand in for the isolated driver subprocess and record the agent kwargs it was handed."""
+    received: list[Mapping[str, object]] = []
 
     def preflight(requests):
         configs = []
         for path, model_agent_kwargs in requests:
+            received.append(model_agent_kwargs)
             policy = json.dumps({"source": path.name}, separators=(",", ":"))
-            model_info = reconciled_model_info(model_agent_kwargs.get("model_info"), None)
             configs.append(
                 ValidatedHarborConfig(
                     stable_policy_json=policy,
@@ -65,13 +70,14 @@ def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
                     workspace_dataset_path=None,
                     agent="opencode",
                     environment="daytona",
-                    max_input_tokens=model_info["max_input_tokens"],
-                    max_output_tokens=model_info["max_output_tokens"],
+                    max_input_tokens=_PREFLIGHT_MAX_INPUT_TOKENS,
+                    max_output_tokens=_PREFLIGHT_MAX_OUTPUT_TOKENS,
                 )
             )
         return tuple(configs)
 
     monkeypatch.setattr("experiments.evaluation.launch.preflight_harbor_configs", preflight)
+    return received
 
 
 def _write_harbor_config(path: Path) -> Path:
@@ -706,8 +712,8 @@ def test_build_evaluation_batch_combines_registry_evalchemy_and_harbor_configs(t
             "env": "daytona",
             "task_limit": 2,
             "config_digest": evaluation.identity.eval_ref.harbor.config_digest,
-            "max_input_tokens": 32768,
-            "max_output_tokens": 8192,
+            "max_input_tokens": _PREFLIGHT_MAX_INPUT_TOKENS,
+            "max_output_tokens": _PREFLIGHT_MAX_OUTPUT_TOKENS,
         },
     }
     assert batch.secret_env == {
@@ -757,7 +763,7 @@ def test_build_evaluation_batch_combines_registry_evalchemy_and_harbor_configs(t
 
 
 def test_build_evaluation_batch_gives_harbor_the_served_context_limits(tmp_path, monkeypatch):
-    _install_fake_harbor_preflight(monkeypatch)
+    preflight_requests = _install_fake_harbor_preflight(monkeypatch)
     monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
     config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
     spec = LaunchSpec(
@@ -780,39 +786,28 @@ def test_build_evaluation_batch_gives_harbor_the_served_context_limits(tmp_path,
 
     batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
 
+    served_limits = {"max_input_tokens": 1048576, "max_output_tokens": 393216}
     (evaluation,) = batch.evaluations
+    assert [request["model_info"] for request in preflight_requests] == [served_limits]
+    assert evaluation.executor.model_agent_kwargs["model_info"] == served_limits
     harbor = evaluation.identity.eval_ref.harbor
-    assert (harbor.max_input_tokens, harbor.max_output_tokens) == (1048576, 393216)
-    assert evaluation.executor.model_agent_kwargs["model_info"] == {
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 393216,
-    }
+    assert (harbor.max_input_tokens, harbor.max_output_tokens) == (
+        _PREFLIGHT_MAX_INPUT_TOKENS,
+        _PREFLIGHT_MAX_OUTPUT_TOKENS,
+    )
 
 
 def test_launch_dry_run_prints_the_resolved_harbor_agent_context(tmp_path, monkeypatch):
     _install_fake_harbor_preflight(monkeypatch)
     monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
-    model_path = tmp_path / "long-context.yaml"
-    model_path.write_text(
-        """\
-name: long-context
-location: Qwen/Qwen3-8B
-resource_hint:
-  hbm_gb: 21
-serve:
-  max_model_len: 1048576
-generation:
-  max_gen_toks: 393216
-"""
-    )
     config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
 
     result = CliRunner().invoke(
         cli,
         [
             "launch",
-            "--model-config",
-            str(model_path),
+            "--model",
+            "qwen3-8b",
             "--harbor-config",
             str(config_path),
             "--dry-run",
@@ -820,8 +815,8 @@ generation:
     )
 
     assert result.exit_code == 0, result.output
-    assert "max_input_tokens=1048576" in result.output
-    assert "max_output_tokens=393216" in result.output
+    assert f"max_input_tokens={_PREFLIGHT_MAX_INPUT_TOKENS}" in result.output
+    assert f"max_output_tokens={_PREFLIGHT_MAX_OUTPUT_TOKENS}" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -52,7 +52,6 @@ _PREFLIGHT_MAX_OUTPUT_TOKENS = 65536
 
 
 def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> list[Mapping[str, object]]:
-    """Stand in for the isolated driver subprocess and record the agent kwargs it was handed."""
     received: list[Mapping[str, object]] = []
 
     def preflight(requests):

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -18,9 +18,10 @@ from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, Constra
 from iris.rpc import job_pb2
 from marin.evaluation.evalchemy.runner import EvalchemyExecutor, EvalchemyRunConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig
+from marin.evaluation.harbor.agent_context import reconciled_model_info
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, HarborDatasetKind, ValidatedHarborConfig
 from marin.evaluation.hardware import AcceleratorChoice, Platform
-from marin.evaluation.model_config import GenerationConfig, ModelConfig, ResourceHint
+from marin.evaluation.model_config import GenerationConfig, ModelConfig, ResourceHint, ServeConfig
 from marin.evaluation.records import EVALCHEMY_INFRASTRUCTURE_ERROR, EvalRef, RunStatus, TaskCoverage, read_record
 from marin.evaluation.runner import (
     Evaluation,
@@ -47,10 +48,13 @@ from experiments.evaluation.models import models
 
 
 def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for the isolated driver subprocess, resolving agent limits the way it does."""
+
     def preflight(requests):
         configs = []
-        for path, _model_agent_kwargs in requests:
+        for path, model_agent_kwargs in requests:
             policy = json.dumps({"source": path.name}, separators=(",", ":"))
+            model_info = reconciled_model_info(model_agent_kwargs.get("model_info"), None)
             configs.append(
                 ValidatedHarborConfig(
                     stable_policy_json=policy,
@@ -61,6 +65,8 @@ def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
                     workspace_dataset_path=None,
                     agent="opencode",
                     environment="daytona",
+                    max_input_tokens=model_info["max_input_tokens"],
+                    max_output_tokens=model_info["max_output_tokens"],
                 )
             )
         return tuple(configs)
@@ -700,6 +706,8 @@ def test_build_evaluation_batch_combines_registry_evalchemy_and_harbor_configs(t
             "env": "daytona",
             "task_limit": 2,
             "config_digest": evaluation.identity.eval_ref.harbor.config_digest,
+            "max_input_tokens": 32768,
+            "max_output_tokens": 8192,
         },
     }
     assert batch.secret_env == {
@@ -746,6 +754,74 @@ def test_build_evaluation_batch_combines_registry_evalchemy_and_harbor_configs(t
     assert captured["overlay"].served_model == "served-qwen3-8b"
     assert captured["overlay"].endpoint_url == "https://iris.example/capability/v1"
     assert captured["overlay"].model_agent_kwargs["extra_body"] == ('{"chat_template_kwargs":{"enable_thinking":true}}')
+
+
+def test_build_evaluation_batch_gives_harbor_the_served_context_limits(tmp_path, monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
+    spec = LaunchSpec(
+        model=replace(
+            models()["qwen3-8b"],
+            serve=ServeConfig(max_model_len=1048576),
+            generation=GenerationConfig(max_gen_toks=393216),
+        ),
+        evals=(),
+        evalchemy_definitions=(),
+        harbor_definitions=(HarborDefinition(name="aime-policy", config_path=config_path),),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=None,
+        records_prefix="memory://records",
+        submission_cluster="marin",
+        federated_cluster=None,
+        priority_band=job_pb2.PRIORITY_BAND_INHERIT,
+    )
+
+    batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    (evaluation,) = batch.evaluations
+    harbor = evaluation.identity.eval_ref.harbor
+    assert (harbor.max_input_tokens, harbor.max_output_tokens) == (1048576, 393216)
+    assert evaluation.executor.model_agent_kwargs["model_info"] == {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+    }
+
+
+def test_launch_dry_run_prints_the_resolved_harbor_agent_context(tmp_path, monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    model_path = tmp_path / "long-context.yaml"
+    model_path.write_text(
+        """\
+name: long-context
+location: Qwen/Qwen3-8B
+resource_hint:
+  hbm_gb: 21
+serve:
+  max_model_len: 1048576
+generation:
+  max_gen_toks: 393216
+"""
+    )
+    config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "launch",
+            "--model-config",
+            str(model_path),
+            "--harbor-config",
+            str(config_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "max_input_tokens=1048576" in result.output
+    assert "max_output_tokens=393216" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -99,7 +99,6 @@ def test_reconciled_model_info_keeps_harbor_defaults_when_the_model_states_no_li
 
 @pytest.mark.parametrize("policy_max_input_tokens", [64512, 65536])
 def test_reconciled_model_info_keeps_a_policy_limit_within_the_served_window(policy_max_input_tokens):
-    """grug-opencode-id asks for 64512 against a model serving 65536, keeping 1024 tokens of headroom."""
     served = served_model_info(max_model_len=65536, max_gen_toks=16384)
 
     resolved = reconciled_model_info(served, {"max_input_tokens": policy_max_input_tokens})

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -8,6 +8,11 @@ import pytest
 from finestore.reader import ReadView
 from fsspec.implementations.memory import MemoryFileSystem
 from marin.evaluation.harbor import driver_config, runner
+from marin.evaluation.harbor.agent_context import (
+    DEFAULT_MODEL_INFO,
+    reconciled_model_info,
+    served_model_info,
+)
 from marin.evaluation.harbor.dataset import materialize_harbor_dataset
 from marin.evaluation.harbor.driver_config import (
     HarborBackendsUnavailable,
@@ -67,7 +72,44 @@ def _validated_config(
         workspace_dataset_path=workspace_dataset_path,
         agent=agent,
         environment="daytona",
+        max_input_tokens=32768,
+        max_output_tokens=8192,
     )
+
+
+def test_reconciled_model_info_takes_context_limits_from_the_served_model():
+    served = served_model_info(max_model_len=1048576, max_gen_toks=393216)
+
+    assert reconciled_model_info(served, None) == {
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+    }
+
+
+def test_reconciled_model_info_keeps_harbor_defaults_when_the_model_states_no_limits():
+    served = served_model_info(max_model_len=None, max_gen_toks=None)
+
+    assert reconciled_model_info(served, {"input_cost_per_token": 1.5}) == {
+        **DEFAULT_MODEL_INFO,
+        "input_cost_per_token": 1.5,
+    }
+
+
+def test_reconciled_model_info_accepts_a_policy_that_repeats_the_served_limits():
+    served = served_model_info(max_model_len=64512, max_gen_toks=16384)
+
+    resolved = reconciled_model_info(served, {"max_input_tokens": 64512, "max_output_tokens": 16384})
+
+    assert (resolved["max_input_tokens"], resolved["max_output_tokens"]) == (64512, 16384)
+
+
+def test_reconciled_model_info_rejects_a_policy_that_contradicts_the_served_limits():
+    served = served_model_info(max_model_len=32768, max_gen_toks=None)
+
+    with pytest.raises(ValueError, match=r"64512.*serve\.max_model_len is 32768"):
+        reconciled_model_info(served, {"max_input_tokens": 64512})
 
 
 def _write_job_record(job_dir: Path, n_total_trials: int) -> None:

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -97,19 +97,28 @@ def test_reconciled_model_info_keeps_harbor_defaults_when_the_model_states_no_li
     }
 
 
-def test_reconciled_model_info_accepts_a_policy_that_repeats_the_served_limits():
-    served = served_model_info(max_model_len=64512, max_gen_toks=16384)
+@pytest.mark.parametrize("policy_max_input_tokens", [64512, 65536])
+def test_reconciled_model_info_keeps_a_policy_limit_within_the_served_window(policy_max_input_tokens):
+    """grug-opencode-id asks for 64512 against a model serving 65536, keeping 1024 tokens of headroom."""
+    served = served_model_info(max_model_len=65536, max_gen_toks=16384)
 
-    resolved = reconciled_model_info(served, {"max_input_tokens": 64512, "max_output_tokens": 16384})
+    resolved = reconciled_model_info(served, {"max_input_tokens": policy_max_input_tokens})
 
-    assert (resolved["max_input_tokens"], resolved["max_output_tokens"]) == (64512, 16384)
+    assert (resolved["max_input_tokens"], resolved["max_output_tokens"]) == (policy_max_input_tokens, 16384)
 
 
-def test_reconciled_model_info_rejects_a_policy_that_contradicts_the_served_limits():
-    served = served_model_info(max_model_len=32768, max_gen_toks=None)
+@pytest.mark.parametrize(
+    ("policy", "message"),
+    [
+        ({"max_input_tokens": 64512}, r"64512.*serve\.max_model_len is only 32768"),
+        ({"max_output_tokens": 16384}, r"16384.*generation\.max_gen_toks is only 8192"),
+    ],
+)
+def test_reconciled_model_info_rejects_a_policy_limit_above_the_served_window(policy, message):
+    served = served_model_info(max_model_len=32768, max_gen_toks=8192)
 
-    with pytest.raises(ValueError, match=r"64512.*serve\.max_model_len is 32768"):
-        reconciled_model_info(served, {"max_input_tokens": 64512})
+    with pytest.raises(ValueError, match=message):
+        reconciled_model_info(served, policy)
 
 
 def _write_job_record(job_dir: Path, n_total_trials: int) -> None:

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -219,7 +219,16 @@ def test_preflight_reports_agent_context_resolved_from_the_served_model(tmp_path
     assert result["max_output_tokens"] == 393216
 
 
-def test_preflight_rejects_a_policy_agent_context_the_served_model_contradicts(tmp_path):
+def test_preflight_keeps_a_policy_agent_context_below_the_served_window(tmp_path):
+    """grug-opencode-id keeps 1024 tokens of headroom under grug-agentic-s3-step1903's 65536."""
+    served = {"model_info": {"max_input_tokens": 65536}}
+
+    (result,) = json.loads(_preflight(tmp_path, [(_POLICIES / "grug-opencode-id.yaml", served)]).stdout)
+
+    assert result["max_input_tokens"] == 64512
+
+
+def test_preflight_rejects_a_policy_agent_context_above_the_served_window(tmp_path):
     served = {"model_info": {"max_input_tokens": 32768}}
 
     completed = _preflight(tmp_path, [(_POLICIES / "grug-opencode-id.yaml", served)], check=False)

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -220,7 +220,6 @@ def test_preflight_reports_agent_context_resolved_from_the_served_model(tmp_path
 
 
 def test_preflight_keeps_a_policy_agent_context_below_the_served_window(tmp_path):
-    """grug-opencode-id keeps 1024 tokens of headroom under grug-agentic-s3-step1903's 65536."""
     served = {"model_info": {"max_input_tokens": 65536}}
 
     (result,) = json.loads(_preflight(tmp_path, [(_POLICIES / "grug-opencode-id.yaml", served)]).stdout)

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -210,6 +210,25 @@ def test_preflight_digest_is_stable_across_hash_seeds(tmp_path, checked_policies
     assert all(result["digest"] == expected["digest"] for result in seeded)
 
 
+def test_preflight_reports_agent_context_resolved_from_the_served_model(tmp_path):
+    served = {"model_info": {"max_input_tokens": 1048576, "max_output_tokens": 393216}}
+
+    (result,) = json.loads(_preflight(tmp_path, [(_POLICIES / "tb2.yaml", served)]).stdout)
+
+    assert result["max_input_tokens"] == 1048576
+    assert result["max_output_tokens"] == 393216
+
+
+def test_preflight_rejects_a_policy_agent_context_the_served_model_contradicts(tmp_path):
+    served = {"model_info": {"max_input_tokens": 32768}}
+
+    completed = _preflight(tmp_path, [(_POLICIES / "grug-opencode-id.yaml", served)], check=False)
+
+    assert completed.returncode == 2
+    assert "64512" in completed.stderr
+    assert "32768" in completed.stderr
+
+
 @pytest.mark.parametrize(
     ("setup_parameters", "run_parameters", "callback", "keywords"),
     [
@@ -392,7 +411,7 @@ def test_effective_job_applies_runtime_precedence_and_validates_nested_updates(t
                 "task_limit": 3,
                 "model_agent_kwargs": {
                     "extra_body": '{"chat_template_kwargs":{"enable_thinking":true}}',
-                    "model_info": {"max_input_tokens": 123},
+                    "model_info": {"max_input_tokens": 64512, "max_output_tokens": 16384},
                     "trajectory_config": {"raw_content": True},
                 },
             }


### PR DESCRIPTION
Derive Harbor agent input and output limits from the model's serving and generation configuration. A DeepSeek-V4-Flash evaluation served a 1,048,576-token context and a 393,216-token generation budget, but Harbor compacted at its default 32,768 input tokens, invalidating the long-context comparison.

With automatic serving overrides enabled, clamp the model's explicit context limit to the checkpoint's native window before Harbor preflight and retain the resolved serving configuration for execution. A policy limit below the resolved model limit wins; a policy limit above it fails preflight. This prevents an agent budget from exceeding a server window that was reduced during serving configuration.

If neither model nor policy specifies a limit, retain Harbor's defaults. Dry-run output and evaluation records include the resolved agent limits. The `grug-opencode-id` policy requests 64,512 input tokens against its matching model's 65,536-token window; the 31 catalog models configured to serve 32,768 tokens now reject that policy at preflight.

Fixes #8212
