### PR TITLE
Document code review access for new contributors

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -8,7 +8,7 @@ are not tied to an issue.
 
 If you are new to Marin, ask for code review in the `#code-review` channel of
 the [Marin Discord](https://discord.gg/J9CTk7pqcM). If you are unable to join
-the Discord, tag someone appropriate.
+the Discord, tag a Marin maintainer in the issue or pull request.
 
 ## AI-generated contributions
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -6,6 +6,10 @@ are unsure whether a change is wanted, open an issue or ask in the
 unlikely to merge typo fixes, stylistic rewrites, or speculative refactors that
 are not tied to an issue.
 
+If you are new to Marin, ask for code review in the `#code-review` channel of
+the [Marin Discord](https://discord.gg/J9CTk7pqcM). If you are unable to join
+the Discord, tag someone appropriate.
+
 ## AI-generated contributions
 
 We use coding agents ourselves and accept contributions made with them. We do


### PR DESCRIPTION
Direct new contributors to Discord's `#code-review` channel for code review and
provide a fallback to tag someone appropriate if they cannot join the Discord.
