### PR TITLE
[evals] Add publication and recovery policies

### DIFF
--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -175,7 +175,9 @@ uv run python -m experiments.evaluation.cli launch \
 
 The checked-in `mmlu-pro`, `gpqa-diamond`, `cruxeval`, `financebench`, `ifbench`, and
 `mrcr` files preserve Marin's publication-policy defaults. Select them individually with repeatable
-`--evalchemy-config` options; the `chat` suite remains the shorter general-purpose selection.
+`--evalchemy-config` options on a compatible backend; the `chat` suite remains the shorter
+general-purpose selection. The policies were validated on H100. GPQA Diamond's seeded requests are
+not compatible with the TPU vLLM backend.
 
 Marin decodes the `evalchemy_config.EvaluationConfig`-compatible fields without importing Evalchemy.
 The evaluation child then invokes the `evalchemy` console script from the pinned external runtime.
@@ -248,9 +250,10 @@ file extensions fail before Iris submission.
 
 The checked-in `swebench-recovery`, `ot-tblite-recovery`, `tb2-recovery`,
 `simpleqa-recovery`, and `ds-1000-local` files preserve the Snowball evaluation campaign policies.
-They are file-backed policies rather than registry entries. `ds-1000-local` expects the generated
-Harbor task tree at `experiments/evaluation/local_datasets/ds1000`; create that tree with Harbor's
-DS-1000 adapter before launching it.
+They are file-backed policies rather than registry entries. A `recovery` name denotes an exact-identity
+resume policy; each benchmark retains its own retry count and exception taxonomy. `ds-1000-local`
+expects the generated Harbor task tree at `experiments/evaluation/local_datasets/ds1000`; create that
+tree with Harbor's DS-1000 adapter before launching it.
 
 Harbor and `harbor_config` are absent from Marin's environment and root lock. Both preflight and execution
 install the exact `marin.external_dependencies.HARBOR` revision in an isolated uv environment. Every

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -173,6 +173,10 @@ uv run python -m experiments.evaluation.cli launch \
   --dry-run
 ```
 
+The checked-in `mmlu-pro`, `gpqa-diamond`, `cruxeval`, `financebench`, `ifbench`, and
+`mrcr` files preserve Marin's publication-policy defaults. Select them individually with repeatable
+`--evalchemy-config` options; the `chat` suite remains the shorter general-purpose selection.
+
 Marin decodes the `evalchemy_config.EvaluationConfig`-compatible fields without importing Evalchemy.
 The evaluation child then invokes the `evalchemy` console script from the pinned external runtime.
 A dry run checks the YAML shape and the resolved Marin launch plan; task availability is checked when
@@ -241,6 +245,12 @@ an existing directory inside the Marin workspace, and must be included in the Ir
 The launcher records the workspace-relative path so the submitted worker resolves the same directory
 under its unpacked workspace. Absolute paths, unknown fields, malformed provider kwargs, and unsupported
 file extensions fail before Iris submission.
+
+The checked-in `swebench-recovery`, `ot-tblite-recovery`, `tb2-recovery`,
+`simpleqa-recovery`, and `ds-1000-local` files preserve the Snowball evaluation campaign policies.
+They are file-backed policies rather than registry entries. `ds-1000-local` expects the generated
+Harbor task tree at `experiments/evaluation/local_datasets/ds1000`; create that tree with Harbor's
+DS-1000 adapter before launching it.
 
 Harbor and `harbor_config` are absent from Marin's environment and root lock. Both preflight and execution
 install the exact `marin.external_dependencies.HARBOR` revision in an isolated uv environment. Every

--- a/experiments/evaluation/configs/evalchemy/cruxeval.yaml
+++ b/experiments/evaluation/configs/evalchemy/cruxeval.yaml
@@ -1,0 +1,11 @@
+tasks: [CruxEval]
+task_options:
+  CruxEval:
+    num_fewshot: 0
+    task_alias: cruxeval
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 2048
+runtime_extras: [cruxeval]

--- a/experiments/evaluation/configs/evalchemy/financebench.yaml
+++ b/experiments/evaluation/configs/evalchemy/financebench.yaml
@@ -1,0 +1,11 @@
+tasks: [FinanceBench]
+task_options:
+  FinanceBench:
+    num_fewshot: 0
+    task_alias: financebench
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 4096
+runtime_extras: [financebench]

--- a/experiments/evaluation/configs/evalchemy/gpqa-diamond.yaml
+++ b/experiments/evaluation/configs/evalchemy/gpqa-diamond.yaml
@@ -1,0 +1,11 @@
+tasks: [GPQADiamond]
+task_options:
+  GPQADiamond:
+    num_fewshot: 0
+    task_alias: gpqa-diamond
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 32768
+runtime_extras: [gpqadiamond]

--- a/experiments/evaluation/configs/evalchemy/ifbench.yaml
+++ b/experiments/evaluation/configs/evalchemy/ifbench.yaml
@@ -1,0 +1,11 @@
+tasks: [IFBench]
+task_options:
+  IFBench:
+    num_fewshot: 0
+    task_alias: ifbench
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 1024
+runtime_extras: [ifbench]

--- a/experiments/evaluation/configs/evalchemy/mmlu-pro.yaml
+++ b/experiments/evaluation/configs/evalchemy/mmlu-pro.yaml
@@ -1,0 +1,12 @@
+tasks: [MMLUPro]
+task_options:
+  MMLUPro:
+    num_fewshot: 0
+    task_alias: mmlu-pro
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 32768
+max_length: 65536
+runtime_extras: [mmlupro]

--- a/experiments/evaluation/configs/evalchemy/mrcr.yaml
+++ b/experiments/evaluation/configs/evalchemy/mrcr.yaml
@@ -1,0 +1,12 @@
+tasks: [MRCR]
+task_options:
+  MRCR:
+    num_fewshot: 0
+    task_alias: mrcr
+    generation: true
+apply_chat_template: true
+batch_size: 1
+seed: 42
+max_tokens: 4096
+max_length: 73728
+runtime_extras: [mrcr]

--- a/experiments/evaluation/configs/harbor/ds-1000-local.yaml
+++ b/experiments/evaluation/configs/harbor/ds-1000-local.yaml
@@ -1,0 +1,25 @@
+n_concurrent_trials: 32
+release_trial_payloads_in_memory: true
+retry:
+  max_retries: 10
+  include_exceptions:
+    - InternalServerError
+    - APIConnectionError
+    - APITimeoutError
+    - ArtifactUploadTimeoutError
+    - ArtifactWriterBacklogError
+    - CancelledError
+    - ContextManagementInfrastructureError
+    - LLMRequestTimeoutError
+    - SandboxBuildFailedError
+    - TrialTimeoutError
+  exclude_exceptions: []
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 60.0
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - path: ../../local_datasets/ds1000

--- a/experiments/evaluation/configs/harbor/ot-tblite-recovery.yaml
+++ b/experiments/evaluation/configs/harbor/ot-tblite-recovery.yaml
@@ -1,0 +1,25 @@
+n_concurrent_trials: 16
+release_trial_payloads_in_memory: true
+retry:
+  max_retries: 10
+  include_exceptions:
+    - InternalServerError
+    - APIConnectionError
+    - APITimeoutError
+    - ArtifactUploadTimeoutError
+    - ArtifactWriterBacklogError
+    - CancelledError
+    - ContextManagementInfrastructureError
+    - LLMRequestTimeoutError
+    - SandboxBuildFailedError
+    - TrialTimeoutError
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 60.0
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - name: openthoughts-tblite
+    version: "2.0"

--- a/experiments/evaluation/configs/harbor/simpleqa-recovery.yaml
+++ b/experiments/evaluation/configs/harbor/simpleqa-recovery.yaml
@@ -1,0 +1,24 @@
+n_concurrent_trials: 16
+release_trial_payloads_in_memory: true
+retry:
+  max_retries: 3
+  include_exceptions:
+    - InternalServerError
+    - APIConnectionError
+    - APITimeoutError
+  exclude_exceptions: []
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 60.0
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - name: simpleqa
+    version: "1.0"
+verifier:
+  env:
+    OPENAI_API_KEY: "${TOGETHER_API_KEY}"
+    OPENAI_BASE_URL: "https://api.together.xyz/v1"
+    MODEL_NAME: "openai/gpt-oss-120b"

--- a/experiments/evaluation/configs/harbor/swebench-recovery.yaml
+++ b/experiments/evaluation/configs/harbor/swebench-recovery.yaml
@@ -1,0 +1,25 @@
+n_concurrent_trials: 16
+release_trial_payloads_in_memory: true
+retry:
+  max_retries: 10
+  include_exceptions:
+    - InternalServerError
+    - APIConnectionError
+    - APITimeoutError
+    - ArtifactUploadTimeoutError
+    - ArtifactWriterBacklogError
+    - CancelledError
+    - ContextManagementInfrastructureError
+    - LLMRequestTimeoutError
+    - SandboxBuildFailedError
+    - TrialTimeoutError
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 60.0
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - name: hf://DCAgent2/swebench-verified-random-100-folders
+    ref: main

--- a/experiments/evaluation/configs/harbor/tb2-recovery.yaml
+++ b/experiments/evaluation/configs/harbor/tb2-recovery.yaml
@@ -1,0 +1,25 @@
+n_concurrent_trials: 16
+release_trial_payloads_in_memory: true
+retry:
+  max_retries: 10
+  include_exceptions:
+    - InternalServerError
+    - APIConnectionError
+    - APITimeoutError
+    - ArtifactUploadTimeoutError
+    - ArtifactWriterBacklogError
+    - CancelledError
+    - ContextManagementInfrastructureError
+    - LLMRequestTimeoutError
+    - SandboxBuildFailedError
+    - TrialTimeoutError
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 60.0
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - name: hf://DCAgent2/terminal_bench_2
+    ref: main

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -115,9 +115,10 @@ class HarborDefinition:
     max_eval_instances: int | None = None
 
     def secret_env_for(self, config: ValidatedHarborConfig) -> Mapping[str, SecretSpec]:
-        if config.environment == _DAYTONA_ENVIRONMENT_TYPE:
-            return _DAYTONA_SECRET_ENV
-        return MappingProxyType({})
+        secret_env = dict(_DAYTONA_SECRET_ENV) if config.environment == _DAYTONA_ENVIRONMENT_TYPE else {}
+        for key in config.verifier_env_keys:
+            secret_env.setdefault(key, (f"env:{key}",))
+        return MappingProxyType(secret_env)
 
     def record_ref_for(self, config: ValidatedHarborConfig, runtime_task_limit: int | None) -> EvalRef:
         return EvalRef(
@@ -306,9 +307,8 @@ NLP_EVALS: tuple[str, ...] = (
     "gsm8k-0shot",
 )
 
-# The Evalchemy chat benchmarks that run greedily in the lean uvx runtime. Chat-template models only.
-# GPQADiamond is omitted because its sampled requests carry a seed the TPU vLLM backend rejects.
-# MMLU-Pro, CruxEval, MRCR, IFBench, and FinanceBench have no working task on the pinned fork.
+# The short general-purpose chat suite. Longer publication-policy benchmarks are file-backed under
+# configs/evalchemy and validated on H100; GPQADiamond's seeded requests remain incompatible with TPU vLLM.
 CHAT_EVALS: tuple[str, ...] = ("math500", "aime24", "olympiadbench")
 
 MATH_EVALS: tuple[str, ...] = ("math500", "aime24", "gsm8k-0shot")

--- a/lib/marin/src/marin/evaluation/harbor/driver_config.py
+++ b/lib/marin/src/marin/evaluation/harbor/driver_config.py
@@ -105,6 +105,7 @@ class ValidatedHarborConfig:
     workspace_dataset_path: Path | None
     agent: str
     environment: str
+    verifier_env_keys: tuple[str, ...] = ()
 
     @property
     def record_dataset(self) -> str:
@@ -220,6 +221,9 @@ def _validated_config(payload: object, path: Path) -> ValidatedHarborConfig:
     revision = payload.get("dataset_revision")
     if revision is not None and not isinstance(revision, str):
         raise ValueError(f"Harbor preflight returned invalid dataset revision metadata for {path}")
+    verifier_env_keys = payload.get("verifier_env_keys")
+    if not isinstance(verifier_env_keys, list) or any(not isinstance(key, str) or not key for key in verifier_env_keys):
+        raise ValueError(f"Harbor preflight returned invalid verifier environment metadata for {path}")
     try:
         dataset_kind = HarborDatasetKind(required_string("dataset_kind"))
     except ValueError as exc:
@@ -247,6 +251,7 @@ def _validated_config(payload: object, path: Path) -> ValidatedHarborConfig:
         workspace_dataset_path=workspace_dataset_path,
         agent=required_string("agent"),
         environment=required_string("environment"),
+        verifier_env_keys=tuple(verifier_env_keys),
     )
 
 

--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -22,6 +22,7 @@ from harbor.agents.factory import AgentFactory  # pyrefly: ignore[missing-import
 from harbor.environments.factory import _load_environment_class  # pyrefly: ignore[missing-import]
 from harbor.job import Job  # pyrefly: ignore[missing-import]  # installed by external driver
 from harbor_config import JobConfig  # pyrefly: ignore[missing-import]  # installed by external driver
+from harbor_config.env import get_required_host_vars  # pyrefly: ignore[missing-import]
 from harbor_config.models.agent.name import AgentName  # pyrefly: ignore[missing-import]
 from harbor_config.models.job.config import DatasetConfig  # pyrefly: ignore[missing-import]
 from harbor_config.models.trial.config import AgentConfig  # pyrefly: ignore[missing-import]
@@ -365,6 +366,9 @@ def _preflight_one(path: Path, model_agent_kwargs: Mapping[str, object]) -> dict
         "dataset_revision": dataset_metadata.revision,
         "agent": agent_name,
         "environment": environment_name,
+        "verifier_env_keys": sorted(
+            {name for name, default in get_required_host_vars(config.verifier.env) if default is None}
+        ),
     }
 
 

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -46,7 +46,11 @@ from experiments.evaluation.launch import (
 from experiments.evaluation.models import models
 
 
-def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+def _install_fake_harbor_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    verifier_env_keys: tuple[str, ...] = (),
+) -> None:
     def preflight(requests):
         configs = []
         for path, _model_agent_kwargs in requests:
@@ -61,6 +65,7 @@ def _install_fake_harbor_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
                     workspace_dataset_path=None,
                     agent="opencode",
                     environment="daytona",
+                    verifier_env_keys=verifier_env_keys,
                 )
             )
         return tuple(configs)
@@ -486,6 +491,36 @@ def test_build_evaluation_batch_merges_the_shared_daytona_spec(monkeypatch):
     assert {evaluation.identity.eval_runtime for evaluation in batch.evaluations} == {HARBOR_RUNTIME}
     assert all(evaluation.identity.eval_ref.harbor.config_digest for evaluation in batch.evaluations)
     assert all(evaluation.identity.eval_ref.harbor.task_limit == 1 for evaluation in batch.evaluations)
+
+
+def test_build_evaluation_batch_routes_declared_verifier_host_secrets(monkeypatch, tmp_path):
+    _install_fake_harbor_preflight(monkeypatch, verifier_env_keys=("TOGETHER_API_KEY",))
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    config_path = _write_harbor_config(tmp_path / "simpleqa.yaml")
+    spec = LaunchSpec(
+        model=models()["qwen3-8b"],
+        evals=(),
+        evalchemy_definitions=(),
+        harbor_definitions=(HarborDefinition("simpleqa", config_path),),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        submission_cluster="marin",
+        federated_cluster=None,
+        priority_band=job_pb2.PRIORITY_BAND_INHERIT,
+    )
+
+    batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    assert batch.secret_env == {
+        "DAYTONA_API_KEY": (
+            "env:DAYTONA_API_KEY",
+            "gcp-secret://projects/hai-gcp-models/secrets/DAYTONA_EVAL_API_KEY/versions/latest",
+        ),
+        "TOGETHER_API_KEY": ("env:TOGETHER_API_KEY",),
+    }
+    assert batch.evaluations[0].secret_env_keys == ("DAYTONA_API_KEY", "TOGETHER_API_KEY")
 
 
 def test_resolve_eval_keys_validates_programmatic_selections() -> None:

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -210,6 +210,37 @@ def test_preflight_digest_is_stable_across_hash_seeds(tmp_path, checked_policies
     assert all(result["digest"] == expected["digest"] for result in seeded)
 
 
+def test_preflight_reports_only_verifier_host_environment_dependencies(tmp_path):
+    policy_path = tmp_path / "external-judge.yaml"
+    policy_path.write_text(
+        """
+environment:
+  type: daytona
+agents:
+  - name: terminus-2
+datasets:
+  - name: simpleqa
+    version: "1.0"
+verifier:
+  env:
+    OPENAI_API_KEY: "${TOGETHER_API_KEY}"
+    OPENAI_BASE_URL: "https://api.together.xyz/v1"
+    MODEL_NAME: "openai/gpt-oss-120b"
+"""
+    )
+
+    payload = json.loads(_preflight(tmp_path, [(policy_path, {})]).stdout)[0]
+    stable_policy = json.loads(payload["stable_policy_json"])
+
+    assert payload["verifier_env_keys"] == ["TOGETHER_API_KEY"]
+    assert stable_policy["verifier"]["env"] == {
+        "MODEL_NAME": "openai/gpt-oss-120b",
+        "OPENAI_API_KEY": "${TOGETHER_API_KEY}",
+        "OPENAI_BASE_URL": "https://api.together.xyz/v1",
+    }
+    assert stable_policy["agents"][0]["env"] == {}
+
+
 @pytest.mark.parametrize(
     ("setup_parameters", "run_parameters", "callback", "keywords"),
     [


### PR DESCRIPTION
Add file-backed Evalchemy policies for MMLU-Pro, GPQA Diamond, CruxEval, FinanceBench, IFBench, and MRCR with the zero-shot, generation, context, and token limits used for publication evaluation. These remain separate from the shorter general chat suite.

Add file-backed Harbor recovery policies for SWE-bench, OT-TBLite, Terminal-Bench 2.0, SimpleQA, and DS-1000. SimpleQA uses the Together-hosted openai/gpt-oss-120b judge. DS-1000 expects the adapter-generated local task tree.

Route verifier-only host environment references through Marin secret resolution and into the isolated Harbor driver. This makes the Together-backed SimpleQA policy runnable without changing candidate endpoint authentication.

Part of #9070
Part of #8083