### PR TITLE
[grafana] Set hero chart ranges and filter early evaluations

### DIFF
--- a/infra/grafana/marin-infra-panel/README.md
+++ b/infra/grafana/marin-infra-panel/README.md
@@ -13,20 +13,6 @@ The `cluster` view renders live cluster packing and observed resource usage. The
 `nightlies`, `commits`, and `wandb` views remain available. The panel receives
 Grafana data frames. The Python bridge owns credentials, queries, and caches.
 
-The hero charts use linear y-axes:
-
-- MFU starts at 0%, with a soft maximum of 30%.
-- Train loss uses soft limits of 1.20–1.60 nats/token.
-- Paloma loss defaults to **After initialization**. This view excludes samples
-  below 1% of the maximum cumulative token count across all report samples.
-  The axis includes all remaining values, with 10% of the loss span as padding at each end.
-  For constant loss, the padding is 10% of the absolute loss, or 0.1 at minimum.
-  Select **Full run** to include every evaluation and recalculate the range.
-
-Soft limits expand to include extreme values. The charts show the original loss
-values in nats/token and keep each run's color when the evaluation view changes.
-The initialization cutoff advances as the latest token count increases.
-
 ```bash
 npm ci
 npm run typecheck

--- a/infra/grafana/marin-infra-panel/README.md
+++ b/infra/grafana/marin-infra-panel/README.md
@@ -13,6 +13,20 @@ The `cluster` view renders live cluster packing and observed resource usage. The
 `nightlies`, `commits`, and `wandb` views remain available. The panel receives
 Grafana data frames. The Python bridge owns credentials, queries, and caches.
 
+The hero charts use linear y-axes:
+
+- MFU starts at 0%, with a soft maximum of 30%.
+- Train loss uses soft limits of 1.20–1.60 nats/token.
+- Paloma loss defaults to **After initialization**. This view excludes samples
+  below 1% of the maximum cumulative token count across all report samples.
+  The axis includes all remaining values, with 10% of the loss span as padding at each end.
+  For constant loss, the padding is 10% of the absolute loss, or 0.1 at minimum.
+  Select **Full run** to include every evaluation and recalculate the range.
+
+Soft limits expand to include extreme values. The charts show the original loss
+values in nats/token and keep each run's color when the evaluation view changes.
+The initialization cutoff advances as the latest token count increases.
+
 ```bash
 npm ci
 npm run typecheck

--- a/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
@@ -15,6 +15,12 @@ const LOSS_PADDING = 0.1;
 const MFU_SOFT_MAX = 30;
 const TRAIN_SOFT_MIN = 1.2;
 const TRAIN_SOFT_MAX = 1.6;
+const TICK_ROUNDING_TOLERANCE = 1e-12;
+
+enum EvalView {
+  AfterInitialization = 'after-initialization',
+  FullRun = 'full-run',
+}
 
 function compact(value: number): string {
   if (value >= 1e12) {return `${(value / 1e12).toFixed(1)}T`;}
@@ -25,14 +31,14 @@ function compact(value: number): string {
 
 export function WandbChart({ frames, width, height }: Props) {
   const theme = useTheme2();
-  const [evalView, setEvalView] = useState('after-initialization');
+  const [evalView, setEvalView] = useState(EvalView.AfterInitialization);
   const frame = frameWithField(frames, 'tokens');
   const points = useMemo(() => (frame ? wandbPoints(frame) : []), [frame]);
   const isMfu = points[0]?.chart === MFU_TITLE;
   const isEval = points[0]?.chart === EVAL_TITLE;
   const { paths, xMin, xMax, yMin, yMax, ticks, decimals } = useMemo(() => {
     const latestTokens = Math.max(0, ...points.map((point) => point.tokens));
-    const cutoff = isEval && evalView === 'after-initialization' ? latestTokens * INITIAL_TOKEN_FRACTION : 0;
+    const cutoff = isEval && evalView === EvalView.AfterInitialization ? latestTokens * INITIAL_TOKEN_FRACTION : 0;
     // Keep every run in the map so the view control does not change run colors.
     const groups = new Map<string, typeof points>();
     for (const point of points) {
@@ -60,9 +66,9 @@ export function WandbChart({ frames, width, height }: Props) {
       const maximum = Math.max(isMfu ? MFU_SOFT_MAX : TRAIN_SOFT_MAX, high);
       const targetStep = (maximum - minimum) / 4;
       const magnitude = 10 ** Math.floor(Math.log10(targetStep));
-      const step = [1, 2, 5, 10].find((factor) => factor * magnitude >= targetStep - 1e-12)! * magnitude;
-      yMin = Math.floor(minimum / step + 1e-12) * step;
-      yMax = Math.ceil(maximum / step - 1e-12) * step;
+      const step = [1, 2, 5, 10].find((factor) => factor * magnitude >= targetStep - TICK_ROUNDING_TOLERANCE)! * magnitude;
+      yMin = Math.floor(minimum / step + TICK_ROUNDING_TOLERANCE) * step;
+      yMax = Math.ceil(maximum / step - TICK_ROUNDING_TOLERANCE) * step;
       ticks = Array.from({ length: Math.round((yMax - yMin) / step) + 1 }, (_, index) => yMin + index * step);
       decimals = isMfu ? 0 : Math.max(1, -Math.floor(Math.log10(step)));
     }
@@ -82,9 +88,9 @@ export function WandbChart({ frames, width, height }: Props) {
       </div>
       <div className={css`display:flex;align-items:center;justify-content:space-between;gap:8px;margin-top:4px;color:${theme.colors.text.secondary};`}>
         <span>{isMfu ? 'Model FLOP utilization' : 'nats/token'}</span>
-        {isEval && <select aria-label="Evaluation range" value={evalView} onChange={(event) => setEvalView(event.target.value)} title="After initialization excludes the first 1% of the latest cumulative token count." className={css`color:${theme.colors.text.primary};background:${theme.colors.background.secondary};border:1px solid ${theme.colors.border.weak};border-radius:3px;font:inherit;`}>
-          <option value="after-initialization">After initialization</option>
-          <option value="full-run">Full run</option>
+        {isEval && <select aria-label="Evaluation range" value={evalView} onChange={(event) => setEvalView(event.target.value as EvalView)} title="After initialization excludes the first 1% of the latest cumulative token count." className={css`color:${theme.colors.text.primary};background:${theme.colors.background.secondary};border:1px solid ${theme.colors.border.weak};border-radius:3px;font:inherit;`}>
+          <option value={EvalView.AfterInitialization}>After initialization</option>
+          <option value={EvalView.FullRun}>Full run</option>
         </select>}
       </div>
     </div>

--- a/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { css } from '@emotion/css';
 import { DataFrame } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
@@ -7,6 +7,14 @@ import { PanelMessage } from './PanelMessage';
 import { SERIES_COLORS } from './palette';
 
 interface Props { frames: DataFrame[]; width: number; height: number }
+
+const MFU_TITLE = 'MFU (%)';
+const EVAL_TITLE = 'Paloma macro loss (dropless)';
+const INITIAL_TOKEN_FRACTION = 0.01;
+const LOSS_PADDING = 0.1;
+const MFU_SOFT_MAX = 30;
+const TRAIN_SOFT_MIN = 1.2;
+const TRAIN_SOFT_MAX = 1.6;
 
 function compact(value: number): string {
   if (value >= 1e12) {return `${(value / 1e12).toFixed(1)}T`;}
@@ -17,31 +25,75 @@ function compact(value: number): string {
 
 export function WandbChart({ frames, width, height }: Props) {
   const theme = useTheme2();
+  const [evalView, setEvalView] = useState('after-initialization');
   const frame = frameWithField(frames, 'tokens');
   const points = useMemo(() => (frame ? wandbPoints(frame) : []), [frame]);
-  const { paths, xMin, xMax, yMin, yMax } = useMemo(() => {
-    if (points.length === 0) {return { paths: [] as Array<[string, typeof points]>, xMin: 0, xMax: 1, yMin: 0, yMax: 1 };}
+  const isMfu = points[0]?.chart === MFU_TITLE;
+  const isEval = points[0]?.chart === EVAL_TITLE;
+  const { paths, xMin, xMax, yMin, yMax, ticks, decimals } = useMemo(() => {
+    const latestTokens = Math.max(0, ...points.map((point) => point.tokens));
+    const cutoff = isEval && evalView === 'after-initialization' ? latestTokens * INITIAL_TOKEN_FRACTION : 0;
+    // Keep every run in the map so the view control does not change run colors.
     const groups = new Map<string, typeof points>();
-    for (const point of points) {groups.set(point.run, [...(groups.get(point.run) ?? []), point]);}
+    for (const point of points) {
+      if (!groups.has(point.run)) {groups.set(point.run, []);}
+      if (point.tokens >= cutoff) {groups.get(point.run)!.push(point);}
+    }
     for (const values of groups.values()) {values.sort((a, b) => a.tokens - b.tokens);}
-    const xs = points.map((point) => point.tokens);
-    const ys = [...points.map((point) => point.value)].sort((a, b) => a - b);
-    const low = ys[Math.floor(ys.length * 0.02)] ?? 0;
-    const high = ys[Math.min(ys.length - 1, Math.floor(ys.length * 0.98))] ?? 1;
-    return { paths: [...groups.entries()], xMin: Math.min(...xs), xMax: Math.max(...xs), yMin: low, yMax: high === low ? low + 1 : high };
-  }, [points]);
+    const visible = [...groups.values()].flat();
+    const xs = visible.map((point) => point.tokens);
+    const ys = visible.map((point) => point.value);
+    const low = ys.length ? Math.min(...ys) : 0;
+    const high = ys.length ? Math.max(...ys) : 1;
+    let yMin: number;
+    let yMax: number;
+    let ticks: number[];
+    let decimals: number;
+    if (isEval) {
+      const padding = (high - low || Math.max(Math.abs(low), 1)) * LOSS_PADDING;
+      yMin = low - padding;
+      yMax = high + padding;
+      ticks = [yMin, (yMin + yMax) / 2, yMax];
+      decimals = Math.max(2, -Math.floor(Math.log10(yMax - yMin)) + 1);
+    } else {
+      const minimum = isMfu ? 0 : Math.min(TRAIN_SOFT_MIN, low);
+      const maximum = Math.max(isMfu ? MFU_SOFT_MAX : TRAIN_SOFT_MAX, high);
+      const targetStep = (maximum - minimum) / 4;
+      const magnitude = 10 ** Math.floor(Math.log10(targetStep));
+      const step = [1, 2, 5, 10].find((factor) => factor * magnitude >= targetStep - 1e-12)! * magnitude;
+      yMin = Math.floor(minimum / step + 1e-12) * step;
+      yMax = Math.ceil(maximum / step - 1e-12) * step;
+      ticks = Array.from({ length: Math.round((yMax - yMin) / step) + 1 }, (_, index) => yMin + index * step);
+      decimals = isMfu ? 0 : Math.max(1, -Math.floor(Math.log10(step)));
+    }
+    return { paths: [...groups.entries()], xMin: xs.length ? Math.min(...xs) : 0, xMax: latestTokens, yMin, yMax, ticks, decimals };
+  }, [points, isMfu, isEval, evalView]);
   if (points.length === 0) {return <PanelMessage width={width} height={height}>No W&B data</PanelMessage>;}
-  const pad = { left: 45, right: 10, top: 28, bottom: 20 };
+  const pad = { left: 60, right: 10, top: width < 400 ? 76 : 56, bottom: 20 };
   const chartWidth = Math.max(1, width - pad.left - pad.right);
   const chartHeight = Math.max(1, height - pad.top - pad.bottom);
   const x = (value: number) => pad.left + ((value - xMin) / Math.max(1, xMax - xMin)) * chartWidth;
-  const y = (value: number) => pad.top + (1 - (value - yMin) / Math.max(1e-12, yMax - yMin)) * chartHeight;
+  const y = (value: number) => pad.top + (1 - (value - yMin) / (yMax - yMin)) * chartHeight;
   return <section className={css`width:${width}px;height:${height}px;color:${theme.colors.text.primary};position:relative;overflow:hidden;`} aria-label={`${points[0].chart} W&B chart`}>
-    <div className={css`position:absolute;top:2px;left:6px;right:6px;display:flex;justify-content:space-between;font-size:13px;z-index:1;`}><strong>{points[0].chart}</strong><a href={points[0].reportUrl} target="_blank" rel="noreferrer" className={css`color:${theme.colors.text.link};`}>W&B report ↗</a></div>
+    <div className={css`position:absolute;top:2px;left:6px;right:6px;font-size:12px;z-index:1;`}>
+      <div className={css`display:flex;justify-content:space-between;gap:8px;`}>
+        <strong>{points[0].chart}</strong>
+        <a href={points[0].reportUrl} target="_blank" rel="noreferrer" className={css`color:${theme.colors.text.link};white-space:nowrap;`}>W&B report ↗</a>
+      </div>
+      <div className={css`display:flex;align-items:center;justify-content:space-between;gap:8px;margin-top:4px;color:${theme.colors.text.secondary};`}>
+        <span>{isMfu ? 'Model FLOP utilization' : 'nats/token'}</span>
+        {isEval && <select aria-label="Evaluation range" value={evalView} onChange={(event) => setEvalView(event.target.value)} title="After initialization excludes the first 1% of the latest cumulative token count." className={css`color:${theme.colors.text.primary};background:${theme.colors.background.secondary};border:1px solid ${theme.colors.border.weak};border-radius:3px;font:inherit;`}>
+          <option value="after-initialization">After initialization</option>
+          <option value="full-run">Full run</option>
+        </select>}
+      </div>
+    </div>
     <svg width={width} height={height} role="img" aria-label={`${points[0].chart} versus cumulative training tokens`}>
-      {[0, .5, 1].map((fraction) => { const yy = pad.top + fraction * chartHeight; const value = yMax - fraction * (yMax - yMin); return <g key={fraction}><line x1={pad.left} x2={width-pad.right} y1={yy} y2={yy} stroke={theme.colors.border.weak} strokeDasharray="2 4"/><text x={pad.left-5} y={yy+3} textAnchor="end" fill={theme.colors.text.secondary} fontSize="11">{value.toFixed(2)}</text></g>; })}
+      {ticks.map((value) => { const yy = y(value); return <g key={value}><line x1={pad.left} x2={width-pad.right} y1={yy} y2={yy} stroke={theme.colors.border.weak} strokeDasharray="2 4"/><text x={pad.left-5} y={yy+3} textAnchor="end" fill={theme.colors.text.secondary} fontSize="11">{value.toFixed(decimals)}{isMfu ? '%' : ''}</text></g>; })}
       {[0, .5, 1].map((fraction) => { const xx = pad.left + fraction * chartWidth; const value = xMin + fraction * (xMax-xMin); return <text key={fraction} x={xx} y={height-7} textAnchor={fraction===0?'start':fraction===1?'end':'middle'} fill={theme.colors.text.secondary} fontSize="11">{compact(value)}</text>; })}
-      {paths.map(([run, values], index) => <polyline key={run} fill="none" stroke={SERIES_COLORS[index % SERIES_COLORS.length]} strokeWidth="2" points={values.map((point) => `${x(point.tokens)},${y(Math.min(yMax, Math.max(yMin, point.value)))}`).join(' ')} />)}
+      {paths.map(([run, values], index) => values.length === 1
+        ? <circle key={run} cx={x(values[0].tokens)} cy={y(values[0].value)} r="2" fill={SERIES_COLORS[index % SERIES_COLORS.length]} />
+        : <polyline key={run} fill="none" stroke={SERIES_COLORS[index % SERIES_COLORS.length]} strokeWidth="2" points={values.map((point) => `${x(point.tokens)},${y(point.value)}`).join(' ')} />)}
     </svg>
   </section>;
 }

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -153,3 +153,90 @@ test('SM raster hover matches the painted time bucket', () => {
   expect(screen.getByRole('tooltip')).toHaveTextContent('node-1');
   contextSpy.mockRestore();
 });
+
+function wandbFrame(chart: string, samples: Array<{ tokens: number; value: number; run?: string }>) {
+  return frame('A', samples.map((sample) => ({
+    chart, report_title: 'Hero run', report_url: 'https://example/report', run: 'hero', ...sample,
+  })));
+}
+
+test('MFU starts at zero and expands above 30 percent without clipping samples', () => {
+  const { rerender } = render(<WandbChart frames={[wandbFrame('MFU (%)', [
+    { tokens: 1e9, value: 21 }, { tokens: 2e9, value: 24 },
+  ])]} width={480} height={260} />);
+  for (const tick of ['0%', '10%', '20%', '30%']) {
+    expect(screen.getByText(tick)).toBeInTheDocument();
+  }
+  rerender(<WandbChart frames={[wandbFrame('MFU (%)', [
+    { tokens: 1e9, value: 0 }, { tokens: 2e9, value: 35 }, { tokens: 3e9, value: 45 },
+  ])]} width={480} height={260} />);
+  const axis = Array.from(screen.getByRole('img').querySelectorAll('g text'), (label) => parseFloat(label.textContent!));
+  expect(Math.max(...axis)).toBeGreaterThanOrEqual(45);
+  const plotted = screen.getByRole('img').querySelector('polyline')!.getAttribute('points')!.split(' ');
+  const heights = plotted.map((point) => Number(point.split(',')[1]));
+  expect(heights[0]).toBe(240);
+  expect(heights[1]).toBeGreaterThan(heights[2]);
+  expect(heights[2]).toBeGreaterThan(56);
+});
+
+test('train loss uses the preferred range and expands for rare extremes', () => {
+  const samples = Array.from({ length: 100 }, (_, index) => ({ tokens: index * 1e9, value: 1.3 }));
+  const { rerender } = render(<WandbChart frames={[wandbFrame('Train cross-entropy loss', samples)]} width={480} height={260} />);
+  for (const tick of ['1.2', '1.3', '1.4', '1.5', '1.6']) {
+    expect(screen.getByText(tick)).toBeInTheDocument();
+  }
+  samples[0].value = 1.1;
+  samples[99].value = 1.8;
+  rerender(<WandbChart frames={[wandbFrame('Train cross-entropy loss', samples)]} width={480} height={260} />);
+  const svg = screen.getByRole('img');
+  const axis = Array.from(svg.querySelectorAll('g text'), (label) => Number(label.textContent));
+  expect(Math.min(...axis)).toBeLessThanOrEqual(1.1);
+  expect(Math.max(...axis)).toBeGreaterThanOrEqual(1.8);
+  const plotted = svg.querySelector('polyline')!.getAttribute('points')!.split(' ');
+  const heights = plotted.map((point) => Number(point.split(',')[1]));
+  expect(heights[0]).toBeGreaterThan(heights[1]);
+  expect(heights[99]).toBeLessThan(heights[1]);
+});
+
+test('eval excludes the first percent of tokens and restores all runs with the same colors', () => {
+  const samples = [
+    { tokens: 0, value: 11.8, run: 'initial' },
+    { tokens: 99, value: 10, run: 'initial' },
+    { tokens: 10000, value: 2.22, run: 'resumed' },
+    { tokens: 100, value: 2.24, run: 'resumed' },
+    { tokens: 5000, value: 2.23, run: 'resumed' },
+  ];
+  render(<WandbChart frames={[wandbFrame('Paloma macro loss (dropless)', samples)]} width={480} height={260} />);
+  const control = screen.getByRole('combobox', { name: 'Evaluation range' });
+  expect(control).toHaveDisplayValue('After initialization');
+  const svg = screen.getByRole('img');
+  expect(Array.from(svg.querySelectorAll('g text'), (label) => label.textContent)).toEqual(['2.218', '2.230', '2.242']);
+  const resumed = svg.querySelectorAll('polyline')[1];
+  const color = resumed.getAttribute('stroke');
+  const plotted = resumed.getAttribute('points')!.split(' ').map((point) => point.split(',').map(Number));
+  expect(plotted).toHaveLength(3);
+  expect(plotted[0][0]).toBe(60);
+  expect(plotted[2][0]).toBe(470);
+  expect(plotted[0][1]).toBeGreaterThan(56);
+  expect(plotted[2][1]).toBeLessThan(240);
+  expect(svg.querySelectorAll('polyline')[0]).toHaveAttribute('points', '');
+
+  fireEvent.change(control, { target: { value: 'full-run' } });
+  expect(control).toHaveDisplayValue('Full run');
+  expect(svg.querySelectorAll('polyline')[0].getAttribute('points')!.split(' ')).toHaveLength(2);
+  expect(svg.querySelectorAll('polyline')[1]).toHaveAttribute('stroke', color);
+  expect(Math.max(...Array.from(svg.querySelectorAll('g text'), (label) => Number(label.textContent)))).toBeGreaterThan(11.8);
+
+  fireEvent.change(control, { target: { value: 'after-initialization' } });
+  expect(screen.getByText('2.242')).toBeInTheDocument();
+});
+
+test('a single eval at zero tokens stays visible with a finite axis', () => {
+  render(<WandbChart frames={[wandbFrame('Paloma macro loss (dropless)', [
+    { tokens: 0, value: 2.23 },
+  ])]} width={280} height={260} />);
+  const point = screen.getByRole('img').querySelector('circle')!;
+  expect(Number(point.getAttribute('cy'))).toBeGreaterThan(76);
+  expect(Number(point.getAttribute('cy'))).toBeLessThan(240);
+  expect(screen.getByRole('combobox')).toHaveDisplayValue('After initialization');
+});

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -208,7 +208,6 @@ test('eval excludes the first percent of tokens and restores all runs with the s
   ];
   render(<WandbChart frames={[wandbFrame('Paloma macro loss (dropless)', samples)]} width={480} height={260} />);
   const control = screen.getByRole('combobox', { name: 'Evaluation range' });
-  expect(control).toHaveDisplayValue('After initialization');
   const svg = screen.getByRole('img');
   expect(Array.from(svg.querySelectorAll('g text'), (label) => label.textContent)).toEqual(['2.218', '2.230', '2.242']);
   const resumed = svg.querySelectorAll('polyline')[1];
@@ -222,7 +221,6 @@ test('eval excludes the first percent of tokens and restores all runs with the s
   expect(svg.querySelectorAll('polyline')[0]).toHaveAttribute('points', '');
 
   fireEvent.change(control, { target: { value: 'full-run' } });
-  expect(control).toHaveDisplayValue('Full run');
   expect(svg.querySelectorAll('polyline')[0].getAttribute('points')!.split(' ')).toHaveLength(2);
   expect(svg.querySelectorAll('polyline')[1]).toHaveAttribute('stroke', color);
   expect(Math.max(...Array.from(svg.querySelectorAll('g text'), (label) => Number(label.textContent)))).toBeGreaterThan(11.8);
@@ -238,5 +236,4 @@ test('a single eval at zero tokens stays visible with a finite axis', () => {
   const point = screen.getByRole('img').querySelector('circle')!;
   expect(Number(point.getAttribute('cy'))).toBeGreaterThan(76);
   expect(Number(point.getAttribute('cy'))).toBeLessThan(240);
-  expect(screen.getByRole('combobox')).toHaveDisplayValue('After initialization');
 });

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -9,6 +9,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlsplit
 
 from config import K8S_CLUSTERS
+from wandb_source import WANDB_CHARTS
 
 _NOW = datetime(2026, 7, 21, 12, tzinfo=UTC)
 _CW_K8S_CLUSTERS = tuple(target.name for target in K8S_CLUSTERS)
@@ -80,7 +81,6 @@ def _builds() -> list[dict]:
 
 
 def _wandb(chart: str) -> list[dict]:
-    titles = {"train-loss": "Train cross-entropy loss", "paloma-macro-loss": "Paloma macro loss", "mfu": "MFU (%)"}
     rows = []
     for run_index, run in enumerate(("hero-12d8b6f0-dee637",)):
         for index in range(40):
@@ -91,7 +91,7 @@ def _wandb(chart: str) -> list[dict]:
                 value = 3.2 - index * 0.035 + run_index * 0.08
             rows.append(
                 {
-                    "chart": titles[chart],
+                    "chart": WANDB_CHARTS[chart][0],
                     "run": run,
                     "tokens": tokens,
                     "value": value,


### PR DESCRIPTION
Start the hero-run MFU chart at 0%, with a soft maximum of 30%. Use soft limits of 1.20–1.60 nats/token for train loss. Expand these ranges to include extreme values instead of clipping samples to the 2nd–98th percentiles.

Default Paloma loss to evaluations at or above 1% of the maximum cumulative token count across all report samples. Add 10% of the displayed loss span as padding at each end. This prevents initial evaluations from compressing later changes. A Full run control restores all sampled evaluations. Keep each run's color when the view changes.
