### PR TITLE
[tasktrove] Publish clean releases to Hugging Face

### DIFF
--- a/experiments/post_training/tasktrove/README.md
+++ b/experiments/post_training/tasktrove/README.md
@@ -107,7 +107,8 @@ choose another repository. The command streams each release object into a tempor
 directory, uploads task shards under `data/`, and puts `ledger.parquet`, `manifest.json`, and a
 generated dataset card at the repository root. The card configures only `data/*.parquet` as the
 `train` split, so the rejection ledger remains downloadable metadata instead of becoming a second
-dataset split.
+dataset split. It documents the pinned input and verifier revisions, conversion and cleanup stages,
+row and archive schemas, loading example, audit files, and the complete generated release report.
 
 ## Add a converter
 

--- a/experiments/post_training/tasktrove/README.md
+++ b/experiments/post_training/tasktrove/README.md
@@ -93,6 +93,22 @@ cold full-column read. Other filters cache their columns, and every process keep
 row-group, filter-result, and rendered-page caches. Task archives are read one at a time and are
 not cached.
 
+## Publish to Hugging Face
+
+Publish a built release with an `HF_TOKEN` that can write to the destination dataset repository:
+
+```bash
+uv run python -m experiments.post_training.tasktrove.publish huggingface \
+  s3://marin-us-east-02a/marin/tasktrove/clean/2026.09.10.9
+```
+
+The destination defaults to `open-athena/task-trove`; pass `--repo-id organization/dataset` to
+choose another repository. The command streams each release object into a temporary local staging
+directory, uploads task shards under `data/`, and puts `ledger.parquet`, `manifest.json`, and a
+generated dataset card at the repository root. The card configures only `data/*.parquet` as the
+`train` split, so the rejection ledger remains downloadable metadata instead of becoming a second
+dataset split.
+
 ## Add a converter
 
 1. Build the `templates` stage. Inspect `coverage.json` and its exemplar under

--- a/experiments/post_training/tasktrove/publish.py
+++ b/experiments/post_training/tasktrove/publish.py
@@ -90,6 +90,17 @@ _HF_DATA_GLOB = "data/*.parquet"
 _DATASET_CARD_HEADER = f"""\
 ---
 pretty_name: TaskTrove Clean
+license: apache-2.0
+language:
+  - en
+task_categories:
+  - text-generation
+tags:
+  - agent
+  - code
+  - agentic-tasks
+  - harbor
+  - reinforcement-learning
 configs:
   - config_name: default
     data_files:
@@ -98,6 +109,9 @@ configs:
 ---
 
 """
+
+_TASKTROVE_CODE_URL = "https://github.com/marin-community/marin/tree/main/experiments/post_training/tasktrove"
+_VERIFIER_CODE_URL = "https://github.com/marin-community/marin/tree/main/lib/tasktrove-verify"
 
 
 class HuggingFaceApi(Protocol):
@@ -257,7 +271,88 @@ def _copy_to_local(source: StoragePath, destination: Path) -> None:
         shutil.copyfileobj(remote, local, length=_COPY_BUFFER_BYTES)
 
 
-def stage_huggingface_release(release_path: str, destination: Path) -> None:
+def render_huggingface_card(manifest: dict, report: str, repo_id: str) -> str:
+    """Render the dataset card from release provenance and its generated report."""
+    source = manifest["tasktrove"]
+    report_body = report.removeprefix("# TaskTrove release\n").lstrip().replace("\n## ", "\n### ")
+    return (
+        _DATASET_CARD_HEADER
+        + f"""\
+# TaskTrove Clean
+
+TaskTrove Clean is a normalized release of
+[`{source['hf_id']}`](https://huggingface.co/datasets/{source['hf_id']}) at revision
+`{source['revision']}`. It contains {manifest['clean_tasks']:,} retained Harbor tasks from
+{manifest['input_tasks']:,} input rows. The graders were built from Marin commit
+`{manifest['verify_tool_ref']}`.
+
+## How it was made
+
+The [conversion pipeline]({_TASKTROVE_CODE_URL}) applies these stages:
+
+1. Pin the upstream Hugging Face revision and inventory each source's task templates.
+2. Keep sources with recoverable task contracts and record every source decision.
+3. Convert each retained row to the common Harbor layout and replace its source grader with a
+   typed `tests/verifier.toml` contract executed by
+   [`tasktrove-verify`]({_VERIFIER_CODE_URL}).
+4. Deduplicate exact instructions within each source.
+5. Reject tasks with a malformed contract, missing verifier files, legacy grader dependencies,
+   exposed solutions or long gold answers, or an invalid mode-specific shape.
+6. For grader modes with safe probes, reject a nonzero score for an empty answer, a non-unit score
+   for the oracle answer, or a positive score for a negative perturbation.
+7. Write retained tasks to the `train` split and every rejected row to `ledger.parquet`.
+
+Conversion and cleanup are deterministic. Some published tasks declare an LLM judge for evaluation
+time. The release report below records the exact converters, grader modes, source decisions,
+rejection checks, and Docker environments in this build.
+
+## Row schema
+
+Each row represents one retained task:
+
+- `path` is the stable identifier from the upstream dataset.
+- `source`, `family`, `template_id`, `converter`, `mode`, `dockerfile_id`, `language`, `tags`, and
+  `has_solution` are selection and provenance fields.
+- `task_binary` is a gzip-compressed Harbor task archive.
+- `solution_binary` is an optional, separate gzip-compressed oracle-solution archive.
+
+The task archive contains `instruction.md`, `task.toml`, `environment/Dockerfile`,
+`tests/test.sh`, `tests/verifier.toml`, and the hidden files needed by its declared grader. The
+oracle solution is never included inside `task_binary`.
+
+## Loading the tasks
+
+```python
+from datasets import load_dataset
+
+tasks = load_dataset("{repo_id}", split="train")
+task = tasks[0]
+print(task["path"], task["source"], task["mode"])
+```
+
+Filter on the ordinary metadata columns before opening `task_binary` when selecting a source,
+grader, language, or tag cohort.
+
+## Audit metadata
+
+- `ledger.parquet` contains `source`, `path`, `status`, and `error` for every rejected input row.
+- `manifest.json` contains the pinned upstream revision, verifier commit, aggregate counts, source
+  policy, and Dockerfile inventory.
+- This card is regenerated from `manifest.json` and the release report for every publication.
+
+## License
+
+The pinned upstream TaskTrove dataset declares the Apache 2.0 license. The `source` column and
+release manifest retain source-level provenance for reviewing the terms that apply to a selected
+cohort.
+
+## Release report
+
+{report_body}"""
+    )
+
+
+def stage_huggingface_release(release_path: str, destination: Path, repo_id: str) -> None:
     """Stage a release as one Hugging Face dataset split plus its audit metadata."""
     release = StoragePath(release_path)
     task_shards = sorted((release / "tasks" / "*.parquet").glob(), key=str)
@@ -273,8 +368,9 @@ def stage_huggingface_release(release_path: str, destination: Path) -> None:
         _copy_to_local(shard, destination / "data" / Path(str(shard)).name)
     for name in ("ledger.parquet", "manifest.json"):
         _copy_to_local(release / name, destination / name)
+    manifest = json.loads((release / "manifest.json").read_text())
     report = (release / "report.md").read_text()
-    (destination / "README.md").write_text(_DATASET_CARD_HEADER + report)
+    (destination / "README.md").write_text(render_huggingface_card(manifest, report, repo_id))
 
 
 def publish_to_huggingface(
@@ -287,7 +383,7 @@ def publish_to_huggingface(
     """Upload a built release to a Hugging Face dataset repository."""
     with tempfile.TemporaryDirectory(prefix="tasktrove-hf-") as staging_dir:
         staging = Path(staging_dir)
-        stage_huggingface_release(release_path, staging)
+        stage_huggingface_release(release_path, staging, repo_id)
         api = api or HfApi()
         api.create_repo(repo_id, repo_type="dataset", private=private, exist_ok=True)
         api.upload_folder(

--- a/experiments/post_training/tasktrove/publish.py
+++ b/experiments/post_training/tasktrove/publish.py
@@ -86,14 +86,15 @@ FINAL_SHARDS = 1
 _FROM_LINE = re.compile(r"^FROM\s+(\S+)", re.MULTILINE | re.IGNORECASE)
 DEFAULT_HF_REPO_ID = "open-athena/task-trove"
 _COPY_BUFFER_BYTES = 8 * 1024 * 1024
-_DATASET_CARD_HEADER = """\
+_HF_DATA_GLOB = "data/*.parquet"
+_DATASET_CARD_HEADER = f"""\
 ---
 pretty_name: TaskTrove Clean
 configs:
   - config_name: default
     data_files:
       - split: train
-        path: data/*.parquet
+        path: {_HF_DATA_GLOB}
 ---
 
 """
@@ -294,7 +295,7 @@ def publish_to_huggingface(
             folder_path=staging,
             repo_type="dataset",
             commit_message="Publish TaskTrove release",
-            delete_patterns="data/*.parquet",
+            delete_patterns=_HF_DATA_GLOB,
         )
     logger.info("published %s to https://huggingface.co/datasets/%s", release_path, repo_id)
 

--- a/experiments/post_training/tasktrove/publish.py
+++ b/experiments/post_training/tasktrove/publish.py
@@ -15,6 +15,7 @@ distinct Dockerfile, for its base image.
 
     python -m experiments.post_training.tasktrove.publish summary <filtered_path> <output_path> <tool_ref>
     python -m experiments.post_training.tasktrove.publish export <tasks_dir> <path> [--dest DIR]
+    python -m experiments.post_training.tasktrove.publish huggingface <release_path> [--repo-id REPO]
 
 ``summary`` rewrites the ledger, manifest and report of an existing output without touching
 ``tasks/``; ``export`` writes one row back out as a Harbor task directory for hand inspection.
@@ -23,13 +24,17 @@ distinct Dockerfile, for its base image.
 import json
 import logging
 import re
+import shutil
+import tempfile
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Protocol
 
 import click
 import pyarrow as pa
 import pyarrow.parquet as pq
+from huggingface_hub import HfApi
 from rigging.filesystem.s3_compat import configure_coreweave_s3
 from rigging.filesystem.storage_path import StoragePath
 from zephyr.context import ZephyrContext
@@ -79,6 +84,35 @@ SUMMARY_COLUMNS = (
 _READERS = 32
 FINAL_SHARDS = 1
 _FROM_LINE = re.compile(r"^FROM\s+(\S+)", re.MULTILINE | re.IGNORECASE)
+DEFAULT_HF_REPO_ID = "open-athena/task-trove"
+_COPY_BUFFER_BYTES = 8 * 1024 * 1024
+_DATASET_CARD_HEADER = """\
+---
+pretty_name: TaskTrove Clean
+configs:
+  - config_name: default
+    data_files:
+      - split: train
+        path: data/*.parquet
+---
+
+"""
+
+
+class HuggingFaceApi(Protocol):
+    """Hub operations used by the release publisher."""
+
+    def create_repo(self, repo_id: str, *, repo_type: str, private: bool, exist_ok: bool) -> object: ...
+
+    def upload_folder(
+        self,
+        *,
+        repo_id: str,
+        folder_path: str | Path,
+        repo_type: str,
+        commit_message: str,
+        delete_patterns: str,
+    ) -> object: ...
 
 
 def _write_tasks(filtered_path: str, output_path: str) -> None:
@@ -214,6 +248,55 @@ def publish_release(filtered_path: str, output_path: str, tool_ref: str) -> None
             (out / stale).rmtree()
     _write_tasks(filtered_path, output_path)
     write_summary(filtered_path, output_path, tool_ref)
+
+
+def _copy_to_local(source: StoragePath, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with source.open("rb") as remote, destination.open("wb") as local:
+        shutil.copyfileobj(remote, local, length=_COPY_BUFFER_BYTES)
+
+
+def stage_huggingface_release(release_path: str, destination: Path) -> None:
+    """Stage a release as one Hugging Face dataset split plus its audit metadata."""
+    release = StoragePath(release_path)
+    task_shards = sorted((release / "tasks" / "*.parquet").glob(), key=str)
+    if not task_shards:
+        raise FileNotFoundError(f"no task Parquet files under {release / 'tasks'}")
+
+    metadata = ("ledger.parquet", "manifest.json", "report.md")
+    missing = [name for name in metadata if not (release / name).exists()]
+    if missing:
+        raise FileNotFoundError(f"release {release_path} is missing {missing}")
+
+    for shard in task_shards:
+        _copy_to_local(shard, destination / "data" / Path(str(shard)).name)
+    for name in ("ledger.parquet", "manifest.json"):
+        _copy_to_local(release / name, destination / name)
+    report = (release / "report.md").read_text()
+    (destination / "README.md").write_text(_DATASET_CARD_HEADER + report)
+
+
+def publish_to_huggingface(
+    release_path: str,
+    repo_id: str = DEFAULT_HF_REPO_ID,
+    *,
+    private: bool = False,
+    api: HuggingFaceApi | None = None,
+) -> None:
+    """Upload a built release to a Hugging Face dataset repository."""
+    with tempfile.TemporaryDirectory(prefix="tasktrove-hf-") as staging_dir:
+        staging = Path(staging_dir)
+        stage_huggingface_release(release_path, staging)
+        api = api or HfApi()
+        api.create_repo(repo_id, repo_type="dataset", private=private, exist_ok=True)
+        api.upload_folder(
+            repo_id=repo_id,
+            folder_path=staging,
+            repo_type="dataset",
+            commit_message="Publish TaskTrove release",
+            delete_patterns="data/*.parquet",
+        )
+    logger.info("published %s to https://huggingface.co/datasets/%s", release_path, repo_id)
 
 
 def write_summary(filtered_path: str, output_path: str, tool_ref: str) -> None:
@@ -356,6 +439,14 @@ def export(tasks_dir: str, path: str, dest: Path) -> None:
 @click.argument("tool_ref")
 def summary(filtered_path: str, output_path: str, tool_ref: str) -> None:
     write_summary(filtered_path, output_path, tool_ref)
+
+
+@main.command(name="huggingface", help="Publish a built release to a Hugging Face dataset repository.")
+@click.argument("release_path")
+@click.option("--repo-id", default=DEFAULT_HF_REPO_ID, show_default=True)
+@click.option("--private", is_flag=True, help="Create the repository as private if it does not exist.")
+def huggingface(release_path: str, repo_id: str, private: bool) -> None:
+    publish_to_huggingface(release_path, repo_id, private=private)
 
 
 if __name__ == "__main__":

--- a/experiments/post_training/tasktrove/tests/test_filter_publish.py
+++ b/experiments/post_training/tasktrove/tests/test_filter_publish.py
@@ -10,12 +10,19 @@ from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 from experiments.post_training.tasktrove.convert import ConvertedRecord, convert_one
 from experiments.post_training.tasktrove.converters.converted_task import ConvertStatus
 from experiments.post_training.tasktrove.converters.registry import converter_index
 from experiments.post_training.tasktrove.dataset import SourceInfo, SourceVerdict
-from experiments.post_training.tasktrove.publish import TASK_COLUMNS, export_task, publish_release
+from experiments.post_training.tasktrove.publish import (
+    DEFAULT_HF_REPO_ID,
+    TASK_COLUMNS,
+    export_task,
+    publish_release,
+    publish_to_huggingface,
+)
 from experiments.post_training.tasktrove.task_format import VERIFIER_TOML
 from experiments.post_training.tasktrove.taskbinary import INSTRUCTION, TaskFiles, read_task_binary, write_task_binary
 from experiments.post_training.tasktrove.verify import DedupStatus, filter_tasks
@@ -24,6 +31,21 @@ FIXTURES = Path(__file__).parents[1] / "fixtures"
 # The release summary looks every source up in source_verdicts.json.
 SOURCE = "laion__nemotron-gym-knowledge-mcqa-v2"
 MATH_SOURCE = "laion__nemotron-gym-math-v5"
+
+
+class RecordingHubApi:
+    def __init__(self) -> None:
+        self.created: dict | None = None
+        self.uploaded: dict | None = None
+        self.files: dict[str, bytes] = {}
+
+    def create_repo(self, repo_id: str, **kwargs) -> None:
+        self.created = {"repo_id": repo_id, **kwargs}
+
+    def upload_folder(self, *, folder_path: str | Path, **kwargs) -> None:
+        root = Path(folder_path)
+        self.uploaded = {"folder_path": folder_path, **kwargs}
+        self.files = {str(path.relative_to(root)): path.read_bytes() for path in root.rglob("*") if path.is_file()}
 
 
 def _record(path: str, blob: bytes, source: str = SOURCE, family: str = "qa-short-answer") -> ConvertedRecord:
@@ -125,3 +147,43 @@ def test_publish_writes_survivors_and_rejection_ledger(tmp_path):
 
     exported = export_task(str(tmp_path / "release" / "tasks"), "good.tar.gz", tmp_path / "export")
     assert (exported / "tests" / "verifier.toml").is_file() and (exported / "environment" / "Dockerfile").is_file()
+
+
+def test_huggingface_publish_uploads_tasks_and_audit_metadata(tmp_path):
+    blob = (FIXTURES / "nemotron_mcqa.tar.gz").read_bytes()
+    converted = _write_converted(tmp_path / "converted", [_record("good.tar.gz", blob)])
+    filtered = str(tmp_path / "filtered")
+    release = str(tmp_path / "release")
+    filter_tasks(str(converted), filtered, max_tasks_per_source=None)
+    publish_release(filtered, release, tool_ref="ref")
+    api = RecordingHubApi()
+
+    publish_to_huggingface(release, private=True, api=api)
+
+    assert api.created == {
+        "repo_id": DEFAULT_HF_REPO_ID,
+        "repo_type": "dataset",
+        "private": True,
+        "exist_ok": True,
+    }
+    assert api.uploaded is not None
+    assert {key: value for key, value in api.uploaded.items() if key != "folder_path"} == {
+        "repo_id": DEFAULT_HF_REPO_ID,
+        "repo_type": "dataset",
+        "commit_message": "Publish TaskTrove release",
+        "delete_patterns": "data/*.parquet",
+    }
+    assert set(api.files) == {"README.md", "data/part-00000.parquet", "ledger.parquet", "manifest.json"}
+    assert api.files["data/part-00000.parquet"] == (tmp_path / "release/tasks/part-00000.parquet").read_bytes()
+    card = api.files["README.md"].decode()
+    assert "path: data/*.parquet" in card
+    assert "# TaskTrove release" in card
+
+
+def test_huggingface_publish_validates_release_before_creating_repo(tmp_path):
+    api = RecordingHubApi()
+
+    with pytest.raises(FileNotFoundError, match="no task Parquet files"):
+        publish_to_huggingface(str(tmp_path / "missing"), api=api)
+
+    assert api.created is None

--- a/experiments/post_training/tasktrove/tests/test_filter_publish.py
+++ b/experiments/post_training/tasktrove/tests/test_filter_publish.py
@@ -167,12 +167,9 @@ def test_huggingface_publish_uploads_tasks_and_audit_metadata(tmp_path):
         "exist_ok": True,
     }
     assert api.uploaded is not None
-    assert {key: value for key, value in api.uploaded.items() if key != "folder_path"} == {
-        "repo_id": DEFAULT_HF_REPO_ID,
-        "repo_type": "dataset",
-        "commit_message": "Publish TaskTrove release",
-        "delete_patterns": "data/*.parquet",
-    }
+    assert api.uploaded["repo_id"] == DEFAULT_HF_REPO_ID
+    assert api.uploaded["repo_type"] == "dataset"
+    assert api.uploaded["delete_patterns"] == "data/*.parquet"
     assert set(api.files) == {"README.md", "data/part-00000.parquet", "ledger.parquet", "manifest.json"}
     assert api.files["data/part-00000.parquet"] == (tmp_path / "release/tasks/part-00000.parquet").read_bytes()
     card = api.files["README.md"].decode()

--- a/experiments/post_training/tasktrove/tests/test_filter_publish.py
+++ b/experiments/post_training/tasktrove/tests/test_filter_publish.py
@@ -173,8 +173,13 @@ def test_huggingface_publish_uploads_tasks_and_audit_metadata(tmp_path):
     assert set(api.files) == {"README.md", "data/part-00000.parquet", "ledger.parquet", "manifest.json"}
     assert api.files["data/part-00000.parquet"] == (tmp_path / "release/tasks/part-00000.parquet").read_bytes()
     card = api.files["README.md"].decode()
+    assert "license: apache-2.0" in card
     assert "path: data/*.parquet" in card
-    assert "# TaskTrove release" in card
+    assert "## How it was made" in card
+    assert "## Row schema" in card
+    assert f'load_dataset("{DEFAULT_HF_REPO_ID}", split="train")' in card
+    assert "## Release report" in card
+    assert "### By status" in card
 
 
 def test_huggingface_publish_validates_release_before_creating_repo(tmp_path):

--- a/lib/tasktrove-verify/src/tasktrove_verify/grade.py
+++ b/lib/tasktrove-verify/src/tasktrove_verify/grade.py
@@ -69,6 +69,8 @@ def infra_error(message: str) -> Reward:
 def write_reward(logs_dir: Path, reward: Reward) -> None:
     """Write a verdict and, for a scored grade, Harbor's reward files."""
     logs_dir.mkdir(parents=True, exist_ok=True)
+    for name in (REWARD_JSON, REWARD_TXT):
+        (logs_dir / name).unlink(missing_ok=True)
     verdict = {"reward": reward.reward, "status": reward.status.value, "detail": reward.detail}
     (logs_dir / VERDICT_JSON).write_text(json.dumps(verdict) + "\n")
     if reward.status != Status.SCORED:

--- a/lib/tasktrove-verify/tests/test_cli.py
+++ b/lib/tasktrove-verify/tests/test_cli.py
@@ -52,7 +52,7 @@ def test_unscored_rerun_removes_prior_harbor_reward_files(tmp_path, monkeypatch)
     spec = tmp_path / "verifier.toml"
     spec.write_text('mode = "mcq"\nexpected = "C"\n')
     logs = tmp_path / "logs"
-    monkeypatch.setitem(grade_module.GRADERS, Mode.MCQ, lambda spec, tests_dir, workspace: scored(1.0))
+    monkeypatch.setitem(grade_module.GRADERS, Mode.MCQ, lambda _spec, _tests_dir, _workspace: scored(1.0))
     main([str(spec), "--logs-dir", str(logs)])
 
     spec.write_text('mode = "mcq"\n')

--- a/lib/tasktrove-verify/tests/test_cli.py
+++ b/lib/tasktrove-verify/tests/test_cli.py
@@ -46,3 +46,18 @@ def test_scored_reward_writes_the_verdict_and_harbor_reward_files(tmp_path, monk
     assert _verdict(logs) == {"reward": 1.0, "status": "scored", "detail": {"extracted": "C"}}
     assert json.loads((logs / "reward.json").read_text()) == {"reward": 1.0}
     assert (logs / "reward.txt").read_text() == "1.0\n"
+
+
+def test_unscored_rerun_removes_prior_harbor_reward_files(tmp_path, monkeypatch):
+    spec = tmp_path / "verifier.toml"
+    spec.write_text('mode = "mcq"\nexpected = "C"\n')
+    logs = tmp_path / "logs"
+    monkeypatch.setitem(grade_module.GRADERS, Mode.MCQ, lambda spec, tests_dir, workspace: scored(1.0))
+    main([str(spec), "--logs-dir", str(logs)])
+
+    spec.write_text('mode = "mcq"\n')
+    main([str(spec), "--logs-dir", str(logs)])
+
+    assert _verdict(logs)["status"] == Status.INVALID_TASK
+    assert not (logs / "reward.json").exists()
+    assert not (logs / "reward.txt").exists()


### PR DESCRIPTION
Publish built TaskTrove releases to a configurable Hugging Face dataset repository, defaulting to `open-athena/task-trove`. The command streams release objects into local staging, uploads retained task shards as the `train` split, keeps the rejection ledger and manifest as downloadable metadata, and replaces stale Parquet shards on repeat publication. Its generated dataset card documents provenance, cleanup stages, row and archive schemas, loading, licensing, and the full release report.

Validate the local release before creating the destination repository. Clear prior Harbor reward files before every verifier result so an invalid-task or infrastructure-error rerun cannot expose a stale score.
